### PR TITLE
fix: respect endpoint_name parameter in BedrockBase constructor

### DIFF
--- a/llmeter/endpoints/bedrock.py
+++ b/llmeter/endpoints/bedrock.py
@@ -39,10 +39,8 @@ class BedrockBase(Endpoint):
         max_attempts: int = 3,
     ):
         super().__init__(
-            model_id=model_id, endpoint_name=endpoint_name or "", provider="bedrock"
+            model_id=model_id, endpoint_name=endpoint_name or "amazon bedrock", provider="bedrock"
         )
-
-        self.endpoint_name = "amazon bedrock"
 
         self.region = region or boto3.session.Session().region_name
         logger.info(f"Using AWS region: {self.region}")


### PR DESCRIPTION
BedrockBase was accepting an endpoint_name parameter but immediately overriding it with a hardcoded "amazon bedrock" value. This change removes the override and uses the parameter value when provided, defaulting to "amazon bedrock" only when no value is passed.



*Issue #, if available:*
#25

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
