### PR TITLE
Feature/load test sizing

### DIFF
--- a/examples/LLMeter with Amazon SageMaker JumpStart.ipynb
+++ b/examples/LLMeter with Amazon SageMaker JumpStart.ipynb
@@ -509,7 +509,8 @@
     "    endpoint=sagemaker_endpoint_stream,\n",
     "    payload=payloads_streaming,\n",
     "    sequence_of_clients=[1, 5, 20, 50, 100, 500],\n",
-    "    n_requests=5,\n",
+    "    min_requests_per_client=5,\n",
+    "    min_requests_per_run=10, \n",
     "    output_path=f\"outputs/{sagemaker_endpoint_stream.model_id}/sweep\",\n",
     ")\n",
     "sweep_results = await sweep_test.run()"


### PR DESCRIPTION
Updated logic to set number of requests per clients when testing multiple concurrences in `LoadTest`. This change is to provide a convenient way to set a minimum statistics for each concurrency setting (`min_requests_per_run`), and the number of requests per client (`min_requests_per_client`).

Also update the SageMaker example notebook to reflect the updated arguments.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
