### PR TITLE
feat: low-memory mode, RunningStats, and live progress-bar stats

### DIFF
--- a/llmeter/results.py
+++ b/llmeter/results.py
@@ -5,7 +5,6 @@ import json
 import logging
 from dataclasses import asdict, dataclass
 from datetime import datetime
-from functools import cached_property
 from numbers import Number
 from typing import Any, Sequence
 
@@ -162,8 +161,8 @@ class Result:
                 InvocationResponse(**json.loads(line)) for line in f if line
             ]
         logger.info("Loaded %d responses from %s", len(self.responses), responses_path)
-        # Invalidate cached stats so they are recomputed with the loaded responses
-        self.__dict__.pop("_builtin_stats", None)
+        # Recompute stats from the freshly loaded responses
+        self._preloaded_stats = self._compute_stats(self)
         return self.responses
 
     @classmethod
@@ -234,9 +233,9 @@ class Result:
 
         result = cls(responses=responses, **summary)
 
-        # When skipping responses, load pre-computed stats from stats.json if available
-        # so that result.stats works without needing the responses
+        # Load or compute stats
         if not load_responses:
+            # Use pre-computed stats from disk when responses aren't loaded
             stats_path = result_path / "stats.json"
             if stats_path.exists():
                 with stats_path.open("r") as s:
@@ -253,78 +252,84 @@ class Result:
                                 pass
             else:
                 result._preloaded_stats = None
+        else:
+            # Compute stats from the loaded responses
+            result._preloaded_stats = cls._compute_stats(result)
 
         return result
 
-    @cached_property
-    def _builtin_stats(self) -> dict:
-        """
-        Default run metrics and aggregated statistics provided by LLMeter core
+    @classmethod
+    def _compute_stats(cls, result: "Result") -> dict:
+        """Compute stats from in-memory responses.
 
-        Users should generally refer to the `.stats` property instead, which combines this data
-        with any additional values contributed by callbacks or other extensions.
+        This is the fallback used when ``_preloaded_stats`` is not available — for
+        example when a ``Result`` is constructed manually or after
+        :meth:`load_responses` reloads data from disk.
 
-        This is a read-only and `@cached_property`, which means the result is computed once and
-        then cached for subsequent accesses - improving performance.
+        Args:
+            result: A ``Result`` instance whose ``responses`` list is populated.
 
         Returns:
-            stats: A dictionary containing all computed statistics. The keys are:
-                - All key-value pairs from the Result's dictionary representation
-                - Test-specific statistics
-                - Aggregated statistics with keys in the format "{stat_name}-{aggregation_type}"
-                  where stat_name is one of the four metrics listed above, and
-                  aggregation_type includes measures like mean, median, etc.
-        """
+            A flat dictionary matching the ``Result.stats`` schema, containing
+            run-level metrics (``failed_requests``, ``requests_per_minute``, …)
+            and per-metric aggregations (``time_to_first_token-p50``, …).
 
+        Example::
+
+            result = Result(responses=my_responses, total_requests=100, ...)
+            stats = Result._compute_stats(result)
+            stats["time_to_first_token-p90"]  # 0.485
+        """
         aggregation_metrics = [
             "time_to_last_token",
             "time_to_first_token",
             "num_tokens_output",
             "num_tokens_input",
         ]
-
-        results_stats = _get_stats_from_results(
-            self,
-            aggregation_metrics,
-        )
+        results_stats = _get_stats_from_results(result, aggregation_metrics)
         return {
-            **self.to_dict(),
-            **_get_run_stats(self),
+            **result.to_dict(),
+            **_get_run_stats(result),
             **{f"{k}-{j}": v for k, o in results_stats.items() for j, v in o.items()},
         }
 
     @property
     def stats(self) -> dict:
+        """Run metrics and aggregated statistics over the individual requests.
+
+        Returns a flat dictionary combining:
+
+        * Basic run information (from ``to_dict()``).
+        * Aggregated statistics (``average``, ``p50``, ``p90``, ``p99``) for
+          ``time_to_last_token``, ``time_to_first_token``, ``num_tokens_output``,
+          and ``num_tokens_input``.  Keys use the format
+          ``"{metric}-{aggregation}"``.
+        * Run-level throughput metrics (``requests_per_minute``,
+          ``total_input_tokens``, etc.).
+        * Any additional stats contributed by callbacks via
+          :meth:`_update_contributed_stats`.
+
+        During a live run, stats are computed incrementally by
+        :class:`~llmeter.utils.RunningStats` and stored in ``_preloaded_stats``.
+        When loading from disk with ``load_responses=False``, pre-computed stats
+        from ``stats.json`` are used.  As a fallback (e.g. manually constructed
+        ``Result``), stats are computed on the fly from ``self.responses``.
+
+        Returns:
+            A new shallow copy of the stats dictionary on each access.
+
+        Example::
+
+            result = await runner.run(payload=my_payload, clients=5)
+            result.stats["time_to_first_token-p50"]   # 0.312
+            result.stats["requests_per_minute"]        # 141.2
+            result.stats["failed_requests"]            # 0
         """
