### PR TITLE
Fix TypeError in OpenAI streaming when first chunk content is None

### DIFF
--- a/llmeter/endpoints/openai.py
+++ b/llmeter/endpoints/openai.py
@@ -204,11 +204,11 @@ class OpenAICompletionStreamEndpoint(OpenAIEndpoint):
         time_to_first_token = time.perf_counter() - start_t
         if response_id is None:
             response_id = first_chunk.id  # type: ignore
-        response_text = first_chunk.choices[0].delta.content
+        response_text = first_chunk.choices[0].delta.content or ""
 
         for chunk in client_response:
             if chunk.choices[0].delta.content is not None:  # type: ignore
-                response_text += chunk.choices[0].delta.content  # type: ignore
+                response_text += chunk.choices[0].delta.content or ""  # type: ignore
             if hasattr(chunk, "usage") and chunk.usage is not None:  # type: ignore
                 prompt_tokens = chunk.usage.prompt_tokens  # type: ignore
                 completion_tokens = chunk.usage.completion_tokens  # type: ignore


### PR DESCRIPTION
*Issue #16 *

*Description of changes:*
- Initialize the content accumulator defensively when processing the first streamed chunk: `response_text = first_chunk.choices[0].delta.content or ""` (`llmeter/endpoints/openai.py:207`).
- Normalize each subsequent chunk’s content before concatenation: `response_text += chunk.choices[0].delta.content or ""` (`llmeter/endpoints/openai.py:211`).
- Prevents `NoneType + str` errors when the first chunk has `delta.content=None`, while preserving behavior for non-empty content.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
