### PR TITLE
boxplot_by_dimension to respect name parameter

### DIFF
--- a/llmeter/plotting/plotting.py
+++ b/llmeter/plotting/plotting.py
@@ -196,9 +196,8 @@ def boxplot_by_dimension(
     result: Result, dimension: str, name: str | None = None, **box_kwargs
 ) -> go.Box:
     x = result.get_dimension(dimension)
-    name = box_kwargs.pop("name", None) or result.run_name
 
-    return go.Box(x=x, name=name, **box_kwargs)
+    return go.Box(x=x, name=name or result.run_name, **box_kwargs)
 
 
 def stat_clients(load_test_result: LoadTestResult, stat: str, **scatter_kwargs):
@@ -234,7 +233,9 @@ def stat_clients(load_test_result: LoadTestResult, stat: str, **scatter_kwargs):
     return go.Scatter(**default_kwargs)
 
 
-def error_clients_fig(load_test_result: LoadTestResult, log_scale=False, **scatter_kwargs):
+def error_clients_fig(
+    load_test_result: LoadTestResult, log_scale=False, **scatter_kwargs
+):
     """
     Create a figure showing error rate vs number of clients.
 
@@ -247,7 +248,9 @@ def error_clients_fig(load_test_result: LoadTestResult, log_scale=False, **scatt
         plotly.graph_objects.Figure: Figure showing error rate vs number of clients
     """
     fig = go.Figure()
-    fig.add_trace(stat_clients(load_test_result, "failed_requests_rate", **scatter_kwargs))
+    fig.add_trace(
+        stat_clients(load_test_result, "failed_requests_rate", **scatter_kwargs)
+    )
     fig.update_layout(
         title="Error rate vs number of clients",
         xaxis_title="Number of clients",
@@ -261,7 +264,9 @@ def error_clients_fig(load_test_result: LoadTestResult, log_scale=False, **scatt
     return fig
 
 
-def rpm_clients_fig(load_test_result: LoadTestResult, log_scale=False, **scatter_kwargs):
+def rpm_clients_fig(
+    load_test_result: LoadTestResult, log_scale=False, **scatter_kwargs
+):
     """
     Create a figure showing requests per minute vs number of clients.
 
@@ -274,7 +279,9 @@ def rpm_clients_fig(load_test_result: LoadTestResult, log_scale=False, **scatter
         plotly.graph_objects.Figure: Figure showing requests per minute vs number of clients
     """
     fig = go.Figure()
-    fig.add_trace(stat_clients(load_test_result, "requests_per_minute", **scatter_kwargs))
+    fig.add_trace(
+        stat_clients(load_test_result, "requests_per_minute", **scatter_kwargs)
+    )
     fig.update_layout(
         title="Requests per minute vs number of clients",
         xaxis_title="Number of clients",
@@ -295,7 +302,9 @@ def average_input_tokens_clients_fig(
 ):
     fig = go.Figure()
     fig.add_trace(
-        stat_clients(load_test_result, "average_input_tokens_per_minute", **scatter_kwargs)
+        stat_clients(
+            load_test_result, "average_input_tokens_per_minute", **scatter_kwargs
+        )
     )
     fig.update_layout(
         title="Average input tokens per minute vs number of clients",
@@ -317,7 +326,9 @@ def average_output_tokens_clients_fig(
 ):
     fig = go.Figure()
     fig.add_trace(
-        stat_clients(load_test_result, "average_output_tokens_per_minute", **scatter_kwargs)
+        stat_clients(
+            load_test_result, "average_output_tokens_per_minute", **scatter_kwargs
+        )
     )
     fig.update_layout(
         title="Average output tokens per minute vs number of clients",
@@ -439,14 +450,18 @@ def plot_load_test_results(
     Returns:
         dict: Dictionary containing the following plots:
             - time_to_first_token: Figure showing time to first token vs number of clients
-            - time_to_last_token: Figure showing time to last token vs number of clients  
+            - time_to_last_token: Figure showing time to last token vs number of clients
             - requests_per_minute: Figure showing requests per minute vs number of clients
             - error_rate: Figure showing error rate vs number of clients
             - average_input_tokens_clients: Figure showing average input tokens per minute vs clients
             - average_output_tokens_clients: Figure showing average output tokens per minute vs clients
     """
-    f1 = latency_clients_fig(load_test_result, "time_to_first_token", log_scale=log_scale)
-    f2 = latency_clients_fig(load_test_result, "time_to_last_token", log_scale=log_scale)
+    f1 = latency_clients_fig(
+        load_test_result, "time_to_first_token", log_scale=log_scale
+    )
+    f2 = latency_clients_fig(
+        load_test_result, "time_to_last_token", log_scale=log_scale
+    )
     f3 = rpm_clients_fig(load_test_result, log_scale=log_scale)
     f4 = error_clients_fig(load_test_result, log_scale=log_scale)
     f5 = average_input_tokens_clients_fig(load_test_result, log_scale=log_scale)


### PR DESCRIPTION
**Issue #, if available:** #22

**Description of changes:**

update `boxplot_by_dimension` function to properly consume the `name` parameter, which was previously always being overridden to the result.run_name.

Also ran `ruff format`, which has created some whitespace changes elsewhere in the file.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