-        Run metrics and aggregated statistics over the individual requests
-
-        This combined view includes:
-        - Basic information about the run (from the Result's dictionary representation)
-        - Aggregated statistics ('average', 'p50', 'p90', 'p99') for:
-            - Time to last token
-            - Time to first token
-            - Number of tokens output
-            - Number of tokens input
-
-        Aggregated statistics are keyed in the format "{stat_name}-{aggregation_type}"
-
-        This property is read-only and returns a new shallow copy of the data on each access.
-        Default stats provided by LLMeter are calculated on first access and then cached. Callbacks
-        Callbacks or other mechanisms needing to augment stats should use the
-        `_update_contributed_stats()` method.
-
-        When the Result was loaded with ``load_responses=False``, pre-computed stats from
-        ``stats.json`` are returned if available. Call ``load_responses()`` to load the
-        individual responses and recompute stats from the raw data.
-        """
-        # Use preloaded stats when responses were not loaded
-        if not self.responses and self._preloaded_stats is not None:
+        if self._preloaded_stats is not None:
             stats = self._preloaded_stats.copy()
-            if self._contributed_stats:
-                stats.update(self._contributed_stats)
-            return stats
-
-        stats = self._builtin_stats.copy()
+        else:
+            # Fallback: compute from responses (e.g. Result constructed manually)
+            stats = self._compute_stats(self)
 
         if self._contributed_stats:
             stats.update(self._contributed_stats)

--- a/llmeter/runner.py
+++ b/llmeter/runner.py
@@ -21,7 +21,7 @@ from tqdm.auto import tqdm, trange
 from upath import UPath as Path
 from upath.types import ReadablePathLike, WritablePathLike
 
-from .utils import ensure_path, now_utc
+from .utils import RunningStats, ensure_path, now_utc
 
 if TYPE_CHECKING:
     # Avoid circular import: We only need typing for Callback
@@ -63,6 +63,8 @@ class _RunConfig:
     run_description: str | None = None
     timeout: int | float = 60
     callbacks: list[Callback] | None = None
+    low_memory: bool = False
+    progress_bar_stats: dict[str, tuple[str, ...] | str] | None = None
     disable_per_client_progress_bar: InitVar[bool] = True
     disable_clients_progress_bar: InitVar[bool] = True
 
@@ -168,6 +170,22 @@ class _Run(_RunConfig):
         self._validate_and_prepare_payload()
         self._responses = []
 
+        if self.low_memory:
+            assert self.output_path is not None, (
+                "output_path is required when low_memory=True "
+                "(responses must be written to disk)"
+            )
+
+        self._running_stats = RunningStats(
+            metrics=[
+                "time_to_last_token",
+                "time_to_first_token",
+                "time_per_output_token",
+                "num_tokens_output",
+                "num_tokens_input",
+            ]
+        )
+
     def _validate_and_prepare_payload(self):
         """Validate and prepare the payload for the test run and update n_requests
 
@@ -257,9 +275,18 @@ class _Run(_RunConfig):
             if self.callbacks is not None:
                 [await cb.after_invoke(response) for cb in self.callbacks]
 
-            self._responses.append(response)
+            if self.low_memory and self._running_stats is not None:
+                self._running_stats.update(response.to_dict())
+            else:
+                self._responses.append(response)
+                self._running_stats.update(response.to_dict())
+
             if self._progress_bar:
                 self._progress_bar.update(1)
+                self._progress_bar.set_postfix(
+                    self._running_stats.snapshot(self.progress_bar_stats),
+                    refresh=False,
+                )
 
             if output_path:
                 output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -490,6 +517,22 @@ class _Run(_RunConfig):
             end_time=run_end_time,
         )
 
