### PR TITLE
fix: centralize time_per_output_token calculation in runner

### DIFF
--- a/llmeter/runner.py
+++ b/llmeter/runner.py
@@ -186,6 +186,7 @@ class _Run(_RunConfig):
             if (
                 response.time_to_last_token
                 and response.num_tokens_output
+                and response.num_tokens_output > 1
                 and response.time_to_first_token
             ):
                 response.time_per_output_token = (


### PR DESCRIPTION
## Problem

When `max_tokens=1`, the stream parser computes `time_per_output_token = (ttlt - ttft) / (num_tokens_output - 1)` which is a division by zero. This was caught as an error and wiped the entire response — but `num_tokens_input` had already been parsed from metadata, so valid data was lost.

The same calculation was duplicated across 4 endpoints (bedrock, sagemaker streaming, sagemaker non-streaming, litellm), each with slightly different implementations and inconsistent guards.

## Fix

- Remove the `time_per_output_token` computation from all endpoint implementations
- Rely solely on the runner's existing `_compute_time_per_output_token` method, which already runs as a post-processing step on every response
- Add a `num_tokens_output > 1` guard in the runner to prevent the division by zero
- When there's only 1 output token, `time_per_output_token` is left as `None` instead of crashing

## Testing

All 432 existing tests pass. Updated endpoint tests to reflect that `time_per_output_token` is no longer set by endpoints directly.
