### PR TITLE
Fix Python 3.10 UTC ImportError

### DIFF
--- a/llmeter/results.py
+++ b/llmeter/results.py
@@ -5,7 +5,7 @@ import json
 import logging
 import os
 from dataclasses import asdict, dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from functools import cached_property
 from numbers import Number
 from typing import Any, Sequence
@@ -34,7 +34,7 @@ def utc_datetime_serializer(obj):
     if isinstance(obj, datetime):
         # Convert to UTC if timezone is set
         if obj.tzinfo is not None:
-            obj = obj.astimezone(UTC)
+            obj = obj.astimezone(timezone.utc)
         return obj.isoformat(timespec="seconds").replace("+00:00", "Z")
     return str(obj)
 


### PR DESCRIPTION
**Issue #, if available:** Fixes #18

**Description of changes:**

Reference the original `datetime.timezone.utc` constant instead of [datetime.UTC](https://docs.python.org/3/library/datetime.html#datetime.UTC) which (per the linked doc) was only added in Python 3.11 so breaks our Python 3.10 support.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