+        # Compute stats from the running accumulators
+        result._preloaded_stats = self._running_stats.to_stats(
+            total_requests=result.total_requests,
+            total_test_time=total_test_time,
+            result_dict=result.to_dict(),
+        )
+        result._preloaded_stats["start_time"] = run_start_time
+        result._preloaded_stats["end_time"] = run_end_time
+        result._preloaded_stats["total_test_time"] = total_test_time
+
+        if self.low_memory:
+            logger.info(
+                "Low-memory mode: responses not stored in memory. "
+                "Use result.load_responses() to load from disk."
+            )
+
         if self.callbacks is not None:
             [await cb.after_run(result) for cb in self.callbacks]
 
@@ -560,6 +603,15 @@ class Runner(_RunConfig):
             endpoint. Defaults to 60 seconds.
         callbacks (list[Callback] | None): Optional callbacks to enable during the test Run. See
             `llmeter.callbacks` for more information.
+        low_memory (bool): When ``True``, responses are written to disk but not kept in memory
+            during the run.  Stats are computed incrementally via
+            :class:`~llmeter.utils.RunningStats`.  Requires ``output_path`` to be set.  Use
+            ``result.load_responses()`` to load responses from disk after the run.  Defaults to
+            ``False``.
+        progress_bar_stats (dict | None): Controls which live stats appear on the progress bar.
+            Maps short display labels to field specs — see
+            :attr:`RunningStats.DEFAULT_SNAPSHOT_STATS` for the format and defaults.  Pass ``{}``
+            to disable live stats entirely.  Defaults to ``None`` (use built-in defaults).
         disable_per_client_progress_bar (bool): Set `True` to disable per-client progress bars
             from showing during the run. Default `False` (each client's progress will be shown).
         disable_clients_progress_bar (bool): Set `True` to disable overall progress bar from
@@ -608,6 +660,8 @@ class Runner(_RunConfig):
         run_description: str | None = None,
         timeout: int | float | None = None,
         callbacks: list[Callback] | None = None,
+        low_memory: bool | None = None,
+        progress_bar_stats: dict[str, tuple[str, ...] | str] | None = None,
         disable_per_client_progress_bar: bool | None = None,
         disable_clients_progress_bar: bool | None = None,
     ) -> Result:
@@ -643,6 +697,36 @@ class Runner(_RunConfig):
                 endpoint.
             callbacks (list[Callback] | None): Optional callbacks to enable during the test Run. See
                 `llmeter.callbacks` for more information.
+            low_memory (bool): When ``True``, responses are written to disk but not
+                kept in memory.  Stats are computed incrementally via
+                :class:`~llmeter.utils.RunningStats`.  Requires ``output_path``.
+                Use ``result.load_responses()`` to access responses after the run.
+
+                Example::
+
+                    result = await runner.run(
+                        output_path="/tmp/my_run",
+                        low_memory=True,
+                    )
+                    result.stats          # works (computed incrementally)
+                    result.responses      # [] (empty)
+                    result.load_responses()  # loads from disk
+
+            progress_bar_stats (dict): Controls which live stats appear on the
+                progress bar.  Maps short display labels to field specs — see
+                :attr:`RunningStats.DEFAULT_SNAPSHOT_STATS` for the format and
+                defaults.  Pass ``{}`` to disable live stats entirely.
+
+                Example::
+
+                    # Show only p99 latency and tokens per second:
+                    result = await runner.run(
+                        progress_bar_stats={
+                            "p99_ttlt": ("time_to_last_token", "p99"),
+                            "tps": ("time_per_output_token", "p50", "inv"),
+                            "fail": "failed",
+                        },
+                    )
             disable_per_client_progress_bar (bool): Set `True` to disable per-client progress bars
                 from showing during the run.
             disable_clients_progress_bar (bool): Set `True` to disable overall progress bar from
@@ -675,6 +759,8 @@ class Runner(_RunConfig):
             run_description=run_description,
             timeout=timeout,
             callbacks=callbacks,
+            low_memory=low_memory,
+            progress_bar_stats=progress_bar_stats,
             disable_per_client_progress_bar=disable_per_client_progress_bar,
             disable_clients_progress_bar=disable_clients_progress_bar,
         )

--- a/llmeter/utils.py
+++ b/llmeter/utils.py
@@ -1,5 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+import bisect
 from datetime import datetime, timezone
 from itertools import filterfalse
 from math import isnan
