### PR TITLE
docs: improve API reference generation and table styling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,13 +98,25 @@ ruff check llmeter/ && ruff format llmeter/
 
 This project uses [Zensical](https://zensical.org/) (A compatible [alernative to MkDocs](https://squidfunk.github.io/mkdocs-material/blog/2025/11/05/zensical/)) to power an interactive docs website, hosted on GitHub pages. This documentation should be updated as part of contributed changes, wherever appropriate.
 
-To test the docs locally, ensure you've installed llmeter with the `docs` group and run:
+To work on docs locally, install only the docs dependencies (this avoids pulling in the full project dependency tree):
 
-```
-uv run zensical serve
+```bash
+uv sync --only-group docs
 ```
 
-This should start the dev server for preview at http://localhost:8000/, which should automatically refresh as you edit the `docs/`.
+Then preview with the dev server:
+
+```bash
+uv run --no-sync zensical serve
+```
+
+This starts a preview at http://localhost:8000/ that auto-refreshes as you edit `docs/`.
+
+To do a clean production build:
+
+```bash
+uv run --no-sync zensical build --clean
+```
 
 ⚠️ Note - The following processes are stil **manual** for now (contributions to automate this work are much appreciated!):
 - When adding/renaming/deleting .py modules in LLMeter, you need to update the corresponding API reference folders and .md files under `docs/reference`

--- a/docs/reference/prompt_utils.md
+++ b/docs/reference/prompt_utils.md
@@ -1,0 +1,1 @@
+::: llmeter.prompt_utils

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -230,3 +230,13 @@
     background: linear-gradient(var(--md-primary-fg-color--light), var(--md-primary-fg-color));
   }
 }
+
+/* Tables: keep code tokens on one line and let the table scroll if needed */
+.md-typeset table:not([class]) code {
+  white-space: nowrap;
+}
+
+.md-typeset table:not([class]) td:last-child,
+.md-typeset table:not([class]) th:last-child {
+  min-width: 14em;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,7 +103,6 @@ plugins:
           show_root_full_path: false
           show_symbol_type_heading: true
           show_symbol_type_toc: true
-          members_order: source
           merge_init_into_class: true
           show_if_no_docstring: false
           signature_crossrefs: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
     - results: reference/results.md
     - runner: reference/runner.md
     - tokenizers: reference/tokenizers.md
+    - prompt_utils: reference/prompt_utils.md
     - utils: reference/utils.md
 repo_url: https://github.com/awslabs/llmeter
 repo_name: awslabs/llmeter
@@ -89,4 +90,21 @@ extra_css:
   - stylesheets/extra.css
 plugins:
 - search
-- mkdocstrings
+- mkdocstrings:
+    default_handler: python
+    handlers:
+      python:
+        options:
+          docstring_style: google
+          docstring_options:
+            ignore_init_summary: true
+          show_source: true
+          show_root_heading: true
+          show_root_full_path: false
+          show_symbol_type_heading: true
+          show_symbol_type_toc: true
+          members_order: source
+          merge_init_into_class: true
+          show_if_no_docstring: false
+          signature_crossrefs: true
+          separate_signature: true


### PR DESCRIPTION
## Changes

- Configure mkdocstrings Python handler with Google-style docstring parsing, source links, cross-references, and merged `__init__` docs
- Add missing `prompt_utils` API reference page and nav entry
- Fix table column width issues causing awkward word splits in inline code tokens
- Update CONTRIBUTING.md with lightweight docs build instructions using `uv sync --only-group docs`