### PR TITLE
fix(openai): IndexError on chunks with no choices

### DIFF
--- a/llmeter/endpoints/openai.py
+++ b/llmeter/endpoints/openai.py
@@ -207,7 +207,7 @@ class OpenAICompletionStreamEndpoint(OpenAIEndpoint):
         response_text = first_chunk.choices[0].delta.content or ""
 
         for chunk in client_response:
-            if chunk.choices[0].delta.content is not None:  # type: ignore
+            if chunk.choices and chunk.choices[0].delta.content:  # type: ignore
                 response_text += chunk.choices[0].delta.content or ""  # type: ignore
             if hasattr(chunk, "usage") and chunk.usage is not None:  # type: ignore
                 prompt_tokens = chunk.usage.prompt_tokens  # type: ignore


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**

Bedrock Mantle endpoints are sometimes returning stream chunks with no `choices`, e.g. for control chunks that only report usage with no content. Handle this case properly to avoid `IndexError: list index out of range` on these chunks (currently happening on *every* request, for at least some Mantle models)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.