### PR TITLE
fix: prevent uv version from triggering full dependency sync in publish workflow

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -38,7 +38,7 @@ jobs:
           if [[ $GITHUB_REF_TYPE == "tag" ]] && [[ $GITHUB_REF_NAME == v* ]]
           then
             # Drop leading 'v'
-            uv version ${GITHUB_REF_NAME:1}
+            uv version --no-sync ${GITHUB_REF_NAME:1}
           else
             echo "Invalid tag trigger\nGITHUB_REF_TYPE=${GITHUB_REF_TYPE}\nGITHUB_REF_NAME=${GITHUB_REF_NAME}"
             exit 1


### PR DESCRIPTION
## Problem

`uv version` modifies `pyproject.toml`, which triggers uv to automatically sync the full dependency tree (280+ packages including numpy, pandas, scikit-learn, etc.) — none of which are needed for building and publishing.

## Fix

Add `--no-sync` to `uv version` so it only updates the version string without resolving/installing dependencies.

This makes the publish workflow significantly faster and avoids pulling unnecessary packages.