### PR TITLE
Upgrade BEDROCK_TEST_MODEL to Nova 2 Lite

### DIFF
--- a/tests/integ/conftest.py
+++ b/tests/integ/conftest.py
@@ -93,7 +93,7 @@ def bedrock_test_model():
         str: Bedrock model ID for testing.
     """
     return os.environ.get(
-        "BEDROCK_TEST_MODEL", "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+        "BEDROCK_TEST_MODEL", "global.amazon.nova-2-lite-v1:0"
     )
 
 


### PR DESCRIPTION
**Issue #, if available:** #35

**Description of changes:**

Upgrade the default Bedrock Converse integration test model from Claude Sonnet 3.5 to Nova Lite 2: Global endpoint, Newer model, and no marketplace permissions required.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
