### PR TITLE
Fix #26: Remove duplicate time_per_output_token calculations

### DIFF
--- a/llmeter/endpoints/bedrock.py
+++ b/llmeter/endpoints/bedrock.py
@@ -342,16 +342,6 @@ class BedrockConverseStream(BedrockConverse):
                         error=f"Metadata parsing error: {e}",
                     )
 
-            # compute time per output token if the model supports it
-            if (
-                response.num_tokens_output
-                and response.time_to_last_token
-                and response.time_to_first_token
-            ):
-                response.time_per_output_token = (
-                    response.time_to_last_token - response.time_to_first_token
-                ) / (response.num_tokens_output - 1)
-
             response.retries = client_response["ResponseMetadata"]["RetryAttempts"]
 
             return response

--- a/llmeter/endpoints/litellm.py
+++ b/llmeter/endpoints/litellm.py
@@ -191,9 +191,4 @@ class LiteLLMStreaming(LiteLLMBase):
             time_to_first_token=time_to_first_token,
             time_to_last_token=time_to_last_token,
         )
-        if response.num_tokens_output and time_to_last_token and time_to_first_token:
-            generation_time = time_to_last_token - time_to_first_token
-            response.time_per_output_token = (response.num_tokens_output - 1) and (
-                generation_time / (response.num_tokens_output - 1)
-            )
         return response

--- a/llmeter/endpoints/sagemaker.py
+++ b/llmeter/endpoints/sagemaker.py
@@ -158,11 +158,6 @@ class SageMakerEndpoint(SageMakerBase):
             time_to_last_token=time_to_last_token,
             input_prompt=input_prompt,
             num_tokens_output=num_tokens_output if num_tokens_output else None,
-            time_per_output_token=(
-                (time_to_last_token / (num_tokens_output - 1))
-                if num_tokens_output
-                else None
-            ),
         )
 
 
@@ -204,8 +199,6 @@ class SageMakerStreamEndpoint(SageMakerBase):
             time_to_first_token=time_to_first_token,
             time_to_last_token=time_to_last_token,
             num_tokens_output=num_tokens_output,
-            time_per_output_token=(time_to_last_token - time_to_first_token)
-            / (num_tokens_output - 1),
         )
 
     def invoke(self, payload: dict) -> InvocationResponse:

--- a/tests/unit/endpoints/test_bedrock.py
+++ b/tests/unit/endpoints/test_bedrock.py
@@ -61,8 +61,8 @@ class TestBedrock:
         # Check that timing information is set
         assert result.time_to_first_token is not None
         assert result.time_to_last_token is not None
-        assert result.time_per_output_token is not None
-        assert result.time_per_output_token < 0.01
+        # time_per_output_token is computed by the runner, not the endpoint
+        assert result.time_per_output_token is None
         # Verify that time calculations are logical
         assert 0 < result.time_to_first_token < result.time_to_last_token
 
@@ -178,7 +178,8 @@ class TestBedrock:
         assert response.num_tokens_output == 5
         assert response.time_to_first_token is not None
         assert response.time_to_last_token is not None
-        assert response.time_per_output_token is not None
+        # time_per_output_token is computed by the runner, not the endpoint
+        assert response.time_per_output_token is None
         assert response.retries == 0
 
     def test__parse_conversation_stream_6(self):
@@ -224,7 +225,8 @@ class TestBedrock:
         assert result.time_to_last_token is not None
         assert result.num_tokens_input == 10
         assert result.num_tokens_output == 5
-        assert result.time_per_output_token is not None
+        # time_per_output_token is computed by the runner, not the endpoint
+        assert result.time_per_output_token is None
         assert result.retries == 0
 
     def test__parse_conversation_stream_7(self):

--- a/tests/unit/endpoints/test_litellm.py
+++ b/tests/unit/endpoints/test_litellm.py
@@ -327,7 +327,8 @@ class TestLiteLLMStreaming:
         assert result.num_tokens_output == 5
         assert result.time_to_first_token == 0.1
         assert result.time_to_last_token == 0.2
-        assert result.time_per_output_token == 0.025  # (0.2-0.1)/(5-1)
+        # time_per_output_token is computed by the runner, not the endpoint
+        assert result.time_per_output_token is None
 
         # Check that stream options were set
         mock_completion.assert_called_once()
@@ -420,7 +421,8 @@ class TestLiteLLMStreaming:
         assert result.num_tokens_output == 3
         assert result.time_to_first_token == 0.15
         assert result.time_to_last_token == 0.4
-        assert result.time_per_output_token == 0.125  # (0.4-0.15)/(3-1)
+        # time_per_output_token is computed by the runner, not the endpoint
+        assert result.time_per_output_token is None
 
     @patch("time.perf_counter")
     def test_parse_stream_no_usage(self, mock_time):


### PR DESCRIPTION
Removed unnecessary duplicate time_per_output_token calculation logic from endpoint classes. The calculation is now centralized in _Run._compute_time_per_output_token() which is called during _process_results_from_q().


*Issue #, if available:*
#26

*Description of changes:*
- llmeter/endpoints/bedrock.py: Removed calculation from BedrockConverseStream._parse_conversation_stream()
- llmeter/endpoints/litellm.py: Removed calculation from LiteLLMStreaming._parse_stream()
- llmeter/endpoints/sagemaker.py: Removed calculations from SageMakerEndpoint.invoke() and SageMakerStreamEndpoint._parse_client_response()
- tests/unit/endpoints/test_bedrock.py: Updated tests to expect time_per_output_token=None from endpoint methods
- tests/unit/endpoints/test_litellm.py: Updated tests to expect time_per_output_token=None from endpoint methods

The runner's _compute_time_per_output_token() method now handles all time_per_output_token calculations consistently across all endpoints.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
