### PR TITLE
Pull PyPI version direct from tag name in release

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -2,8 +2,10 @@ name: Publish to PyPI
 
 on:
   push:
+    # New major & minor releases are disabled here by default for safety. To support new release
+    # lines, add them to the workflow filters:
     tags:
-      - '*.*.*'
+      - 'v0.1.*'
 
 permissions:
   contents: read
@@ -35,6 +37,17 @@ jobs:
 
       - name: Update Poetry configuration
         run: poetry config virtualenvs.create false
+
+      - name: Configure pyproject version
+        run: |
+          if [[ $GITHUB_REF_TYPE == "tag" ]] && [[ $GITHUB_REF_NAME == v* ]]
+          then
+            # Drop leading 'v'
+            poetry version ${GITHUB_REF_NAME:1}
+          else
+            echo "Invalid tag trigger\nGITHUB_REF_TYPE=${GITHUB_REF_TYPE}\nGITHUB_REF_NAME=${GITHUB_REF_NAME}"
+            exit 1
+          fi
 
       - name: Install dependencies
         run: poetry install --sync --no-interaction

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.poetry]
 name = "llmeter"
-version = "0.1.1"
+# Note: version is automatically set from tag name in our GitHub CD release workflow
+version = "0.0.0"
 description = "A lightweight, cross-platform latency and throughput profiler for LLMs"
 authors = ["Amazon Web Services"]
 readme = "README.md"


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**

- Update GitHub PyPI release workflow to pull the target version name directly from the tag the workflow is triggered with.
- Scope down the list of tag names allowed to run the workflow: For now only `v0.1.*` patch releases to prevent accidental releases of unintended versions. We'll need to broaden this list when we deliberately choose to introduce new major or minor release lines.

With this solution, we shouldn't need to bring in extra commits to update pyproject.toml in line with new releases.

<br/>
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