@@ -84,6 +85,241 @@ def summary_stats_from_list(
 
     except StatisticsError:
         return {}
+
+
+class RunningStats:
+    """Accumulate summary statistics incrementally from individual responses.
+
+    Maintains sorted value lists per metric so that percentiles (p50, p90, p99),
+    averages, and sums can be computed at any point — both mid-run (for live
+    progress-bar display via :meth:`snapshot`) and at the end of a run (for the
+    final :class:`~llmeter.results.Result` stats via :meth:`to_stats`).
+
+    Args:
+        metrics: Names of numeric response fields to track (e.g.
+            ``"time_to_first_token"``, ``"num_tokens_output"``).
+
+    Example::
+
+        rs = RunningStats(metrics=["time_to_first_token", "time_to_last_token"])
+        rs.update({"time_to_first_token": 0.3, "time_to_last_token": 0.8})
+        rs.update({"time_to_first_token": 0.5, "time_to_last_token": 1.2, "error": None})
+        rs.to_stats()
+        # {'failed_requests': 0, ..., 'time_to_first_token-p50': 0.4, ...}
+    """
+
+    #: Default stats shown on the progress bar during a run.
+    #: Each entry maps a short display label to a spec:
+    #:
+    #: * ``(metric_name, aggregation)`` — aggregation can be ``"p50"``, ``"p90"``,
+    #:   ``"p99"``, ``"average"``, or ``"sum"``.
+    #: * ``(metric_name, aggregation, "inv")`` — same as above but displays the
+    #:   reciprocal (e.g. seconds-per-token → tokens-per-second).
+    #: * The literal string ``"failed"`` for the running failure count.
+    DEFAULT_SNAPSHOT_STATS: dict[str, tuple[str, ...] | str] = {
+        "p50_ttft": ("time_to_first_token", "p50"),
+        "p90_ttft": ("time_to_first_token", "p90"),
+        "p50_ttlt": ("time_to_last_token", "p50"),
+        "p90_ttlt": ("time_to_last_token", "p90"),
+        "p50_tps": ("time_per_output_token", "p50", "inv"),
+        "input_tokens": ("num_tokens_input", "sum"),
+        "output_tokens": ("num_tokens_output", "sum"),
+        "fail": "failed",
+    }
+
+    def __init__(self, metrics: Sequence[str]):
+        self._metrics = list(metrics)
+        self._count = 0
+        self._failed = 0
+        self._sums: dict[str, float] = {m: 0.0 for m in metrics}
+        self._values: dict[str, list[float]] = {m: [] for m in metrics}
+
+    def update(self, response_dict: dict[str, Any]) -> None:
+        """Record one response's metric values.
+
+        Call this once per :class:`~llmeter.endpoints.base.InvocationResponse`
+        (typically via ``response.to_dict()``).  The method extracts each tracked
+        metric from *response_dict*, skipping ``None`` and ``NaN`` values, and
+        increments the failure counter when an ``"error"`` key is present.
+
+        Args:
+            response_dict: A flat dictionary of response fields, as returned by
+                ``InvocationResponse.to_dict()``.
+
+        Example::
+
+            rs = RunningStats(metrics=["time_to_first_token"])
+            rs.update({"time_to_first_token": 0.42, "error": None})
+            rs.update({"time_to_first_token": None, "error": "timeout"})
+            assert rs._failed == 1
+        """
+        self._count += 1
+        if response_dict.get("error") is not None:
+            self._failed += 1
+        for m in self._metrics:
+            val = response_dict.get(m)
+            if val is not None and not (isinstance(val, float) and isnan(val)):
+                self._sums[m] += val
+                bisect.insort(self._values[m], val)
+
+    def to_stats(
+        self,
+        total_requests: int | None = None,
+        total_test_time: float | None = None,
+        result_dict: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Compute all accumulated statistics as raw numeric values.
+
+        This is the single source of truth for stats computation.  It is called
+        once at the end of a run (with all three optional arguments) to produce
+        the full ``Result.stats`` dict, and also called internally by
+        :meth:`snapshot` (without arguments) for mid-run progress display.
+
+        Args:
+            total_requests: Total number of requests across all clients.  When
+                provided, enables ``failed_requests_rate`` and
+                ``requests_per_minute`` computation.
+            total_test_time: Wall-clock duration of the run in seconds.  When
+                provided, enables throughput metrics (requests/min, tokens/min).
+            result_dict: Base key-value pairs to include in the output (typically
+                from ``Result.to_dict()``).  When ``None``, only metric
+                aggregations and failure counts are returned.
+
+        Returns:
+            A flat dictionary of statistics.  Keys include:
+
+            * ``failed_requests``, ``failed_requests_rate``, ``requests_per_minute``
+            * ``total_input_tokens``, ``total_output_tokens``
+            * ``average_input_tokens_per_minute``, ``average_output_tokens_per_minute``
+            * ``{metric}-{agg}`` for each tracked metric and each aggregation
+              (``average``, ``p50``, ``p90``, ``p99``).
+
+        Example::
+
+            rs = RunningStats(metrics=["time_to_first_token", "num_tokens_output"])
+            for resp in responses:
+                rs.update(resp.to_dict())
+
+            # Mid-run (no run-level context):
+            partial = rs.to_stats()
+            partial["time_to_first_token-p50"]  # 0.312
+
+            # End of run (full Result.stats schema):
+            full = rs.to_stats(
+                total_requests=100,
+                total_test_time=42.5,
+                result_dict=result.to_dict(),
+            )
+            full["requests_per_minute"]  # 141.2
+        """
+        stats: dict[str, Any] = {}
+        if result_dict is not None:
+            stats.update(result_dict)
+
+        # Run-level stats
+        stats["failed_requests"] = self._failed
+        stats["failed_requests_rate"] = total_requests and self._failed / total_requests
+        stats["requests_per_minute"] = (
+            total_test_time and total_requests / total_test_time * 60
+            if total_requests
+            else None
+        )
+        stats["total_input_tokens"] = self._sums.get("num_tokens_input", 0)
+        stats["total_output_tokens"] = self._sums.get("num_tokens_output", 0)
+        stats["average_input_tokens_per_minute"] = (
+            total_test_time and stats["total_input_tokens"] / total_test_time * 60
+        )
+        stats["average_output_tokens_per_minute"] = (
+            total_test_time and stats["total_output_tokens"] / total_test_time * 60
+        )
+
+        # Per-metric aggregations
+        for m in self._metrics:
+            agg = summary_stats_from_list(self._values.get(m, []))
+            for j, v in agg.items():
+                stats[f"{m}-{j}"] = v
+
+        return stats
+
+    def snapshot(
+        self,
+        fields: dict[str, tuple[str, ...] | str] | None = None,
+    ) -> dict[str, str]:
+        """Format a subset of :meth:`to_stats` for progress-bar display.
+
+        Calls :meth:`to_stats` internally and picks only the requested fields,
+        formatting each value as a human-readable string.
+
+        Args:
+            fields: Mapping of ``{display_label: spec}``.  Each *spec* is one of:
+
+                * ``(metric, aggregation)`` — a 2-tuple where *metric* is a tracked
+                  metric name and *aggregation* is ``"p50"``, ``"p90"``, ``"p99"``,
+                  ``"average"``, or ``"sum"``.
+                * ``(metric, aggregation, "inv")`` — a 3-tuple; same as above but
+                  the value is inverted before display (e.g. seconds-per-token →
+                  tokens-per-second).
+                * ``"failed"`` — the literal string; shows the running failure count.
+
+                Defaults to :attr:`DEFAULT_SNAPSHOT_STATS` when ``None``.
+
+        Returns:
+            An ordered dict of ``{label: formatted_value}`` strings suitable for
+            ``tqdm.set_postfix()``.
+
+        Example::
+
+            # Use defaults:
+            rs.snapshot()
+            # {'p50_ttft': '0.312s', 'p90_ttlt': '1.203s', ..., 'fail': '0'}
+
+            # Custom selection — only p99 latency and failures:
+            rs.snapshot({
+                "p99_ttlt": ("time_to_last_token", "p99"),
+                "fail": "failed",
+            })
+            # {'p99_ttlt': '2.105s', 'fail': '1'}
+
+            # Inverted metric — tokens per second from time_per_output_token:
+            rs.snapshot({
+                "tps": ("time_per_output_token", "p50", "inv"),
+            })
+            # {'tps': '28.3 tok/s'}
+        """
+        if self._count == 0:
+            return {}
+
+        if fields is None:
+            fields = self.DEFAULT_SNAPSHOT_STATS
+
+        raw = self.to_stats()
+
+        info: dict[str, str] = {}
+        for label, spec in fields.items():
+            if spec == "failed":
+                info[label] = str(self._failed)
+                continue
+
+            metric = spec[0]
+            agg = spec[1]
+            invert = len(spec) > 2 and spec[2] == "inv"
+
+            if agg == "sum":
+                info[label] = f"{self._sums.get(metric, 0):.0f}"
+                continue
+
+            val = raw.get(f"{metric}-{agg}")
+            if val is None:
+                continue
+
+            if invert and val > 0:
+                info[label] = f"{1.0 / val:.1f} tok/s"
+            elif "time" in metric:
+                info[label] = f"{val:.3f}s"
+            else:
+                info[label] = f"{val:.1f}"
+
+        return info
 
 
 def now_utc() -> datetime:

--- a/tests/unit/test_lazy_load.py
+++ b/tests/unit/test_lazy_load.py
@@ -1,12 +1,12 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 from upath import UPath
 
 from llmeter.endpoints.base import InvocationResponse
-from unittest.mock import MagicMock, patch
-
 from llmeter.experiments import LoadTestResult
 from llmeter.results import Result
 
@@ -129,14 +129,14 @@ class TestLoadResponsesOnDemand:
             assert orig.time_to_first_token == loaded_resp.time_to_first_token
             assert orig.time_to_last_token == loaded_resp.time_to_last_token
 
-    def test_load_responses_invalidates_cached_stats(self, saved_result):
+    def test_load_responses_recomputes_stats(self, saved_result):
         loaded = Result.load(saved_result, load_responses=True)
-        # Access _builtin_stats to cache it
-        _ = loaded._builtin_stats
-        assert "_builtin_stats" in loaded.__dict__
+        original_stats = loaded._preloaded_stats.copy()
 
         loaded.load_responses()
-        assert "_builtin_stats" not in loaded.__dict__
+        # Stats should be recomputed (same values, but a fresh dict)
+        assert loaded._preloaded_stats is not original_stats
+        assert loaded._preloaded_stats == original_stats
 
     def test_load_responses_stats_match_full_load(self, saved_result):
         full = Result.load(saved_result, load_responses=True)

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -192,7 +192,9 @@ def test_stats_property(sample_result: Result):
         assert key in stats
 
     # Test caching returns same object for built-in stats:
-    assert sample_result._builtin_stats is sample_result._builtin_stats
+    assert sample_result._preloaded_stats is None or isinstance(
+        sample_result._preloaded_stats, dict
+    )
 
 
 def test_stats_property_empty_result():


### PR DESCRIPTION
Closes #55

## What

Adds low-memory mode for large-scale test runs, replaces `_builtin_stats` with incremental `RunningStats`, and shows live stats on the progress bar during runs.

## Changes

### `llmeter/utils.py`
- New `RunningStats` class that accumulates metrics incrementally via sorted value lists. Provides:
  - `update()` — records one response's metrics
  - `to_stats()` — computes all stats as raw numeric values (single source of truth)
  - `snapshot()` — formats a configurable subset for tqdm progress-bar display
  - `DEFAULT_SNAPSHOT_STATS` — default fields: p50/p90 TTFT, p50/p90 TTLT, median tokens/s, total input/output tokens, failure count

### `llmeter/runner.py`
- New `low_memory` parameter on `_RunConfig`/`Runner`/`run()`: writes responses to disk without keeping them in memory. Requires `output_path`.
- New `progress_bar_stats` parameter: configurable live stats on the progress bar.
- `RunningStats` is always created and fed during `_process_results_from_q`. In low-memory mode, responses are not appended to `_responses`.
- `_run()` always populates `result._preloaded_stats` from `RunningStats.to_stats()`.

### `llmeter/results.py`
- Removed `_builtin_stats` `@cached_property` (and `functools.cached_property` import).
- New `_compute_stats()` classmethod as fallback for manually constructed Results.
- `stats` property now reads from `_preloaded_stats` first, falls back to `_compute_stats()`.
- `load_responses()` recomputes `_preloaded_stats` from loaded data.
- `Result.load(load_responses=True)` computes `_preloaded_stats` from responses.

### Tests
- Updated `test_lazy_load.py`: replaced `_builtin_stats` cache invalidation test with `_preloaded_stats` recomputation test.
- Updated `test_results.py`: replaced `_builtin_stats` caching assertion.

## Usage

```python
# Low-memory mode
result = await runner.run(output_path="/tmp/run", low_memory=True)
result.stats              # works (computed incrementally)
result.responses          # [] (not in memory)
result.load_responses()   # loads from disk

# Custom progress-bar stats
result = await runner.run(
    progress_bar_stats={
        "p99_ttlt": ("time_to_last_token", "p99"),
        "tps": ("time_per_output_token", "p50", "inv"),
        "fail": "failed",
    },
)
```
