### PR TITLE
feat: time-bound runs, live stats display, and send-window metrics

### DIFF
--- a/docs/user_guide/connect_endpoints.md
+++ b/docs/user_guide/connect_endpoints.md
@@ -38,8 +38,9 @@ class MyEndpoint(Endpoint):
 
     @llmeter_invoke
     def invoke(self, payload: dict) -> InvocationResponse:
+        start_t = time.perf_counter()
         raw_response = my_api_call(payload, api_key=self._api_key)
-        return self.parse_response(raw_response, self._start_t)
+        return self.parse_response(raw_response, start_t)
 
     def parse_response(self, raw_response, start_t: float) -> InvocationResponse:
         return InvocationResponse(

--- a/docs/user_guide/connect_endpoints.md
+++ b/docs/user_guide/connect_endpoints.md
@@ -14,6 +14,49 @@ The [endpoints](../reference/endpoints/index.md) section of the API reference li
 
 You can also **create your own integrations** by extending the [`Endpoint`](../reference/endpoints/base.md#llmeter.endpoints.base.Endpoint) class interface, if your target isn't already supported by the built-in endpoints or through the [LiteLLM Endpoint](../reference/endpoints/litellm.md) and [LiteLLM Python SDK](https://docs.litellm.ai/#basic-usage).
 
+### Custom endpoint example
+
+To create a custom endpoint, implement three methods:
+
+- **`invoke(payload)`** — call the API and pass the raw response to `parse_response()`
+- **`parse_response(raw_response, start_t)`** — extract text, token counts, and metadata into an `InvocationResponse`
+- **`prepare_payload(payload, **kwargs)`** *(optional)* — transform the caller's payload before invocation (merge kwargs, inject model ID, etc.)
+
+The base class automatically wraps `invoke` with error handling, timing, and metadata back-fill, so your implementation only needs the happy path:
+
+```python
+from llmeter.endpoints.base import Endpoint, InvocationResponse
+
+class MyEndpoint(Endpoint):
+    def __init__(self, model_id: str, api_key: str):
+        super().__init__(
+            endpoint_name="my-service",
+            model_id=model_id,
+            provider="my-provider",
+        )
+        self._api_key = api_key
+
+    def invoke(self, payload: dict) -> InvocationResponse:
+        raw_response = my_api_call(payload, api_key=self._api_key)
+        return self.parse_response(raw_response, self._start_t)
+
+    def parse_response(self, raw_response, start_t: float) -> InvocationResponse:
+        return InvocationResponse(
+            response_text=raw_response["text"],
+            num_tokens_input=raw_response.get("input_tokens"),
+            num_tokens_output=raw_response.get("output_tokens"),
+        )
+
+    def prepare_payload(self, payload, **kwargs):
+        return {**payload, **kwargs, "model": self.model_id}
+
+    @staticmethod
+    def create_payload(user_message: str, max_tokens: int = 256) -> dict:
+        return {"prompt": user_message, "max_tokens": max_tokens}
+```
+
+You don't need to handle errors, set `time_to_last_token`, `input_payload`, `input_prompt`, or `id` — the base class does all of that. If your `invoke` or `parse_response` raises an exception, it's caught and converted to an error `InvocationResponse` with the prepared payload attached.
+
 Note that [Amazon Bedrock](https://aws.amazon.com/bedrock/) supports several different APIs for accessing Foundation Models. Depending on your target API, you can use LLMeter's:
 
 - [`bedrock`](../reference/endpoints/bedrock.md) endpoints for connecting to Bedrock's [Converse](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html) or [ConverseStream](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html) APIs

--- a/docs/user_guide/connect_endpoints.md
+++ b/docs/user_guide/connect_endpoints.md
@@ -22,10 +22,10 @@ To create a custom endpoint, implement three methods:
 - **`parse_response(raw_response, start_t)`** — extract text, token counts, and metadata into an `InvocationResponse`
 - **`prepare_payload(payload, **kwargs)`** *(optional)* — transform the caller's payload before invocation (merge kwargs, inject model ID, etc.)
 
-The base class automatically wraps `invoke` with error handling, timing, and metadata back-fill, so your implementation only needs the happy path:
+The `@llmeter_invoke` decorator wraps `invoke` with error handling, timing, and metadata back-fill, so your implementation only needs the happy path:
 
 ```python
-from llmeter.endpoints.base import Endpoint, InvocationResponse
+from llmeter.endpoints.base import Endpoint, InvocationResponse, llmeter_invoke
 
 class MyEndpoint(Endpoint):
     def __init__(self, model_id: str, api_key: str):
@@ -36,6 +36,7 @@ class MyEndpoint(Endpoint):
         )
         self._api_key = api_key
 
+    @llmeter_invoke
     def invoke(self, payload: dict) -> InvocationResponse:
         raw_response = my_api_call(payload, api_key=self._api_key)
         return self.parse_response(raw_response, self._start_t)
@@ -55,7 +56,7 @@ class MyEndpoint(Endpoint):
         return {"prompt": user_message, "max_tokens": max_tokens}
 ```
 
-You don't need to handle errors, set `time_to_last_token`, `input_payload`, `input_prompt`, or `id` — the base class does all of that. If your `invoke` or `parse_response` raises an exception, it's caught and converted to an error `InvocationResponse` with the prepared payload attached.
+You don't need to handle errors, set `time_to_last_token`, `input_payload`, `input_prompt`, or `id` — the decorator does all of that. If your `invoke` or `parse_response` raises an exception, it's caught and converted to an error `InvocationResponse` with the prepared payload attached.
 
 Note that [Amazon Bedrock](https://aws.amazon.com/bedrock/) supports several different APIs for accessing Foundation Models. Depending on your target API, you can use LLMeter's:
 

--- a/docs/user_guide/key_concepts.md
+++ b/docs/user_guide/key_concepts.md
@@ -12,7 +12,7 @@ The base `Endpoint` class handles common concerns (error handling, timing, metad
 2. **`invoke(payload)`** — makes the API call and delegates to `parse_response()`
 3. **`parse_response(raw_response, start_t)`** — extracts text, token counts, and other metadata from the provider's raw response
 
-Subclasses implement these three methods with their provider-specific logic. The base class wraps `invoke` with standardized error handling, timing (`time_to_last_token`), and metadata back-fill (`input_payload`, `input_prompt`, `id`), so individual endpoints don't need to duplicate that boilerplate.
+Subclasses implement these three methods with their provider-specific logic. The `@llmeter_invoke` decorator wraps `invoke` with standardized error handling, timing (`time_to_last_token`), and metadata back-fill (`input_payload`, `input_prompt`, `id`), so individual endpoints don't need to duplicate that boilerplate.
 
 LLMeter provides a [range of built-in Endpoint connectors](connect_endpoints.md) for different types of Cloud-deployed or local LLM, or you can also define your own custom integrations.
 

--- a/docs/user_guide/key_concepts.md
+++ b/docs/user_guide/key_concepts.md
@@ -4,7 +4,15 @@ To break down the complex task of performance testing in a modular way, LLMeter 
 
 ## [Endpoint](connect_endpoints.md): An instrumented LLM/API
 
-An `Endpoint` is the Python interface through which LLMeter connects to whatever model or API you want to evaluate. It provides an `invoke()` method which calls the model, but also stores metadata like the time the request took to process and number of input/output tokens consumed.
+An `Endpoint` is the Python interface through which LLMeter connects to whatever model or API you want to evaluate. It provides an `invoke()` method which calls the model, and automatically captures metadata like request timing, token counts, and error information in an [`InvocationResponse`](../reference/endpoints/base.md#llmeter.endpoints.base.InvocationResponse).
+
+The base `Endpoint` class handles common concerns (error handling, timing, metadata) automatically via an invoke lifecycle:
+
+1. **`prepare_payload(payload, **kwargs)`** — merges caller kwargs and injects provider-specific fields (model ID, streaming options, etc.)
+2. **`invoke(payload)`** — makes the API call and delegates to `parse_response()`
+3. **`parse_response(raw_response, start_t)`** — extracts text, token counts, and other metadata from the provider's raw response
+
+Subclasses implement these three methods with their provider-specific logic. The base class wraps `invoke` with standardized error handling, timing (`time_to_last_token`), and metadata back-fill (`input_payload`, `input_prompt`, `id`), so individual endpoints don't need to duplicate that boilerplate.
 
 LLMeter provides a [range of built-in Endpoint connectors](connect_endpoints.md) for different types of Cloud-deployed or local LLM, or you can also define your own custom integrations.
 

--- a/docs/user_guide/metrics.md
+++ b/docs/user_guide/metrics.md
@@ -121,12 +121,13 @@ After a batch of requests completes, the `Runner` computes aggregate statistics 
 | `failed_requests_rate` | Ratio of failed requests to total requests (0.0 to 1.0). |
 | `total_input_tokens` | Sum of `num_tokens_input` across all requests. |
 | `total_output_tokens` | Sum of `num_tokens_output` across all requests. |
+| `total_cached_input_tokens` | Sum of `num_tokens_input_cached` across all requests. Only non-zero when prompt caching is active. |
 | `average_input_tokens_per_minute` | Total input tokens divided by test time, scaled to per-minute rate. |
 | `average_output_tokens_per_minute` | Total output tokens divided by test time, scaled to per-minute rate. |
 
 #### Distribution statistics
 
-For each of the four core per-request metrics (`time_to_last_token`, `time_to_first_token`, `num_tokens_output`, `num_tokens_input`), LLMeter computes distributional aggregates across all successful responses. Each metric gets the following aggregations, accessible as `{metric}-{aggregation}` keys in `Result.stats`:
+For each of the five core per-request metrics (`time_to_last_token`, `time_to_first_token`, `num_tokens_output`, `num_tokens_input`, `num_tokens_input_cached`), LLMeter computes distributional aggregates across all successful responses. Each metric gets the following aggregations, accessible as `{metric}-{aggregation}` keys in `Result.stats`:
 
 | Aggregation | Key suffix | Description |
 | --- | --- | --- |

--- a/docs/user_guide/metrics.md
+++ b/docs/user_guide/metrics.md
@@ -95,12 +95,18 @@ Each request produces an `InvocationResponse` with:
 
 | Field | Unit | Description |
 | --- | --- | --- |
+| `response_text` | string | The generated text from the model. `None` on error. |
+| `id` | string | A unique identifier for the invocation. Extracted from the API response when available (e.g. OpenAI response ID, AWS RequestId), otherwise auto-generated. |
 | `time_to_first_token` | seconds | TTFT. Only populated for streaming endpoints. |
 | `time_to_last_token` | seconds | TTLT. Always populated on successful requests. |
 | `time_per_output_token` | seconds | TPOT. Only available when `num_tokens_output > 1`. |
 | `num_tokens_input` | count | Input token count. Reported by the endpoint or estimated by a tokenizer configured on the `Runner`. |
 | `num_tokens_output` | count | Output token count. Reported by the endpoint or estimated by a tokenizer configured on the `Runner`. |
-| `error` | string | Error message if the request failed, `None` otherwise. |
+| `num_tokens_input_cached` | count | Input tokens served from prompt cache. Reported by Bedrock (`cacheReadInputTokens`) and OpenAI (`cached_tokens`). `None` when caching is not active. |
+| `input_payload` | dict | The full API request payload as sent to the provider (after `prepare_payload` processing). |
+| `input_prompt` | string | The user-facing input text extracted from the payload, used for observability and as a token-counting fallback. |
+| `error` | string | Error message if the request failed, `None` otherwise. Partial data (text, timing) may still be present alongside an error for streaming endpoints that fail mid-stream. |
+| `retries` | count | Number of retries attempted by the underlying SDK. Reported by AWS endpoints (Bedrock, SageMaker) via `ResponseMetadata.RetryAttempts`. `None` for providers that don't expose this. |
 
 ### Run-level statistics
 

--- a/docs/user_guide/run_experiments.md
+++ b/docs/user_guide/run_experiments.md
@@ -34,6 +34,69 @@ run_2_results = await endpoint_test.run(payload=sample_payload, n_requests=10, c
 assert run_1_results.output_path != run_2_results.output_path
 ```
 
+### Time-bound runs
+
+By default, a Run sends a fixed number of requests per client (`n_requests`). Alternatively, you can use `run_duration` to run each client for a fixed number of **seconds** instead — useful when you want to measure sustained throughput over a time window rather than a fixed batch size.
+
+```python
+# Run for 60 seconds with 10 concurrent clients:
+results = await endpoint_test.run(
+    payload=sample_payload,
+    run_duration=60,
+    clients=10,
+)
+
+results.total_requests  # actual number of requests completed
+results.stats["requests_per_minute"]  # observed throughput
+```
+
+`n_requests` and `run_duration` are mutually exclusive — set one or the other, not both.
+
+During a time-bound run, the progress bar shows two lines: a time bar that fills as seconds elapse, and a request counter with live statistics (requests per minute, latency percentiles, tokens per second, etc.).
+
+### Live progress-bar statistics
+
+Both count-bound and time-bound runs display live statistics on the progress bar as requests complete. By default these include p50/p90 TTFT and TTLT, median output tokens per second, total input/output tokens, requests per minute, and failure count.
+
+You can customize which stats are shown via the `progress_bar_stats` parameter:
+
+```python
+# Show only p99 latency, tokens/s, and rpm:
+results = await endpoint_test.run(
+    payload=sample_payload,
+    n_requests=100,
+    clients=5,
+    progress_bar_stats={
+        "rpm": "rpm",
+        "p99_ttlt": ("time_to_last_token", "p99"),
+        "tps": ("time_per_output_token", "p50", "inv"),
+        "fail": "failed",
+    },
+)
+```
+
+Pass `progress_bar_stats={}` to disable live stats entirely. See [`RunningStats.DEFAULT_SNAPSHOT_STATS`](../reference/utils.md#llmeter.utils.RunningStats) for the full default configuration.
+
+### Low-memory mode
+
+For large-scale runs where keeping all responses in memory is impractical, set `low_memory=True`. Responses are written to disk as they arrive but not accumulated in memory. Statistics are computed incrementally and available immediately via `result.stats`.
+
+```python
+results = await endpoint_test.run(
+    payload=sample_payload,
+    run_duration=300,
+    clients=50,
+    output_path="outputs/large_run",
+    low_memory=True,
+)
+
+results.stats          # works — computed incrementally during the run
+results.responses      # [] — not in memory
+results.load_responses()  # loads from disk on demand
+```
+
+`low_memory=True` requires `output_path` to be set.
+
 ## Analyzing Run results
 
 The [Result](../reference/results.md#llmeter.results.Result) of a Run provides basic metadata, a wide range of pre-computed `.stats`, and also access to the individual `.responses` ([InvocationResponse](../reference/endpoints/base/#llmeter.endpoints.base.InvocationResponse) objects).

--- a/docs/user_guide/run_experiments.md
+++ b/docs/user_guide/run_experiments.md
@@ -75,7 +75,7 @@ results = await endpoint_test.run(
 )
 ```
 
-Pass `progress_bar_stats={}` to disable live stats entirely. See [`RunningStats.DEFAULT_SNAPSHOT_STATS`](../reference/utils.md#llmeter.utils.RunningStats) for the full default configuration.
+Pass `progress_bar_stats={}` to disable live stats entirely. See [`DEFAULT_DISPLAY_STATS`](../reference/live_display.md) for the full default configuration.
 
 ### Low-memory mode
 

--- a/docs/user_guide/run_experiments.md
+++ b/docs/user_guide/run_experiments.md
@@ -67,7 +67,7 @@ results = await endpoint_test.run(
     n_requests=100,
     clients=5,
     progress_bar_stats={
-        "rpm": "rpm",
+        "rpm": "requests_per_minute",
         "p99_ttlt": ("time_to_last_token", "p99"),
         "tps": ("time_per_output_token", "p50", "inv"),
         "fail": "failed",

--- a/examples/Prompt caching latency.ipynb
+++ b/examples/Prompt caching latency.ipynb
@@ -1,0 +1,2734 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Measuring the latency impact of prompt caching\n",
+    "\n",
+    "This notebook demonstrates how to measure the latency benefit of [prompt caching](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html) on Amazon Bedrock using LLMeter.\n",
+    "\n",
+    "Prompt caching allows the model to skip reprocessing a static prefix (e.g. a long system prompt) on repeated requests, reducing both **time to first token (TTFT)** and **cost**. This notebook compares TTFT distributions with and without cache hits, using a `before_invoke` callback to bust the cache on demand."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install \"llmeter[plotting]<1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llmeter.endpoints import BedrockConverseStream\n",
+    "from llmeter.runner import Runner"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Choose a model that supports prompt caching. Amazon Nova models support caching with a minimum of 1024 tokens in the cached prefix. You must use an [inference profile ID](https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html) (e.g. `us.amazon.nova-lite-v1:0`), not the base model ID. See the [supported models table](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html) for details."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_id = \"us.amazon.nova-lite-v1:0\"\n",
+    "\n",
+    "endpoint = BedrockConverseStream(\n",
+    "    model_id=model_id,\n",
+    "    # region=\"us-east-1\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Building a cacheable payload\n",
+    "\n",
+    "Prompt caching requires:\n",
+    "1. A static prefix long enough to meet the model's minimum (1024 tokens for Nova)\n",
+    "2. A `cachePoint` marker after the content to cache\n",
+    "\n",
+    "We'll use a long system prompt as the cached prefix, with a short user message that varies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Build a system prompt that exceeds the 1024-token minimum.\n",
+    "# Each rule line is ~25 tokens, so 80 lines ≈ 2000 tokens.\n",
+    "long_system_text = \"You are a helpful assistant. Follow these rules:\\n\" + \"\\n\".join(\n",
+    "    f\"Rule {i}: Always be concise, accurate, and helpful in your responses. \"\n",
+    "    \"This is an important guideline that must be followed at all times.\"\n",
+    "    for i in range(1, 81)\n",
+    ")\n",
+    "\n",
+    "payload_with_cache = {\n",
+    "    \"system\": [\n",
+    "        {\"text\": long_system_text},\n",
+    "        {\"cachePoint\": {\"type\": \"default\"}},\n",
+    "    ],\n",
+    "    \"messages\": [\n",
+    "        {\n",
+    "            \"role\": \"user\",\n",
+    "            \"content\": [{\"text\": \"What is the capital of France? Answer in one word.\"}],\n",
+    "        }\n",
+    "    ],\n",
+    "    \"inferenceConfig\": {\"maxTokens\": 50},\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's verify caching works with a quick test — the first call writes to cache, the second should read from it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Call 1: TTFT=1.126s, cached_tokens=0\n",
+      "Call 2: TTFT=0.576s, cached_tokens=2435\n"
+     ]
+    }
+   ],
+   "source": [
+    "import time\n",
+    "from uuid import uuid4\n",
+    "\n",
+    "# Use a unique prefix so re-running the notebook doesn't hit a stale cache\n",
+    "verify_prefix = f\"[verify-{uuid4().hex}] \"\n",
+    "verify_payload = {\n",
+    "    **payload_with_cache,\n",
+    "    \"system\": [\n",
+    "        {\"text\": verify_prefix + long_system_text},\n",
+    "        {\"cachePoint\": {\"type\": \"default\"}},\n",
+    "    ],\n",
+    "}\n",
+    "\n",
+    "# First call: cache write (fresh prefix guarantees a miss)\n",
+    "r1 = endpoint.invoke(verify_payload)\n",
+    "print(\n",
+    "    f\"Call 1: TTFT={r1.time_to_first_token:.3f}s, cached_tokens={r1.num_tokens_input_cached}\"\n",
+    ")\n",
+    "\n",
+    "time.sleep(1)  # Brief pause for cache propagation\n",
+    "\n",
+    "# Second call: same prefix, should hit the cache\n",
+    "r2 = endpoint.invoke(verify_payload)\n",
+    "print(\n",
+    "    f\"Call 2: TTFT={r2.time_to_first_token:.3f}s, cached_tokens={r2.num_tokens_input_cached}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cache-busting callback\n",
+    "\n",
+    "To measure latency **without** cache hits, we need every request to miss the cache. We do this with a `before_invoke` callback that prepends a unique random string to the system prompt before each request. This changes the prefix, guaranteeing a cache miss.\n",
+    "\n",
+    "The callback modifies the payload in-place (as required by the LLMeter callback contract)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from uuid import uuid4\n",
+    "\n",
+    "from llmeter.callbacks.base import Callback\n",
+    "\n",
+    "\n",
+    "class CacheBuster(Callback):\n",
+    "    \"\"\"Callback that injects a random prefix into the system prompt to prevent cache hits.\n",
+    "\n",
+    "    This is useful for measuring baseline latency without prompt caching,\n",
+    "    so you can compare it against the cached case.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    async def before_invoke(self, payload: dict) -> None:\n",
+    "        system = payload.get(\"system\")\n",
+    "        if not system:\n",
+    "            return\n",
+    "        # Find the first text block and prepend a unique string\n",
+    "        for block in system:\n",
+    "            if \"text\" in block:\n",
+    "                block[\"text\"] = f\"[session-{uuid4().hex}] \" + block[\"text\"]\n",
+    "                break"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run 1: With prompt caching (baseline)\n",
+    "\n",
+    "First, we prime the cache with a single call, then run the benchmark. All requests use the same system prompt prefix, so they should hit the cache after the first one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7c57c2eeddfb48fcb0a82212f1992c5a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Total requests:   0%|          | 0/90 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Prime the cache\n",
+    "_ = endpoint.invoke(payload_with_cache)\n",
+    "time.sleep(1)\n",
+    "\n",
+    "runner_cached = Runner(\n",
+    "    endpoint,\n",
+    "    output_path=f\"outputs/cache_comparison/{model_id}/cached\",\n",
+    ")\n",
+    "\n",
+    "result_cached = await runner_cached.run(\n",
+    "    payload=payload_with_cache,\n",
+    "    n_requests=30,\n",
+    "    clients=3,\n",
+    "    run_name=\"with-cache\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    \"total_requests\": 90,\n",
+      "    \"clients\": 3,\n",
+      "    \"n_requests\": 30,\n",
+      "    \"total_test_time\": 18.54739387508016,\n",
+      "    \"model_id\": \"us.amazon.nova-lite-v1:0\",\n",
+      "    \"output_path\": \"outputs/cache_comparison/us.amazon.nova-lite-v1:0/cached/with-cache\",\n",
+      "    \"endpoint_name\": \"amazon bedrock\",\n",
+      "    \"provider\": \"bedrock\",\n",
+      "    \"run_name\": \"with-cache\",\n",
+      "    \"run_description\": null,\n",
+      "    \"start_time\": \"2026-04-16T15:37:38Z\",\n",
+      "    \"end_time\": \"2026-04-16T15:37:56Z\",\n",
+      "    \"failed_requests\": 0,\n",
+      "    \"failed_requests_rate\": 0.0,\n",
+      "    \"requests_per_minute\": 291.14602495476805,\n",
+      "    \"total_input_tokens\": 1080,\n",
+      "    \"total_output_tokens\": 180,\n",
+      "    \"total_cached_input_tokens\": 211288,\n",
+      "    \"average_input_tokens_per_minute\": 3493.7522994572164,\n",
+      "    \"average_output_tokens_per_minute\": 582.2920499095361,\n",
+      "    \"time_to_last_token-average\": 0.2627643963619549,\n",
+      "    \"time_to_last_token-p50\": 0.2580558335175738,\n",
+      "    \"time_to_last_token-p90\": 0.5021386420703493,\n",
+      "    \"time_to_last_token-p99\": 0.6087397387891542,\n",
+      "    \"time_to_first_token-average\": 0.25380087868543344,\n",
+      "    \"time_to_first_token-p50\": 0.2532453959574923,\n",
+      "    \"time_to_first_token-p90\": 0.48823858397081493,\n",
+      "    \"time_to_first_token-p99\": 0.6012613537791185,\n",
+      "    \"num_tokens_output-average\": 2,\n",
+      "    \"num_tokens_output-p50\": 2.0,\n",
+      "    \"num_tokens_output-p90\": 2.0,\n",
+      "    \"num_tokens_output-p99\": 2.0,\n",
+      "    \"num_tokens_input-average\": 12,\n",
+      "    \"num_tokens_input-p50\": 12.0,\n",
+      "    \"num_tokens_input-p90\": 12.0,\n",
+      "    \"num_tokens_input-p99\": 12.0,\n",
+      "    \"num_tokens_input_cached-average\": 2347.6444444444446,\n",
+      "    \"num_tokens_input_cached-p50\": 2401.0,\n",
+      "    \"num_tokens_input_cached-p90\": 2401.0,\n",
+      "    \"num_tokens_input_cached-p99\": 2401.0\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(result_cached)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run 2: Without prompt caching (cache-busted)\n",
+    "\n",
+    "Now we run the same workload but with the `CacheBuster` callback, which ensures every request misses the cache."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "982e68a3503644439efa85617a5c2aa0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Total requests:   0%|          | 0/90 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "runner_uncached = Runner(\n",
+    "    endpoint,\n",
+    "    output_path=f\"outputs/cache_comparison/{model_id}/uncached\",\n",
+    "    callbacks=[CacheBuster()],\n",
+    ")\n",
+    "\n",
+    "result_uncached = await runner_uncached.run(\n",
+    "    payload=payload_with_cache,\n",
+    "    n_requests=30,\n",
+    "    clients=3,\n",
+    "    run_name=\"without-cache\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    \"total_requests\": 90,\n",
+      "    \"clients\": 3,\n",
+      "    \"n_requests\": 30,\n",
+      "    \"total_test_time\": 17.43987720797304,\n",
+      "    \"model_id\": \"us.amazon.nova-lite-v1:0\",\n",
+      "    \"output_path\": \"outputs/cache_comparison/us.amazon.nova-lite-v1:0/uncached/without-cache\",\n",
+      "    \"endpoint_name\": \"amazon bedrock\",\n",
+      "    \"provider\": \"bedrock\",\n",
+      "    \"run_name\": \"without-cache\",\n",
+      "    \"run_description\": null,\n",
+      "    \"start_time\": \"2026-04-16T15:37:57Z\",\n",
+      "    \"end_time\": \"2026-04-16T15:38:14Z\",\n",
+      "    \"failed_requests\": 0,\n",
+      "    \"failed_requests_rate\": 0.0,\n",
+      "    \"requests_per_minute\": 309.6352076109381,\n",
+      "    \"total_input_tokens\": 1080,\n",
+      "    \"total_output_tokens\": 183,\n",
+      "    \"total_cached_input_tokens\": 0,\n",
+      "    \"average_input_tokens_per_minute\": 3715.622491331257,\n",
+      "    \"average_output_tokens_per_minute\": 629.5915888089075,\n",
+      "    \"time_to_last_token-average\": 0.26112701249205406,\n",
+      "    \"time_to_last_token-p50\": 0.22509589605033398,\n",
+      "    \"time_to_last_token-p90\": 0.470116974634584,\n",
+      "    \"time_to_last_token-p99\": 0.6483631999033969,\n",
+      "    \"time_to_first_token-average\": 0.2492863449216303,\n",
+      "    \"time_to_first_token-p50\": 0.21820783341536298,\n",
+      "    \"time_to_first_token-p90\": 0.45226739965146406,\n",
+      "    \"time_to_first_token-p99\": 0.6457712807843927,\n",
+      "    \"num_tokens_output-average\": 2.033333333333333,\n",
+      "    \"num_tokens_output-p50\": 2.0,\n",
+      "    \"num_tokens_output-p90\": 2.0,\n",
+      "    \"num_tokens_output-p99\": 3.0,\n",
+      "    \"num_tokens_input-average\": 12,\n",
+      "    \"num_tokens_input-p50\": 12.0,\n",
+      "    \"num_tokens_input-p90\": 12.0,\n",
+      "    \"num_tokens_input-p99\": 12.0,\n",
+      "    \"num_tokens_input_cached-average\": 0,\n",
+      "    \"num_tokens_input_cached-p50\": 0.0,\n",
+      "    \"num_tokens_input_cached-p90\": 0.0,\n",
+      "    \"num_tokens_input_cached-p99\": 0.0\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(result_uncached)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Comparing the results\n",
+    "\n",
+    "Let's compare the TTFT distributions side by side."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import plotly.graph_objects as go\n",
+    "import plotly.io as pio\n",
+    "\n",
+    "from llmeter.plotting import boxplot_by_dimension, histogram_by_dimension\n",
+    "\n",
+    "pio.templates.default = \"plotly_white\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Summary statistics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "With cache:\n",
+      "  time_to_first_token-average: 0.2538s\n",
+      "  time_to_first_token-p50: 0.2532s\n",
+      "  time_to_first_token-p90: 0.4882s\n",
+      "  time_to_first_token-p99: 0.6013s\n",
+      "  total_cached_input_tokens: 211288\n",
+      "  num_tokens_input_cached-average: 2348\n",
+      "\n",
+      "Without cache:\n",
+      "  time_to_first_token-average: 0.2493s\n",
+      "  time_to_first_token-p50: 0.2182s\n",
+      "  time_to_first_token-p90: 0.4523s\n",
+      "  time_to_first_token-p99: 0.6458s\n",
+      "  total_cached_input_tokens: 0\n",
+      "  num_tokens_input_cached-average: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "dimension = \"time_to_first_token\"\n",
+    "\n",
+    "for label, result in [\n",
+    "    (\"With cache\", result_cached),\n",
+    "    (\"Without cache\", result_uncached),\n",
+    "]:\n",
+    "    stats = result.stats\n",
+    "    ttft_stats = {k: v for k, v in stats.items() if dimension in k}\n",
+    "    print(f\"\\n{label}:\")\n",
+    "    for k, v in ttft_stats.items():\n",
+    "        print(f\"  {k}: {v:.4f}s\")\n",
+    "    print(f\"  total_cached_input_tokens: {stats.get('total_cached_input_tokens', 0)}\")\n",
+    "    cached_avg = stats.get(\"num_tokens_input_cached-average\")\n",
+    "    if cached_avg is not None:\n",
+    "        print(f\"  num_tokens_input_cached-average: {cached_avg:.0f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Boxplot comparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "name": "with-cache",
+         "type": "box",
+         "x": [
+          0.524420875008218,
+          0.5013844160130247,
+          0.5104560409672558,
+          0.049560666899196804,
+          0.4561935410602018,
+          0.12974562495946884,
+          0.21377324999775738,
+          0.12177229195367545,
+          0.39698774996213615,
+          0.48881645896472037,
+          0.0863279999466613,
+          0.45013012492563576,
+          0.03540291707031429,
+          0.3445181659189984,
+          0.14262429205700755,
+          0.10628391697537154,
+          0.3792406660504639,
+          0.11809124995488673,
+          0.17569191695656627,
+          0.3633292498998344,
+          0.098407750017941,
+          0.039043082972057164,
+          0.36076000006869435,
+          0.1260559579823166,
+          0.13222329097334296,
+          0.4957298750523478,
+          0.4830377090256661,
+          0.1212633749237284,
+          0.33991666708607227,
+          0.3390210000798106,
+          0.09955895901657641,
+          0.35448570793960243,
+          0.3901331250090152,
+          0.10254704195540398,
+          0.3633966660127044,
+          0.19888037501368672,
+          0.03844391705933958,
+          0.2442422080785036,
+          0.14657262503169477,
+          0.06415404204744846,
+          0.2555985409999266,
+          0.25493729196023196,
+          0.10419383400585502,
+          0.1403009999776259,
+          0.2773136249743402,
+          0.30613087490200996,
+          0.22564754111226648,
+          0.24241437506861985,
+          0.2587809580145404,
+          0.2590472080046311,
+          0.257352500106208,
+          0.2734995000064373,
+          0.3049475000007078,
+          0.15805970795918256,
+          0.026100957999005914,
+          0.296802332974039,
+          0.22837300004903227,
+          0.22845725005026907,
+          0.26566270797047764,
+          0.19321954203769565,
+          0.15556533297058195,
+          0.17872724996414036,
+          0.26165424997452646,
+          0.0645332089625299,
+          0.1822019589599222,
+          0.20521420892328024,
+          0.142869041999802,
+          0.1557908330578357,
+          0.42695683403871953,
+          0.3014569169608876,
+          0.021311999997124076,
+          0.47384816699195653,
+          0.06698600004892796,
+          0.07626533298753202,
+          0.535533917020075,
+          0.5429042499745265,
+          0.09300095797516406,
+          0.3868948749732226,
+          0.3940903749316931,
+          0.2515534999547526,
+          0.20971187495160848,
+          0.2257149169454351,
+          0.25666016701143235,
+          0.28034375002607703,
+          0.2669626659480855,
+          0.25535108300391585,
+          0.2914488329552114,
+          0.26828825008124113,
+          0.5811707910615951,
+          0.5996024999767542
+         ]
+        },
+        {
+         "name": "without-cache",
+         "type": "box",
+         "x": [
+          0.49814399995375425,
+          0.5273453339468688,
+          0.5277198749827221,
+          0.4393974170088768,
+          0.06404616602230817,
+          0.03676820907276124,
+          0.41124558402225375,
+          0.13009104202501476,
+          0.17406516696792096,
+          0.3359577920055017,
+          0.15036595799028873,
+          0.1752173750428483,
+          0.3414169999305159,
+          0.15718429209664464,
+          0.09740962507203221,
+          0.21415700006764382,
+          0.2409779579611495,
+          0.07307174999732524,
+          0.15279483399353921,
+          0.33800158405210823,
+          0.39374562504235655,
+          0.2987165830563754,
+          0.4871455410029739,
+          0.5129253329942003,
+          0.4528837079415098,
+          0.4636999169597402,
+          0.19471087493002415,
+          0.2748476250562817,
+          0.053007832961156964,
+          0.21220287506002933,
+          0.19804320798721164,
+          0.09960612503346056,
+          0.22183516703080386,
+          0.13369970803614706,
+          0.270135665894486,
+          0.11137695889919996,
+          0.1841498330468312,
+          0.23511433403473347,
+          0.21772612491622567,
+          0.12037895899266005,
+          0.2503546249354258,
+          0.07388287503272295,
+          0.15341649996116757,
+          0.2480462919920683,
+          0.10353204200509936,
+          0.42999224993400276,
+          0.41810204193461686,
+          0.19567908300086856,
+          0.2640136250993237,
+          0.10896012501325458,
+          0.3398820840520784,
+          0.07650929095689207,
+          0.06610900000669062,
+          0.40121483290567994,
+          0.04764941695611924,
+          0.08737587498035282,
+          0.38532829110044986,
+          0.36511029105167836,
+          0.2470552499871701,
+          0.37109487503767014,
+          0.39710116607602686,
+          0.06253550003748387,
+          0.3949329589959234,
+          0.0713298749178648,
+          0.11779062508139759,
+          0.35637979197781533,
+          0.3564523329259828,
+          0.12023366603534669,
+          0.37385262502357364,
+          0.2071001660078764,
+          0.13892449997365475,
+          0.3197686669882387,
+          0.37101770797744393,
+          0.34225625009275973,
+          0.08316475001629442,
+          0.19003149995114654,
+          0.25015283294487745,
+          0.13797779195010662,
+          0.06796270806808025,
+          0.40804675000254065,
+          0.4454639999894425,
+          0.05131929100025445,
+          0.4467206250410527,
+          0.043923790915869176,
+          0.21618762507569045,
+          0.2186895419145003,
+          0.09605633397586644,
+          0.18128441693261266,
+          0.4784507090225816,
+          0.6360239170026034
+         ]
+        }
+       ],
+       "layout": {
+        "legend": {
+         "x": 0.99,
+         "xanchor": "right",
+         "y": 0.99,
+         "yanchor": "top"
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Time to First Token: cached vs uncached"
+        },
+        "xaxis": {
+         "title": {
+          "text": "seconds"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig = go.Figure()\n",
+    "fig.add_trace(boxplot_by_dimension(result=result_cached, dimension=dimension))\n",
+    "fig.add_trace(boxplot_by_dimension(result=result_uncached, dimension=dimension))\n",
+    "\n",
+    "fig.update_layout(\n",
+    "    title=\"Time to First Token: cached vs uncached\",\n",
+    "    xaxis_title=\"seconds\",\n",
+    "    legend=dict(yanchor=\"top\", y=0.99, xanchor=\"right\", x=0.99),\n",
+    ")\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Histogram comparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "histnorm": "probability",
+         "name": "with-cache",
+         "opacity": 0.7,
+         "type": "histogram",
+         "x": [
+          0.524420875008218,
+          0.5013844160130247,
+          0.5104560409672558,
+          0.049560666899196804,
+          0.4561935410602018,
+          0.12974562495946884,
+          0.21377324999775738,
+          0.12177229195367545,
+          0.39698774996213615,
+          0.48881645896472037,
+          0.0863279999466613,
+          0.45013012492563576,
+          0.03540291707031429,
+          0.3445181659189984,
+          0.14262429205700755,
+          0.10628391697537154,
+          0.3792406660504639,
+          0.11809124995488673,
+          0.17569191695656627,
+          0.3633292498998344,
+          0.098407750017941,
+          0.039043082972057164,
+          0.36076000006869435,
+          0.1260559579823166,
+          0.13222329097334296,
+          0.4957298750523478,
+          0.4830377090256661,
+          0.1212633749237284,
+          0.33991666708607227,
+          0.3390210000798106,
+          0.09955895901657641,
+          0.35448570793960243,
+          0.3901331250090152,
+          0.10254704195540398,
+          0.3633966660127044,
+          0.19888037501368672,
+          0.03844391705933958,
+          0.2442422080785036,
+          0.14657262503169477,
+          0.06415404204744846,
+          0.2555985409999266,
+          0.25493729196023196,
+          0.10419383400585502,
+          0.1403009999776259,
+          0.2773136249743402,
+          0.30613087490200996,
+          0.22564754111226648,
+          0.24241437506861985,
+          0.2587809580145404,
+          0.2590472080046311,
+          0.257352500106208,
+          0.2734995000064373,
+          0.3049475000007078,
+          0.15805970795918256,
+          0.026100957999005914,
+          0.296802332974039,
+          0.22837300004903227,
+          0.22845725005026907,
+          0.26566270797047764,
+          0.19321954203769565,
+          0.15556533297058195,
+          0.17872724996414036,
+          0.26165424997452646,
+          0.0645332089625299,
+          0.1822019589599222,
+          0.20521420892328024,
+          0.142869041999802,
+          0.1557908330578357,
+          0.42695683403871953,
+          0.3014569169608876,
+          0.021311999997124076,
+          0.47384816699195653,
+          0.06698600004892796,
+          0.07626533298753202,
+          0.535533917020075,
+          0.5429042499745265,
+          0.09300095797516406,
+          0.3868948749732226,
+          0.3940903749316931,
+          0.2515534999547526,
+          0.20971187495160848,
+          0.2257149169454351,
+          0.25666016701143235,
+          0.28034375002607703,
+          0.2669626659480855,
+          0.25535108300391585,
+          0.2914488329552114,
+          0.26828825008124113,
+          0.5811707910615951,
+          0.5996024999767542
+         ],
+         "xbins": {
+          "size": 0.02
+         }
+        },
+        {
+         "histnorm": "probability",
+         "name": "without-cache",
+         "opacity": 0.7,
+         "type": "histogram",
+         "x": [
+          0.49814399995375425,
+          0.5273453339468688,
+          0.5277198749827221,
+          0.4393974170088768,
+          0.06404616602230817,
+          0.03676820907276124,
+          0.41124558402225375,
+          0.13009104202501476,
+          0.17406516696792096,
+          0.3359577920055017,
+          0.15036595799028873,
+          0.1752173750428483,
+          0.3414169999305159,
+          0.15718429209664464,
+          0.09740962507203221,
+          0.21415700006764382,
+          0.2409779579611495,
+          0.07307174999732524,
+          0.15279483399353921,
+          0.33800158405210823,
+          0.39374562504235655,
+          0.2987165830563754,
+          0.4871455410029739,
+          0.5129253329942003,
+          0.4528837079415098,
+          0.4636999169597402,
+          0.19471087493002415,
+          0.2748476250562817,
+          0.053007832961156964,
+          0.21220287506002933,
+          0.19804320798721164,
+          0.09960612503346056,
+          0.22183516703080386,
+          0.13369970803614706,
+          0.270135665894486,
+          0.11137695889919996,
+          0.1841498330468312,
+          0.23511433403473347,
+          0.21772612491622567,
+          0.12037895899266005,
+          0.2503546249354258,
+          0.07388287503272295,
+          0.15341649996116757,
+          0.2480462919920683,
+          0.10353204200509936,
+          0.42999224993400276,
+          0.41810204193461686,
+          0.19567908300086856,
+          0.2640136250993237,
+          0.10896012501325458,
+          0.3398820840520784,
+          0.07650929095689207,
+          0.06610900000669062,
+          0.40121483290567994,
+          0.04764941695611924,
+          0.08737587498035282,
+          0.38532829110044986,
+          0.36511029105167836,
+          0.2470552499871701,
+          0.37109487503767014,
+          0.39710116607602686,
+          0.06253550003748387,
+          0.3949329589959234,
+          0.0713298749178648,
+          0.11779062508139759,
+          0.35637979197781533,
+          0.3564523329259828,
+          0.12023366603534669,
+          0.37385262502357364,
+          0.2071001660078764,
+          0.13892449997365475,
+          0.3197686669882387,
+          0.37101770797744393,
+          0.34225625009275973,
+          0.08316475001629442,
+          0.19003149995114654,
+          0.25015283294487745,
+          0.13797779195010662,
+          0.06796270806808025,
+          0.40804675000254065,
+          0.4454639999894425,
+          0.05131929100025445,
+          0.4467206250410527,
+          0.043923790915869176,
+          0.21618762507569045,
+          0.2186895419145003,
+          0.09605633397586644,
+          0.18128441693261266,
+          0.4784507090225816,
+          0.6360239170026034
+         ],
+         "xbins": {
+          "size": 0.02
+         }
+        }
+       ],
+       "layout": {
+        "barmode": "overlay",
+        "legend": {
+         "x": 0.99,
+         "xanchor": "right",
+         "y": 0.99,
+         "yanchor": "top"
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "TTFT distribution: cached vs uncached"
+        },
+        "xaxis": {
+         "title": {
+          "text": "seconds"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig = go.Figure()\n",
+    "fig.add_trace(histogram_by_dimension(result_cached, dimension, xbins=dict(size=0.02)))\n",
+    "fig.add_trace(histogram_by_dimension(result_uncached, dimension, xbins=dict(size=0.02)))\n",
+    "\n",
+    "fig.update_layout(\n",
+    "    title=\"TTFT distribution: cached vs uncached\",\n",
+    "    xaxis_title=\"seconds\",\n",
+    "    barmode=\"overlay\",\n",
+    "    legend=dict(yanchor=\"top\", y=0.99, xanchor=\"right\", x=0.99),\n",
+    ")\n",
+    "fig.update_traces(opacity=0.7)\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Cache hit verification\n",
+    "\n",
+    "We can verify that the cached run actually used the cache by comparing `total_cached_input_tokens` from `Result.stats`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cached run     — total_cached_input_tokens: 211,288, avg cached/request: 2,348\n",
+      "Uncached run   — total_cached_input_tokens:      0, avg cached/request: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "for label, result in [(\"Cached run\", result_cached), (\"Uncached run\", result_uncached)]:\n",
+    "    stats = result.stats\n",
+    "    total_cached = stats.get(\"total_cached_input_tokens\", 0)\n",
+    "    total_input = stats.get(\"total_input_tokens\", 0)\n",
+    "    cache_avg = stats.get(\"num_tokens_input_cached-average\", 0) or 0\n",
+    "    print(\n",
+    "        f\"{label:14s} — total_cached_input_tokens: {total_cached:>6,}, \"\n",
+    "        f\"avg cached/request: {cache_avg:,.0f}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Statistical comparison\n",
+    "\n",
+    "Latency data is typically skewed, so we use bootstrapping to estimate confidence intervals on the median TTFT for each run, and on the difference between them. This gives us a rigorous way to quantify the caching benefit beyond just comparing point estimates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from scipy.stats import bootstrap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Median TTFT for each run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_cached = [v for v in result_cached.get_dimension(dimension) if v is not None]\n",
+    "data_uncached = [v for v in result_uncached.get_dimension(dimension) if v is not None]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Median TTFT (with cache):\n",
+      "  0.2532s (0.2075, 0.2663)s\n"
+     ]
+    }
+   ],
+   "source": [
+    "res = bootstrap((data_cached,), np.median, confidence_level=0.95)\n",
+    "print(\n",
+    "    f\"Median TTFT (with cache):\\n\"\n",
+    "    f\"  {np.median(data_cached):.4f}s \"\n",
+    "    f\"({res.confidence_interval.low:.4f}, {res.confidence_interval.high:.4f})s\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Median TTFT (without cache):\n",
+      "  0.2182s (0.1871, 0.2671)s\n"
+     ]
+    }
+   ],
+   "source": [
+    "res = bootstrap((data_uncached,), np.median, confidence_level=0.95)\n",
+    "print(\n",
+    "    f\"Median TTFT (without cache):\\n\"\n",
+    "    f\"  {np.median(data_uncached):.4f}s \"\n",
+    "    f\"({res.confidence_interval.low:.4f}, {res.confidence_interval.high:.4f})s\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Difference between medians\n",
+    "\n",
+    "A positive value means the uncached run is slower (as expected). If the confidence interval excludes zero, the difference is statistically significant at the 95% level."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Median TTFT difference (uncached − cached):\n",
+      "  -0.0350s (-0.0815, 0.0128)s\n",
+      "\n",
+      "The difference is not statistically significant at the 95% level.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def median_difference(sample_cached, sample_uncached, axis=-1):\n",
+    "    return np.median(sample_uncached, axis=axis) - np.median(sample_cached, axis=axis)\n",
+    "\n",
+    "\n",
+    "res = bootstrap(\n",
+    "    (data_cached, data_uncached),\n",
+    "    median_difference,\n",
+    "    confidence_level=0.95,\n",
+    ")\n",
+    "\n",
+    "diff = median_difference(data_cached, data_uncached)\n",
+    "print(\n",
+    "    f\"Median TTFT difference (uncached − cached):\\n\"\n",
+    "    f\"  {diff:.4f}s ({res.confidence_interval.low:.4f}, {res.confidence_interval.high:.4f})s\\n\"\n",
+    ")\n",
+    "\n",
+    "if res.confidence_interval.low > 0:\n",
+    "    pct = diff / np.median(data_uncached) * 100\n",
+    "    print(f\"Prompt caching reduces median TTFT by ~{pct:.1f}%\")\n",
+    "else:\n",
+    "    print(\"The difference is not statistically significant at the 95% level.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Notes\n",
+    "\n",
+    "- **Cache TTL**: Bedrock prompt caches have a 5-minute TTL by default (1 hour for some Claude models with `\"ttl\": \"1h\"`). If your test run takes longer than this, later requests may miss the cache.\n",
+    "- **Token minimum**: Nova models require at least 1024 tokens in the cached prefix. Claude models require 1024–2048 depending on the variant. If your system prompt is too short, caching won't activate.\n",
+    "- **Cost**: Cached tokens are charged at a reduced rate for reads, but writes may cost more than standard input tokens. See [Bedrock pricing](https://aws.amazon.com/bedrock/pricing/) for details."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/Time-bound runs with Bedrock OpenAI API.ipynb
+++ b/examples/Time-bound runs with Bedrock OpenAI API.ipynb
@@ -1,0 +1,9672 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Time-bound Runs with Bedrock OpenAI-compatible API\n",
+    "\n",
+    "This notebook demonstrates how to use LLMeter's **time-bound run** feature to measure\n",
+    "sustained throughput and latency over a fixed time window, using Amazon Bedrock's\n",
+    "[OpenAI-compatible Chat Completion API](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-openai-chat.html).\n",
+    "\n",
+    "Instead of specifying a fixed number of requests, you set a `run_duration` in seconds\n",
+    "and LLMeter sends requests continuously until the time expires — giving you a realistic\n",
+    "picture of steady-state performance.\n",
+    "\n",
+    "We also cover:\n",
+    "- **Live progress-bar statistics** (rpm, latency percentiles, tokens/s)\n",
+    "- **Low-memory mode** for large-scale runs\n",
+    "- **Custom progress-bar stats** configuration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Install LLMeter with plotting extras, the OpenAI SDK, and the Bedrock token generator."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install \"llmeter[plotting]<1\" openai aws-bedrock-token-generator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from llmeter.endpoints.openai import OpenAICompletionStreamEndpoint\n",
+    "from llmeter.runner import Runner"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure the Bedrock OpenAI-compatible endpoint\n",
+    "\n",
+    "Amazon Bedrock exposes an [OpenAI-compatible Chat Completions API](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-openai-chat.html)\n",
+    "accessible via the `bedrock-mantle` endpoint. Authentication uses a temporary token\n",
+    "generated from your AWS credentials via `aws-bedrock-token-generator`.\n",
+    "\n",
+    "We use `OpenAICompletionStreamEndpoint` from LLMeter, which works with any\n",
+    "OpenAI Chat Completions-compatible API — including Bedrock's mantle endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Region: us-west-2\n",
+      "Model: openai.gpt-oss-120b\n",
+      "Endpoint: https://bedrock-mantle.us-west-2.api.aws/v1\n"
+     ]
+    }
+   ],
+   "source": [
+    "from aws_bedrock_token_generator import provide_token\n",
+    "\n",
+    "AWS_REGION = os.environ.get(\"AWS_REGION\", \"us-east-1\")\n",
+    "\n",
+    "# OpenAI GPT-OSS models available on the mantle endpoint:\n",
+    "#   openai.gpt-oss-120b  — larger model for complex tasks (120B parameters)\n",
+    "#   openai.gpt-oss-20b   — smaller, faster model (20B parameters)\n",
+    "# Use the Models API to discover all available models in your region.\n",
+    "MODEL_ID = \"openai.gpt-oss-120b\"  # Choose a model available via the Chat Completions API\n",
+    "BASE_URL = f\"https://bedrock-mantle.{AWS_REGION}.api.aws/v1\"\n",
+    "\n",
+    "# Generate temporary token for Bedrock authentication\n",
+    "token = provide_token(region=AWS_REGION)\n",
+    "\n",
+    "bedrock_endpoint = OpenAICompletionStreamEndpoint(\n",
+    "    model_id=MODEL_ID,\n",
+    "    endpoint_name=\"bedrock-mantle\",\n",
+    "    provider=\"bedrock\",\n",
+    "    base_url=BASE_URL,\n",
+    "    api_key=token,\n",
+    ")\n",
+    "\n",
+    "print(f\"Region: {AWS_REGION}\")\n",
+    "print(f\"Model: {MODEL_ID}\")\n",
+    "print(f\"Endpoint: {BASE_URL}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Verify the endpoint\n",
+    "\n",
+    "Send a single request to confirm the endpoint is working and LLMeter captures\n",
+    "the expected metrics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    \"response_text\": \"Latency is the time it takes for a single piece of data to travel from source to destination, i.e., the delay before a response begins. Throughput measures how much data can be transferred successfully over a network or system in a given period of time, typically expressed in bits per second or requests per second. In short, latency is about *speed of response* for one item, while throughput is about *volume of work* that can be handled overall.\",\n",
+      "    \"input_payload\": {\n",
+      "        \"messages\": [\n",
+      "            {\n",
+      "                \"role\": \"user\",\n",
+      "                \"content\": \"Explain the difference between latency and throughput in 3 sentences.\"\n",
+      "            }\n",
+      "        ],\n",
+      "        \"max_tokens\": 256,\n",
+      "        \"model\": \"openai.gpt-oss-120b\",\n",
+      "        \"stream\": true,\n",
+      "        \"stream_options\": {\n",
+      "            \"include_usage\": true\n",
+      "        }\n",
+      "    },\n",
+      "    \"id\": \"chatcmpl-e33a8b37-ad37-4946-9f05-8ce91013245f\",\n",
+      "    \"input_prompt\": \"Explain the difference between latency and throughput in 3 sentences.\",\n",
+      "    \"time_to_first_token\": 1.5777457500007586,\n",
+      "    \"time_to_last_token\": 1.680538542001159,\n",
+      "    \"num_tokens_input\": 77,\n",
+      "    \"num_tokens_output\": 138,\n",
+      "    \"time_per_output_token\": null,\n",
+      "    \"error\": null,\n",
+      "    \"retries\": null\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "sample_payload = OpenAICompletionStreamEndpoint.create_payload(\n",
+    "    \"Explain the difference between latency and throughput in 3 sentences.\",\n",
+    "    max_tokens=256,\n",
+    ")\n",
+    "\n",
+    "response = bedrock_endpoint.invoke(sample_payload)\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You should see `time_to_first_token`, `time_to_last_token`, and token counts in the\n",
+    "response. If you see an error, check your AWS credentials and model access."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Count-bound run (baseline)\n",
+    "\n",
+    "First, let's run a traditional count-bound test for comparison."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "85613de232074b3192ce45fcf85775b4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Total requests:   0%|          | 0/15 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table style='border-collapse:collapse;margin:4px 0'><tr><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Throughput</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTFT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTLT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Tokens</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Errors</th></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>rpm</span>&nbsp;&nbsp;<span style='font-family:monospace'>99.6</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>1.118s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>2.205s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>input_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>1155</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>fail</span>&nbsp;&nbsp;<span style='font-family:monospace'>0</span></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>215.5 tok/s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>3.083s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>5.363s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>1947</span></td><td></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>182.0 tok/s</span></td><td></td><td></td><td></td><td></td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total requests: 15\n",
+      "Duration: 14.3s\n",
+      "RPM: 63.1\n"
+     ]
+    }
+   ],
+   "source": [
+    "runner = Runner(\n",
+    "    bedrock_endpoint,\n",
+    "    output_path=f\"outputs/{MODEL_ID}\",\n",
+    ")\n",
+    "\n",
+    "count_result = await runner.run(\n",
+    "    payload=sample_payload,\n",
+    "    n_requests=5,\n",
+    "    clients=3,\n",
+    "    run_name=\"count-bound-baseline\",\n",
+    ")\n",
+    "\n",
+    "print(f\"Total requests: {count_result.total_requests}\")\n",
+    "print(f\"Duration: {count_result.total_test_time:.1f}s\")\n",
+    "print(f\"RPM: {count_result.stats['requests_per_minute']:.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Time-bound run\n",
+    "\n",
+    "Now let's run the same endpoint for a fixed duration instead. This is useful when you\n",
+    "want to measure **sustained throughput** — how many requests the endpoint can handle\n",
+    "over a realistic time window.\n",
+    "\n",
+    "Set `run_duration` (in seconds) instead of `n_requests`. Each client sends requests\n",
+    "continuously until the duration expires."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "57cf16076c0d4cffac21c4b69f35d2b3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Elapsed:           | 0/30s [00:00]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<span style='font-size:12px;font-family:monospace;color:#555'>reqs=29</span><br><table style='border-collapse:collapse;margin:4px 0'><tr><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Throughput</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTFT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTLT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Tokens</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Errors</th></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>rpm</span>&nbsp;&nbsp;<span style='font-family:monospace'>58.0</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>1.180s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>2.955s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>input_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>2233</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>fail</span>&nbsp;&nbsp;<span style='font-family:monospace'>0</span></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>125.0 tok/s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>3.765s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>6.345s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>3750</span></td><td></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>86.3 tok/s</span></td><td></td><td></td><td></td><td></td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total requests completed: 29\n",
+      "Actual duration: 32.4s\n",
+      "RPM: 53.7\n",
+      "p50 TTFT: 1.180s\n",
+      "p90 TTLT: 6.345s\n"
+     ]
+    }
+   ],
+   "source": [
+    "duration_result = await runner.run(\n",
+    "    payload=sample_payload,\n",
+    "    run_duration=30,  # Run for 30 seconds\n",
+    "    clients=3,\n",
+    "    run_name=\"time-bound-30s\",\n",
+    ")\n",
+    "\n",
+    "print(f\"Total requests completed: {duration_result.total_requests}\")\n",
+    "print(f\"Actual duration: {duration_result.total_test_time:.1f}s\")\n",
+    "print(f\"RPM: {duration_result.stats['requests_per_minute']:.1f}\")\n",
+    "print(f\"p50 TTFT: {duration_result.stats['time_to_first_token-p50']:.3f}s\")\n",
+    "print(f\"p90 TTLT: {duration_result.stats['time_to_last_token-p90']:.3f}s\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that during the run, you see two progress bars:\n",
+    "- **Elapsed**: a time bar filling up as seconds pass\n",
+    "- **Requests**: a counter with live stats (rpm, latency percentiles, tokens/s, etc.)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load test: scaling with more clients\n",
+    "\n",
+    "Time-bound runs are great for exploring how throughput scales with concurrency.\n",
+    "LLMeter's `LoadTest` experiment automates this — it runs each concurrency level\n",
+    "for the same duration and collects results for comparison.\n",
+    "\n",
+    "The `run_duration` parameter makes each concurrency level run for a fixed time\n",
+    "window, giving a fair comparison of sustained throughput."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "96c029b9166648bf89091ad3a2a08bd0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Configurations:   0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7060990ec16749bd93f16fe4a9514899",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Elapsed:           | 0/30s [00:00]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<span style='font-size:12px;font-family:monospace;color:#555'>reqs=13</span><br><table style='border-collapse:collapse;margin:4px 0'><tr><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Throughput</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTFT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTLT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Tokens</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Errors</th></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>rpm</span>&nbsp;&nbsp;<span style='font-family:monospace'>26.8</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>1.071s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>1.927s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>input_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>1001</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>fail</span>&nbsp;&nbsp;<span style='font-family:monospace'>0</span></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>59.8 tok/s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>3.160s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>6.137s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>1741</span></td><td></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>184.6 tok/s</span></td><td></td><td></td><td></td><td></td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d5d22e732c6c4da7a191860e1b7ab87b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Elapsed:           | 0/30s [00:00]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<span style='font-size:12px;font-family:monospace;color:#555'>reqs=37</span><br><table style='border-collapse:collapse;margin:4px 0'><tr><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Throughput</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTFT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTLT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Tokens</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Errors</th></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>rpm</span>&nbsp;&nbsp;<span style='font-family:monospace'>75.0</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>0.886s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>2.035s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>input_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>2849</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>fail</span>&nbsp;&nbsp;<span style='font-family:monospace'>0</span></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>171.7 tok/s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>2.327s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>4.703s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>5079</span></td><td></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>113.6 tok/s</span></td><td></td><td></td><td></td><td></td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "be031a6b2d5e46dca8b0238bc0b1dd9e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Elapsed:           | 0/30s [00:00]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<span style='font-size:12px;font-family:monospace;color:#555'>reqs=63</span><br><table style='border-collapse:collapse;margin:4px 0'><tr><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Throughput</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTFT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTLT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Tokens</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Errors</th></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>rpm</span>&nbsp;&nbsp;<span style='font-family:monospace'>126.6</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>1.181s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>2.388s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>input_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>4851</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>fail</span>&nbsp;&nbsp;<span style='font-family:monospace'>0</span></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>281.6 tok/s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>2.326s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>4.191s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>8411</span></td><td></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>114.9 tok/s</span></td><td></td><td></td><td></td><td></td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bf8f929d26134894ad73b5197385d783",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Elapsed:           | 0/30s [00:00]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<span style='font-size:12px;font-family:monospace;color:#555'>reqs=106</span><br><table style='border-collapse:collapse;margin:4px 0'><tr><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Throughput</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTFT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTLT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Tokens</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Errors</th></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>rpm</span>&nbsp;&nbsp;<span style='font-family:monospace'>214.4</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>1.417s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>3.034s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>input_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>8162</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>fail</span>&nbsp;&nbsp;<span style='font-family:monospace'>0</span></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>481.3 tok/s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>3.600s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>4.954s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>14279</span></td><td></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>103.0 tok/s</span></td><td></td><td></td><td></td><td></td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from llmeter.experiments import LoadTest\n",
+    "\n",
+    "load_test = LoadTest(\n",
+    "    endpoint=bedrock_endpoint,\n",
+    "    payload=sample_payload,\n",
+    "    sequence_of_clients=[1, 3, 5, 10],\n",
+    "    run_duration=30,  # Each concurrency level runs for 30 seconds\n",
+    "    output_path=f\"outputs/{MODEL_ID}\",\n",
+    "    test_name=\"time-bound-load-test\",\n",
+    ")\n",
+    "\n",
+    "load_test_result = await load_test.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1 clients: 13 requests, 23 rpm, p50 TTFT=1.0713617910005269s\n",
+      "  3 clients: 37 requests, 68 rpm, p50 TTFT=0.8862732499983395s\n",
+      "  5 clients: 63 requests, 118 rpm, p50 TTFT=1.181208833004348s\n",
+      "  10 clients: 106 requests, 196 rpm, p50 TTFT=1.4166151039971737s\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Print summary for each concurrency level\n",
+    "for n_clients, result in sorted(load_test_result.results.items()):\n",
+    "    print(\n",
+    "        f\"  {n_clients} clients: \"\n",
+    "        f\"{result.total_requests} requests, \"\n",
+    "        f\"{result.stats['requests_per_minute']:.0f} rpm, \"\n",
+    "        f\"p50 TTFT={result.stats.get('time_to_first_token-p50', 'N/A')}s\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Custom progress-bar statistics\n",
+    "\n",
+    "You can control which live stats appear on the progress bar via `progress_bar_stats`.\n",
+    "Each entry maps a display label to a field spec."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bbfb9c26d3ae441890e7973e44cf0a40",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Elapsed:           | 0/15s [00:00]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<span style='font-size:12px;font-family:monospace;color:#555'>reqs=17</span><br><table style='border-collapse:collapse;margin:4px 0'><tr><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Throughput</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTLT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Errors</th></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>rpm</span>&nbsp;&nbsp;<span style='font-family:monospace'>71.4</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p99_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>5.521s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>fail</span>&nbsp;&nbsp;<span style='font-family:monospace'>0</span></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>75.3 tok/s</span></td><td></td><td></td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "result = await runner.run(\n",
+    "    payload=sample_payload,\n",
+    "    run_duration=15,\n",
+    "    clients=3,\n",
+    "    run_name=\"custom-stats\",\n",
+    "    progress_bar_stats={\n",
+    "        \"rpm\": \"rpm\",\n",
+    "        \"p99_ttlt\": (\"time_to_last_token\", \"p99\"),\n",
+    "        \"tps\": (\"time_per_output_token\", \"p50\", \"inv\"),\n",
+    "        \"fail\": \"failed\",\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Low-memory mode for large-scale runs\n",
+    "\n",
+    "For long-running tests that generate thousands of responses, use `low_memory=True`\n",
+    "to avoid keeping all responses in memory. Responses are streamed to disk and stats\n",
+    "are computed incrementally.\n",
+    "\n",
+    "This requires `output_path` to be set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "03f410a858cc4d4ea2cb6513668b4bb4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Elapsed:           | 0/60s [00:00]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<span style='font-size:12px;font-family:monospace;color:#555'>reqs=220</span><br><table style='border-collapse:collapse;margin:4px 0'><tr><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Throughput</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTFT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTLT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Tokens</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Errors</th></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>rpm</span>&nbsp;&nbsp;<span style='font-family:monospace'>220.1</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>0.880s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>2.555s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>input_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>16940</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>fail</span>&nbsp;&nbsp;<span style='font-family:monospace'>0</span></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>485.8 tok/s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>3.128s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>4.802s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>29135</span></td><td></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>102.0 tok/s</span></td><td></td><td></td><td></td><td></td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total requests: 220\n",
+      "RPM: 209.5\n",
+      "Responses in memory: 0\n",
+      "\n",
+      "Stats are available without loading responses:\n",
+      "  p50 TTFT: 0.880s\n",
+      "  p90 TTLT: 4.802s\n"
+     ]
+    }
+   ],
+   "source": [
+    "large_result = await runner.run(\n",
+    "    payload=sample_payload,\n",
+    "    run_duration=60,\n",
+    "    clients=10,\n",
+    "    run_name=\"large-low-memory\",\n",
+    "    low_memory=True,\n",
+    ")\n",
+    "\n",
+    "print(f\"Total requests: {large_result.total_requests}\")\n",
+    "print(f\"RPM: {large_result.stats['requests_per_minute']:.1f}\")\n",
+    "print(f\"Responses in memory: {len(large_result.responses)}\")\n",
+    "print(f\"\\nStats are available without loading responses:\")\n",
+    "print(f\"  p50 TTFT: {large_result.stats['time_to_first_token-p50']:.3f}s\")\n",
+    "print(f\"  p90 TTLT: {large_result.stats['time_to_last_token-p90']:.3f}s\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded 1045 responses from disk\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Load responses from disk when needed:\n",
+    "responses = large_result.load_responses()\n",
+    "print(f\"Loaded {len(responses)} responses from disk\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Comparing results\n",
+    "\n",
+    "The `LoadTestResult` has a built-in `plot_results()` method that generates\n",
+    "standard charts (TTFT, TTLT, RPM, error rate, token throughput vs clients)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "name": "time-bound-load-test",
+         "type": "box",
+         "x": [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10
+         ],
+         "y": [
+          1.810565542000404,
+          1.1812222500011558,
+          3.868108458002098,
+          0.7137894999978016,
+          0.5251540839963127,
+          0.37060487500275485,
+          0.44968758300092304,
+          0.3802408749979804,
+          1.2211427910006023,
+          1.4571087089934736,
+          0.589481999995769,
+          2.097318999993149,
+          1.0713617910005269,
+          0.33201908400224056,
+          0.7742456669948297,
+          2.397023541998351,
+          1.8993818329981877,
+          0.42726020899863215,
+          1.4716677499964135,
+          0.46759149999707006,
+          0.8862732499983395,
+          0.3939086249956745,
+          1.0275854999999865,
+          0.7189318340024329,
+          1.4116186659957748,
+          0.7474134169970057,
+          0.40672895799798425,
+          0.42657495900493814,
+          1.2491307079981198,
+          0.36702779099869076,
+          0.7880193340024562,
+          1.8055343329979223,
+          2.310052083004848,
+          1.7829697910055984,
+          2.0935321249999106,
+          1.3090343329968164,
+          0.7112003330039443,
+          4.315548667000257,
+          0.8603567079990171,
+          1.7188770830034628,
+          0.8016122080007335,
+          0.7778300419959123,
+          0.4183118330038269,
+          1.3940931660035858,
+          1.555591791999177,
+          1.9584035000007134,
+          0.697202000003017,
+          0.5803299999970477,
+          3.9468323339970084,
+          0.9757721249989117,
+          1.002142333003576,
+          0.9818431249950663,
+          2.109215791999304,
+          2.854000667000946,
+          1.1883622079985798,
+          2.397148707997985,
+          2.0537721249929746,
+          1.2194084170041606,
+          0.55904924999777,
+          1.0641959169952315,
+          0.3820479999994859,
+          1.1137916250008857,
+          0.3648492919965065,
+          1.4079380000039237,
+          1.1204503329936415,
+          0.7068704999983311,
+          1.5245771670015529,
+          2.0880037499955506,
+          0.34228199999779463,
+          2.0938974159944337,
+          1.313775374997931,
+          0.9155073329966399,
+          1.178452667001693,
+          0.8153431250029826,
+          0.7699036249978235,
+          0.47562379100418184,
+          0.455455625000468,
+          1.1047283329971833,
+          1.333313959003135,
+          0.9293282919970807,
+          1.2738797499987413,
+          1.299013833006029,
+          0.3571828749991255,
+          0.48103974999685306,
+          0.4824907499933033,
+          2.367823166998278,
+          2.344774500001222,
+          0.42162933399959,
+          0.5273924579960294,
+          0.4980682919995161,
+          0.8799479170047562,
+          1.7304949169993051,
+          1.6569751249990077,
+          1.7166576250019716,
+          1.280893458002538,
+          2.347654417004378,
+          1.1621644590049982,
+          1.2532084999984363,
+          2.9941925419989275,
+          2.0151528749993304,
+          1.181208833004348,
+          2.2984159589977935,
+          1.2298334160004742,
+          1.418954875000054,
+          1.82515254199825,
+          1.2331472500009113,
+          0.87708987500082,
+          0.50351466700522,
+          1.607961791996786,
+          0.7267654579991358,
+          0.5518672089965548,
+          0.7452832909984863,
+          1.8045194169972092,
+          1.7789633329957724,
+          2.605166624998674,
+          3.056866250000894,
+          1.6265989160019672,
+          0.5625950419998844,
+          4.143405791000987,
+          4.180461500000092,
+          3.5610989999986487,
+          0.5881356660029269,
+          0.9779006249955273,
+          3.690586582997639,
+          4.832465791005234,
+          0.6448706250012037,
+          4.863131999998586,
+          1.382325790997129,
+          0.4846024590005982,
+          2.2435131250022096,
+          1.5739306670002406,
+          2.255111082995427,
+          3.899700750000193,
+          1.4509044169972185,
+          1.2176708330007386,
+          2.9069163750027656,
+          2.5278627079969738,
+          0.40958595799747854,
+          1.1879090829970664,
+          0.6117010829984793,
+          0.6858485839984496,
+          2.8986509589958587,
+          1.788087708002422,
+          2.269181875002687,
+          0.9895395829953486,
+          2.5265816250030184,
+          2.149016749994189,
+          0.7873067089967662,
+          1.8220124579966068,
+          2.769100500001514,
+          0.5327938330010511,
+          3.213817707997805,
+          0.3640439999944647,
+          1.7442852500025765,
+          0.39150920799875166,
+          1.3132492920049117,
+          0.5267627499997616,
+          0.6975128749982105,
+          5.765499125001952,
+          0.6618302920032875,
+          0.531012917002954,
+          2.8477291669987608,
+          1.1358064590021968,
+          0.3917771249980433,
+          1.7981745829965803,
+          1.4685571670052013,
+          0.5237741250020918,
+          0.44857070799480425,
+          2.0674697080030455,
+          2.1612447919978877,
+          0.36861462500382913,
+          0.3830527499958407,
+          2.0479602080013137,
+          1.5750675000017509,
+          0.4111657500034198,
+          2.939957292001054,
+          2.9568471250022412,
+          0.37112295900442405,
+          3.418946000005235,
+          0.3710014160024002,
+          0.32679066600394435,
+          2.0638363340040087,
+          1.0570221669986495,
+          0.6728937090010731,
+          1.0676320409984328,
+          0.3201369589951355,
+          1.3715982919966336,
+          2.2774177090032026,
+          0.39108320900413673,
+          0.41870475000177976,
+          3.82099775000097,
+          1.9569717920021503,
+          1.2734504160034703,
+          0.9579590420034947,
+          1.7040523329997086,
+          2.4146079999991343,
+          0.7444077079999261,
+          2.147584582999116,
+          1.8018520420009736,
+          0.43014495899842586,
+          0.3900236660047085,
+          0.4033835000009276,
+          1.2873853749988484,
+          0.5807214170054067,
+          0.5866758340052911,
+          0.42062020899902564,
+          0.657029166999564,
+          1.4600514160047169,
+          0.9175232499983395,
+          3.7755427500014775,
+          2.2247067500065896,
+          0.8008953329990618,
+          2.464140624993888,
+          3.2319100000022445,
+          3.814959125003952,
+          0.357758082995133,
+          0.3283785839958,
+          2.6948829159955494,
+          1.5338809579989174
+         ]
+        }
+       ],
+       "layout": {
+        "colorway": [
+         "rgb(0,0,255)",
+         "rgb(255,0,0)"
+        ],
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Time to first token vs number of clients"
+        },
+        "xaxis": {
+         "tickformat": "s",
+         "title": {
+          "text": "Number of clients"
+         },
+         "type": "log"
+        },
+        "yaxis": {
+         "tickformat": ".2s",
+         "title": {
+          "text": "Time to first token (s)"
+         },
+         "type": "log"
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "name": "time-bound-load-test",
+         "type": "box",
+         "x": [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          3,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          5,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10,
+          10
+         ],
+         "y": [
+          2.026969166996423,
+          1.4105780000027153,
+          7.017155499997898,
+          3.8645369169971673,
+          0.8202292089990806,
+          0.657336791002308,
+          1.9274062499971478,
+          1.5236599999989267,
+          1.6036553750018356,
+          2.048463749997609,
+          1.3640452499967068,
+          4.816340499994112,
+          4.1498347079977975,
+          0.8604247920011403,
+          4.527456333998998,
+          4.830777458999364,
+          4.042134957999224,
+          0.8596613339977921,
+          1.505671082995832,
+          1.8728053750019171,
+          1.2073444169946015,
+          1.3267667499967501,
+          2.007788625000103,
+          0.8214762089992291,
+          1.457438582998293,
+          1.9353756669952418,
+          1.7568827079958282,
+          2.1657332090035197,
+          2.5171536249981727,
+          2.4936623750036233,
+          1.8358565419985098,
+          2.5352387500024633,
+          4.18328370800009,
+          2.1444086660048924,
+          4.2379080839964445,
+          1.5257862919970648,
+          3.2496527500043157,
+          7.227931708999677,
+          2.9760203749974607,
+          2.6227675410045777,
+          1.3151865409963648,
+          2.4453202499935287,
+          1.117245624998759,
+          1.9994487080039107,
+          1.5960046249965671,
+          2.0353990830044495,
+          4.6709048750053626,
+          1.9501907090016175,
+          5.925759499994456,
+          2.86150141699909,
+          1.250162124997587,
+          1.0117991250008345,
+          2.1457077500017476,
+          4.487846791998891,
+          4.524017457995797,
+          4.866551667000749,
+          5.196730249997927,
+          1.3659177080044174,
+          0.9260156250020373,
+          1.3981401669952902,
+          1.0464315839999472,
+          2.078450959001202,
+          1.0507028339998215,
+          1.6905905000021448,
+          2.6238793749944307,
+          3.485501415998442,
+          4.309456792005221,
+          4.642852416000096,
+          0.7529281669994816,
+          2.353995790996123,
+          3.662087040996994,
+          2.490439165994758,
+          3.0507285830026376,
+          2.388044457999058,
+          3.0282242910034256,
+          2.1366724999970756,
+          1.6564010420042905,
+          2.1372902919974877,
+          3.2651202920023934,
+          1.7618697919970145,
+          1.643917583001894,
+          1.6312250420014607,
+          2.149333665998711,
+          2.428906665998511,
+          1.8692639999935636,
+          2.433882334000373,
+          2.4431621249968885,
+          0.8310220839994145,
+          1.045902957994258,
+          0.8828566669981228,
+          1.8837196250024135,
+          2.982938708999427,
+          3.969376375003776,
+          1.741798708004353,
+          2.9292802909985767,
+          3.2932393750015763,
+          1.406095334001293,
+          2.6276067910002894,
+          3.2220796670007985,
+          2.1393764579988783,
+          3.168885292005143,
+          4.014242750003177,
+          3.173061375004181,
+          2.579963874995883,
+          2.9128747079957975,
+          3.0359742090004147,
+          2.6948128750009346,
+          2.075248291999742,
+          2.100795999998809,
+          2.645283375000872,
+          2.2994953749948763,
+          1.601715790995513,
+          3.14368887499586,
+          2.526538416997937,
+          2.6472249580037897,
+          3.0995452499992098,
+          3.2772074999957113,
+          0.9971983330033254,
+          4.181597540999064,
+          4.221945541998139,
+          4.342931500003033,
+          1.8289941659968463,
+          1.223867082997458,
+          4.93074450000131,
+          5.136637708004855,
+          3.013893208000809,
+          5.778089958999772,
+          1.426899541002058,
+          0.9363519999969867,
+          2.89067904100375,
+          2.944057749999047,
+          3.721774457997526,
+          4.210495624996838,
+          3.5966603749984642,
+          4.719359624999925,
+          5.110498792004364,
+          2.620230332999199,
+          1.5105535420007072,
+          3.440597250002611,
+          2.618421290993865,
+          0.7280902089987649,
+          5.12706341699959,
+          3.5233514999999898,
+          2.377603459004604,
+          1.6091642499959562,
+          4.864977290999377,
+          3.42581183299626,
+          2.015671209002903,
+          2.5336824169935426,
+          3.3301199580018874,
+          1.6080059169980814,
+          4.445332292001694,
+          1.1371099159950973,
+          3.4345513340012985,
+          2.176926625004853,
+          1.318248791998485,
+          1.8371326659980696,
+          3.397253916999034,
+          6.461382583001978,
+          2.2144158330047503,
+          0.9335729590020492,
+          5.486439041997073,
+          3.0541425420015003,
+          1.6030845409986796,
+          4.258436707998044,
+          1.996725625002,
+          2.5789501250037574,
+          0.794825207995018,
+          2.5077784169989172,
+          4.381451000001107,
+          0.7341202500028885,
+          0.526786832997459,
+          3.1630495419958606,
+          3.0988521670005866,
+          1.6619982920019538,
+          3.71616087500297,
+          3.8252187089965446,
+          2.4751521250000224,
+          5.006649583003309,
+          1.3394295000034617,
+          3.611661916002049,
+          4.377064042004349,
+          3.840444875000685,
+          1.659149917002651,
+          2.832853415995487,
+          0.6458929590007756,
+          3.5052734589989996,
+          5.6474424170010025,
+          0.8091522090035141,
+          0.9284407500017551,
+          6.816903582999657,
+          3.9716163330012932,
+          1.5373788330034586,
+          2.054647875003866,
+          3.2553307080015657,
+          5.010804708996147,
+          3.646031333002611,
+          3.5746835000027204,
+          4.229959917000087,
+          1.9007484999965527,
+          0.7102053330017952,
+          2.6844349579987465,
+          3.390159291004238,
+          1.8455996250049793,
+          1.423415750003187,
+          2.3246775419975165,
+          1.438939500003471,
+          3.1382235830024,
+          2.365440415997,
+          4.739204375000554,
+          4.722318541003915,
+          1.851873166000587,
+          4.211808124993695,
+          3.862824666000961,
+          3.8172453340012,
+          2.785455874996842,
+          2.5279075840007863,
+          4.43163616599486,
+          3.2573652919963934
+         ]
+        }
+       ],
+       "layout": {
+        "colorway": [
+         "#30123b",
+         "#4145ab",
+         "#4675ed",
+         "#39a2fc",
+         "#1bcfd4",
+         "#24eca6",
+         "#61fc6c",
+         "#a4fc3b",
+         "#d1e834",
+         "#f3c63a",
+         "#fe9b2d",
+         "#f36315",
+         "#d93806",
+         "#b11901",
+         "#7a0402"
+        ],
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Time to last token vs number of clients"
+        },
+        "xaxis": {
+         "tickformat": "s",
+         "title": {
+          "text": "Number of clients"
+         },
+         "type": "log"
+        },
+        "yaxis": {
+         "tickformat": ".2s",
+         "title": {
+          "text": "Time to last token (s)"
+         },
+         "type": "log"
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "line": {
+          "dash": "dot"
+         },
+         "mode": "lines+markers",
+         "name": "time-bound-load-test",
+         "opacity": 0.5,
+         "type": "scatter",
+         "x": [
+          1,
+          3,
+          5,
+          10
+         ],
+         "y": [
+          23.435395092386933,
+          68.4096394213185,
+          118.005947056227,
+          196.19625184901724
+         ]
+        }
+       ],
+       "layout": {
+        "colorway": [
+         "rgb(124, 29, 111)",
+         "rgb(185, 37, 122)",
+         "rgb(220, 57, 119)",
+         "rgb(227, 79, 111)",
+         "rgb(240, 116, 110)",
+         "rgb(250, 164, 118)",
+         "rgb(252, 222, 156)"
+        ],
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Requests per minute vs number of clients"
+        },
+        "xaxis": {
+         "title": {
+          "text": "Number of clients"
+         },
+         "type": "log"
+        },
+        "yaxis": {
+         "tickformat": ".2s",
+         "title": {
+          "text": "Requests per minute"
+         },
+         "type": "log"
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "line": {
+          "dash": "dot"
+         },
+         "mode": "lines+markers",
+         "name": "time-bound-load-test",
+         "opacity": 0.5,
+         "type": "scatter",
+         "x": [
+          1,
+          3,
+          5,
+          10
+         ],
+         "y": [
+          0,
+          0,
+          0,
+          0
+         ]
+        }
+       ],
+       "layout": {
+        "colorway": [
+         "rgb(0,0,0)",
+         "rgb(230,0,0)",
+         "rgb(230,210,0)",
+         "rgb(255,255,255)",
+         "rgb(160,200,255)"
+        ],
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Error rate vs number of clients"
+        },
+        "xaxis": {
+         "title": {
+          "text": "Number of clients"
+         },
+         "type": "log"
+        },
+        "yaxis": {
+         "title": {
+          "text": "Error rate"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "line": {
+          "dash": "dot"
+         },
+         "mode": "lines+markers",
+         "name": "time-bound-load-test",
+         "opacity": 0.5,
+         "type": "scatter",
+         "x": [
+          1,
+          3,
+          5,
+          10
+         ],
+         "y": [
+          1804.5254221137939,
+          5267.542235441524,
+          9086.457923329479,
+          15107.111392374327
+         ]
+        }
+       ],
+       "layout": {
+        "colorway": [
+         "#440154",
+         "#482878",
+         "#3e4989",
+         "#31688e",
+         "#26828e",
+         "#1f9e89",
+         "#35b779",
+         "#6ece58",
+         "#b5de2b",
+         "#fde725"
+        ],
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Average input tokens per minute vs number of clients"
+        },
+        "xaxis": {
+         "tickformat": ".2s",
+         "title": {
+          "text": "Number of clients"
+         },
+         "type": "log"
+        },
+        "yaxis": {
+         "tickformat": ".2s",
+         "title": {
+          "text": "Average input tokens per minute"
+         },
+         "type": "log"
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "line": {
+          "dash": "dot"
+         },
+         "mode": "lines+markers",
+         "name": "time-bound-load-test",
+         "opacity": 0.5,
+         "type": "scatter",
+         "x": [
+          1,
+          3,
+          5,
+          10
+         ],
+         "y": [
+          3138.5402196804343,
+          9390.609692456126,
+          15754.73048714167,
+          26429.11585049167
+         ]
+        }
+       ],
+       "layout": {
+        "colorway": [
+         "#0d0887",
+         "#46039f",
+         "#7201a8",
+         "#9c179e",
+         "#bd3786",
+         "#d8576b",
+         "#ed7953",
+         "#fb9f3a",
+         "#fdca26",
+         "#f0f921"
+        ],
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Average output tokens per minute vs number of clients"
+        },
+        "xaxis": {
+         "tickformat": ".2s",
+         "title": {
+          "text": "Number of clients"
+         },
+         "type": "log"
+        },
+        "yaxis": {
+         "tickformat": ".2s",
+         "title": {
+          "text": "Average output tokens per minute"
+         },
+         "type": "log"
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "figs = load_test_result.plot_results(show=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Custom charts: TPS and RPM vs clients\n",
+    "\n",
+    "We can also build custom charts from the results. Here we plot the median output\n",
+    "tokens per second (TPS) and requests per minute (RPM) as a function of concurrency."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "mode": "lines+markers",
+         "name": "RPM",
+         "type": "scatter",
+         "x": [
+          1,
+          3,
+          5,
+          10
+         ],
+         "xaxis": "x",
+         "y": [
+          23.435395092386933,
+          68.4096394213185,
+          118.005947056227,
+          196.19625184901724
+         ],
+         "yaxis": "y"
+        },
+        {
+         "mode": "lines+markers",
+         "name": "TPS (p50)",
+         "type": "scatter",
+         "x": [
+          1,
+          3,
+          5,
+          10
+         ],
+         "xaxis": "x2",
+         "y": [
+          184.62017143187063,
+          113.63997467108105,
+          114.90946886186481,
+          102.97720864610096
+         ],
+         "yaxis": "y2"
+        }
+       ],
+       "layout": {
+        "annotations": [
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "Requests per Minute vs Clients",
+          "x": 0.225,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 1,
+          "yanchor": "bottom",
+          "yref": "paper"
+         },
+         {
+          "font": {
+           "size": 16
+          },
+          "showarrow": false,
+          "text": "Median Output Tokens/s vs Clients",
+          "x": 0.775,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 1,
+          "yanchor": "bottom",
+          "yref": "paper"
+         }
+        ],
+        "height": 400,
+        "showlegend": false,
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0,
+          0.45
+         ],
+         "title": {
+          "text": "Clients"
+         },
+         "type": "log"
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "domain": [
+          0.55,
+          1
+         ],
+         "title": {
+          "text": "Clients"
+         },
+         "type": "log"
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0,
+          1
+         ],
+         "title": {
+          "text": "RPM"
+         }
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "domain": [
+          0,
+          1
+         ],
+         "title": {
+          "text": "Tokens/s"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import plotly.graph_objects as go\n",
+    "from plotly.subplots import make_subplots\n",
+    "\n",
+    "clients_sorted = sorted(load_test_result.results.keys())\n",
+    "rpms = [load_test_result.results[c].stats[\"requests_per_minute\"] for c in clients_sorted]\n",
+    "\n",
+    "# Compute median TPS (1 / p50 time_per_output_token) for each concurrency level\n",
+    "tps_values = []\n",
+    "for c in clients_sorted:\n",
+    "    tpot_p50 = load_test_result.results[c].stats.get(\"time_per_output_token-p50\")\n",
+    "    tps_values.append(1.0 / tpot_p50 if tpot_p50 and tpot_p50 > 0 else None)\n",
+    "\n",
+    "fig = make_subplots(\n",
+    "    rows=1, cols=2,\n",
+    "    subplot_titles=(\"Requests per Minute vs Clients\", \"Median Output Tokens/s vs Clients\"),\n",
+    ")\n",
+    "\n",
+    "fig.add_trace(\n",
+    "    go.Scatter(x=clients_sorted, y=rpms, mode=\"lines+markers\", name=\"RPM\"),\n",
+    "    row=1, col=1,\n",
+    ")\n",
+    "fig.add_trace(\n",
+    "    go.Scatter(x=clients_sorted, y=tps_values, mode=\"lines+markers\", name=\"TPS (p50)\"),\n",
+    "    row=1, col=2,\n",
+    ")\n",
+    "\n",
+    "fig.update_xaxes(title_text=\"Clients\", type=\"log\")\n",
+    "fig.update_yaxes(title_text=\"RPM\", row=1, col=1)\n",
+    "fig.update_yaxes(title_text=\"Tokens/s\", row=1, col=2)\n",
+    "fig.update_layout(height=400, showlegend=False)\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "name": "1 clients",
+         "type": "box",
+         "x": [
+          1.810565542000404,
+          1.1812222500011558,
+          3.868108458002098,
+          0.7137894999978016,
+          0.5251540839963127,
+          0.37060487500275485,
+          0.44968758300092304,
+          0.3802408749979804,
+          1.2211427910006023,
+          1.4571087089934736,
+          0.589481999995769,
+          2.097318999993149,
+          1.0713617910005269
+         ]
+        },
+        {
+         "name": "3 clients",
+         "type": "box",
+         "x": [
+          0.33201908400224056,
+          0.7742456669948297,
+          2.397023541998351,
+          1.8993818329981877,
+          0.42726020899863215,
+          1.4716677499964135,
+          0.46759149999707006,
+          0.8862732499983395,
+          0.3939086249956745,
+          1.0275854999999865,
+          0.7189318340024329,
+          1.4116186659957748,
+          0.7474134169970057,
+          0.40672895799798425,
+          0.42657495900493814,
+          1.2491307079981198,
+          0.36702779099869076,
+          0.7880193340024562,
+          1.8055343329979223,
+          2.310052083004848,
+          1.7829697910055984,
+          2.0935321249999106,
+          1.3090343329968164,
+          0.7112003330039443,
+          4.315548667000257,
+          0.8603567079990171,
+          1.7188770830034628,
+          0.8016122080007335,
+          0.7778300419959123,
+          0.4183118330038269,
+          1.3940931660035858,
+          1.555591791999177,
+          1.9584035000007134,
+          0.697202000003017,
+          0.5803299999970477,
+          3.9468323339970084,
+          0.9757721249989117
+         ]
+        },
+        {
+         "name": "5 clients",
+         "type": "box",
+         "x": [
+          1.002142333003576,
+          0.9818431249950663,
+          2.109215791999304,
+          2.854000667000946,
+          1.1883622079985798,
+          2.397148707997985,
+          2.0537721249929746,
+          1.2194084170041606,
+          0.55904924999777,
+          1.0641959169952315,
+          0.3820479999994859,
+          1.1137916250008857,
+          0.3648492919965065,
+          1.4079380000039237,
+          1.1204503329936415,
+          0.7068704999983311,
+          1.5245771670015529,
+          2.0880037499955506,
+          0.34228199999779463,
+          2.0938974159944337,
+          1.313775374997931,
+          0.9155073329966399,
+          1.178452667001693,
+          0.8153431250029826,
+          0.7699036249978235,
+          0.47562379100418184,
+          0.455455625000468,
+          1.1047283329971833,
+          1.333313959003135,
+          0.9293282919970807,
+          1.2738797499987413,
+          1.299013833006029,
+          0.3571828749991255,
+          0.48103974999685306,
+          0.4824907499933033,
+          2.367823166998278,
+          2.344774500001222,
+          0.42162933399959,
+          0.5273924579960294,
+          0.4980682919995161,
+          0.8799479170047562,
+          1.7304949169993051,
+          1.6569751249990077,
+          1.7166576250019716,
+          1.280893458002538,
+          2.347654417004378,
+          1.1621644590049982,
+          1.2532084999984363,
+          2.9941925419989275,
+          2.0151528749993304,
+          1.181208833004348,
+          2.2984159589977935,
+          1.2298334160004742,
+          1.418954875000054,
+          1.82515254199825,
+          1.2331472500009113,
+          0.87708987500082,
+          0.50351466700522,
+          1.607961791996786,
+          0.7267654579991358,
+          0.5518672089965548,
+          0.7452832909984863,
+          1.8045194169972092
+         ]
+        },
+        {
+         "name": "10 clients",
+         "type": "box",
+         "x": [
+          1.7789633329957724,
+          2.605166624998674,
+          3.056866250000894,
+          1.6265989160019672,
+          0.5625950419998844,
+          4.143405791000987,
+          4.180461500000092,
+          3.5610989999986487,
+          0.5881356660029269,
+          0.9779006249955273,
+          3.690586582997639,
+          4.832465791005234,
+          0.6448706250012037,
+          4.863131999998586,
+          1.382325790997129,
+          0.4846024590005982,
+          2.2435131250022096,
+          1.5739306670002406,
+          2.255111082995427,
+          3.899700750000193,
+          1.4509044169972185,
+          1.2176708330007386,
+          2.9069163750027656,
+          2.5278627079969738,
+          0.40958595799747854,
+          1.1879090829970664,
+          0.6117010829984793,
+          0.6858485839984496,
+          2.8986509589958587,
+          1.788087708002422,
+          2.269181875002687,
+          0.9895395829953486,
+          2.5265816250030184,
+          2.149016749994189,
+          0.7873067089967662,
+          1.8220124579966068,
+          2.769100500001514,
+          0.5327938330010511,
+          3.213817707997805,
+          0.3640439999944647,
+          1.7442852500025765,
+          0.39150920799875166,
+          1.3132492920049117,
+          0.5267627499997616,
+          0.6975128749982105,
+          5.765499125001952,
+          0.6618302920032875,
+          0.531012917002954,
+          2.8477291669987608,
+          1.1358064590021968,
+          0.3917771249980433,
+          1.7981745829965803,
+          1.4685571670052013,
+          0.5237741250020918,
+          0.44857070799480425,
+          2.0674697080030455,
+          2.1612447919978877,
+          0.36861462500382913,
+          0.3830527499958407,
+          2.0479602080013137,
+          1.5750675000017509,
+          0.4111657500034198,
+          2.939957292001054,
+          2.9568471250022412,
+          0.37112295900442405,
+          3.418946000005235,
+          0.3710014160024002,
+          0.32679066600394435,
+          2.0638363340040087,
+          1.0570221669986495,
+          0.6728937090010731,
+          1.0676320409984328,
+          0.3201369589951355,
+          1.3715982919966336,
+          2.2774177090032026,
+          0.39108320900413673,
+          0.41870475000177976,
+          3.82099775000097,
+          1.9569717920021503,
+          1.2734504160034703,
+          0.9579590420034947,
+          1.7040523329997086,
+          2.4146079999991343,
+          0.7444077079999261,
+          2.147584582999116,
+          1.8018520420009736,
+          0.43014495899842586,
+          0.3900236660047085,
+          0.4033835000009276,
+          1.2873853749988484,
+          0.5807214170054067,
+          0.5866758340052911,
+          0.42062020899902564,
+          0.657029166999564,
+          1.4600514160047169,
+          0.9175232499983395,
+          3.7755427500014775,
+          2.2247067500065896,
+          0.8008953329990618,
+          2.464140624993888,
+          3.2319100000022445,
+          3.814959125003952,
+          0.357758082995133,
+          0.3283785839958,
+          2.6948829159955494,
+          1.5338809579989174
+         ]
+        }
+       ],
+       "layout": {
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Time to First Token by Client Count"
+        },
+        "xaxis": {
+         "title": {
+          "text": "Time to First Token (s)"
+         },
+         "type": "log"
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from llmeter.plotting import boxplot_by_dimension\n",
+    "\n",
+    "fig = go.Figure(layout=dict(title=\"Time to First Token by Client Count\"))\n",
+    "for n_clients in clients_sorted:\n",
+    "    fig.add_trace(\n",
+    "        boxplot_by_dimension(\n",
+    "            load_test_result.results[n_clients],\n",
+    "            dimension=\"time_to_first_token\",\n",
+    "            name=f\"{n_clients} clients\",\n",
+    "        )\n",
+    "    )\n",
+    "fig.update_xaxes(type=\"log\", title=\"Time to First Token (s)\")\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "name": "1 clients",
+         "type": "box",
+         "x": [
+          2.026969166996423,
+          1.4105780000027153,
+          7.017155499997898,
+          3.8645369169971673,
+          0.8202292089990806,
+          0.657336791002308,
+          1.9274062499971478,
+          1.5236599999989267,
+          1.6036553750018356,
+          2.048463749997609,
+          1.3640452499967068,
+          4.816340499994112,
+          4.1498347079977975
+         ]
+        },
+        {
+         "name": "3 clients",
+         "type": "box",
+         "x": [
+          0.8604247920011403,
+          4.527456333998998,
+          4.830777458999364,
+          4.042134957999224,
+          0.8596613339977921,
+          1.505671082995832,
+          1.8728053750019171,
+          1.2073444169946015,
+          1.3267667499967501,
+          2.007788625000103,
+          0.8214762089992291,
+          1.457438582998293,
+          1.9353756669952418,
+          1.7568827079958282,
+          2.1657332090035197,
+          2.5171536249981727,
+          2.4936623750036233,
+          1.8358565419985098,
+          2.5352387500024633,
+          4.18328370800009,
+          2.1444086660048924,
+          4.2379080839964445,
+          1.5257862919970648,
+          3.2496527500043157,
+          7.227931708999677,
+          2.9760203749974607,
+          2.6227675410045777,
+          1.3151865409963648,
+          2.4453202499935287,
+          1.117245624998759,
+          1.9994487080039107,
+          1.5960046249965671,
+          2.0353990830044495,
+          4.6709048750053626,
+          1.9501907090016175,
+          5.925759499994456,
+          2.86150141699909
+         ]
+        },
+        {
+         "name": "5 clients",
+         "type": "box",
+         "x": [
+          1.250162124997587,
+          1.0117991250008345,
+          2.1457077500017476,
+          4.487846791998891,
+          4.524017457995797,
+          4.866551667000749,
+          5.196730249997927,
+          1.3659177080044174,
+          0.9260156250020373,
+          1.3981401669952902,
+          1.0464315839999472,
+          2.078450959001202,
+          1.0507028339998215,
+          1.6905905000021448,
+          2.6238793749944307,
+          3.485501415998442,
+          4.309456792005221,
+          4.642852416000096,
+          0.7529281669994816,
+          2.353995790996123,
+          3.662087040996994,
+          2.490439165994758,
+          3.0507285830026376,
+          2.388044457999058,
+          3.0282242910034256,
+          2.1366724999970756,
+          1.6564010420042905,
+          2.1372902919974877,
+          3.2651202920023934,
+          1.7618697919970145,
+          1.643917583001894,
+          1.6312250420014607,
+          2.149333665998711,
+          2.428906665998511,
+          1.8692639999935636,
+          2.433882334000373,
+          2.4431621249968885,
+          0.8310220839994145,
+          1.045902957994258,
+          0.8828566669981228,
+          1.8837196250024135,
+          2.982938708999427,
+          3.969376375003776,
+          1.741798708004353,
+          2.9292802909985767,
+          3.2932393750015763,
+          1.406095334001293,
+          2.6276067910002894,
+          3.2220796670007985,
+          2.1393764579988783,
+          3.168885292005143,
+          4.014242750003177,
+          3.173061375004181,
+          2.579963874995883,
+          2.9128747079957975,
+          3.0359742090004147,
+          2.6948128750009346,
+          2.075248291999742,
+          2.100795999998809,
+          2.645283375000872,
+          2.2994953749948763,
+          1.601715790995513,
+          3.14368887499586
+         ]
+        },
+        {
+         "name": "10 clients",
+         "type": "box",
+         "x": [
+          2.526538416997937,
+          2.6472249580037897,
+          3.0995452499992098,
+          3.2772074999957113,
+          0.9971983330033254,
+          4.181597540999064,
+          4.221945541998139,
+          4.342931500003033,
+          1.8289941659968463,
+          1.223867082997458,
+          4.93074450000131,
+          5.136637708004855,
+          3.013893208000809,
+          5.778089958999772,
+          1.426899541002058,
+          0.9363519999969867,
+          2.89067904100375,
+          2.944057749999047,
+          3.721774457997526,
+          4.210495624996838,
+          3.5966603749984642,
+          4.719359624999925,
+          5.110498792004364,
+          2.620230332999199,
+          1.5105535420007072,
+          3.440597250002611,
+          2.618421290993865,
+          0.7280902089987649,
+          5.12706341699959,
+          3.5233514999999898,
+          2.377603459004604,
+          1.6091642499959562,
+          4.864977290999377,
+          3.42581183299626,
+          2.015671209002903,
+          2.5336824169935426,
+          3.3301199580018874,
+          1.6080059169980814,
+          4.445332292001694,
+          1.1371099159950973,
+          3.4345513340012985,
+          2.176926625004853,
+          1.318248791998485,
+          1.8371326659980696,
+          3.397253916999034,
+          6.461382583001978,
+          2.2144158330047503,
+          0.9335729590020492,
+          5.486439041997073,
+          3.0541425420015003,
+          1.6030845409986796,
+          4.258436707998044,
+          1.996725625002,
+          2.5789501250037574,
+          0.794825207995018,
+          2.5077784169989172,
+          4.381451000001107,
+          0.7341202500028885,
+          0.526786832997459,
+          3.1630495419958606,
+          3.0988521670005866,
+          1.6619982920019538,
+          3.71616087500297,
+          3.8252187089965446,
+          2.4751521250000224,
+          5.006649583003309,
+          1.3394295000034617,
+          3.611661916002049,
+          4.377064042004349,
+          3.840444875000685,
+          1.659149917002651,
+          2.832853415995487,
+          0.6458929590007756,
+          3.5052734589989996,
+          5.6474424170010025,
+          0.8091522090035141,
+          0.9284407500017551,
+          6.816903582999657,
+          3.9716163330012932,
+          1.5373788330034586,
+          2.054647875003866,
+          3.2553307080015657,
+          5.010804708996147,
+          3.646031333002611,
+          3.5746835000027204,
+          4.229959917000087,
+          1.9007484999965527,
+          0.7102053330017952,
+          2.6844349579987465,
+          3.390159291004238,
+          1.8455996250049793,
+          1.423415750003187,
+          2.3246775419975165,
+          1.438939500003471,
+          3.1382235830024,
+          2.365440415997,
+          4.739204375000554,
+          4.722318541003915,
+          1.851873166000587,
+          4.211808124993695,
+          3.862824666000961,
+          3.8172453340012,
+          2.785455874996842,
+          2.5279075840007863,
+          4.43163616599486,
+          3.2573652919963934
+         ]
+        }
+       ],
+       "layout": {
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Time to Last Token by Client Count"
+        },
+        "xaxis": {
+         "title": {
+          "text": "Time to Last Token (s)"
+         },
+         "type": "log"
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig = go.Figure(layout=dict(title=\"Time to Last Token by Client Count\"))\n",
+    "for n_clients in clients_sorted:\n",
+    "    fig.add_trace(\n",
+    "        boxplot_by_dimension(\n",
+    "            load_test_result.results[n_clients],\n",
+    "            dimension=\"time_to_last_token\",\n",
+    "            name=f\"{n_clients} clients\",\n",
+    "        )\n",
+    "    )\n",
+    "fig.update_xaxes(type=\"log\", title=\"Time to Last Token (s)\")\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "| Feature | Parameter | Description |\n",
+    "|---|---|---|\n",
+    "| Time-bound runs | `run_duration=60` | Run for a fixed number of seconds instead of a fixed request count |\n",
+    "| Count-bound runs | `n_requests=100` | Traditional mode — fixed number of requests per client |\n",
+    "| Live stats | `progress_bar_stats={...}` | Customize which metrics appear on the progress bar |\n",
+    "| Low-memory mode | `low_memory=True` | Stream responses to disk, compute stats incrementally |"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/llmeter/callbacks/cost/dimensions.py
+++ b/llmeter/callbacks/cost/dimensions.py
@@ -12,7 +12,7 @@ use to bring customized cost dimensions for your own cost models.
 """
 
 # Python Built-Ins:
-from abc import abstractmethod, ABC
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from math import ceil
 from typing import Optional

--- a/llmeter/callbacks/cost/providers/sagemaker.py
+++ b/llmeter/callbacks/cost/providers/sagemaker.py
@@ -4,8 +4,9 @@
 
 # Python Built-Ins:
 from __future__ import annotations
-from dataclasses import dataclass
+
 import json
+from dataclasses import dataclass
 from math import ceil
 
 # External Dependencies:

--- a/llmeter/endpoints/__init__.py
+++ b/llmeter/endpoints/__init__.py
@@ -4,7 +4,7 @@
 
 import importlib.util
 
-from .base import Endpoint, InvocationResponse  # noqa: F401
+from .base import Endpoint, InvocationResponse, llmeter_invoke  # noqa: F401
 from .bedrock import BedrockConverse, BedrockConverseStream  # noqa: F401
 from .bedrock_invoke import BedrockInvoke, BedrockInvokeStream  # noqa: F401
 from .sagemaker import SageMakerEndpoint, SageMakerStreamEndpoint  # noqa: F401

--- a/llmeter/endpoints/__init__.py
+++ b/llmeter/endpoints/__init__.py
@@ -12,9 +12,9 @@ from .sagemaker import SageMakerEndpoint, SageMakerStreamEndpoint  # noqa: F401
 spec = importlib.util.find_spec("openai")
 if spec:
     from .openai import (  # noqa: F401
-        OpenAIEndpoint,
         OpenAICompletionEndpoint,
         OpenAICompletionStreamEndpoint,
+        OpenAIEndpoint,
     )
     from .openai_response import (  # noqa: F401
         OpenAIResponseEndpoint,

--- a/llmeter/endpoints/__init__.py
+++ b/llmeter/endpoints/__init__.py
@@ -4,7 +4,7 @@
 
 import importlib.util
 
-from .base import Endpoint, InvocationResponse, llmeter_invoke  # noqa: F401
+from .base import Endpoint, InvocationResponse  # noqa: F401
 from .bedrock import BedrockConverse, BedrockConverseStream  # noqa: F401
 from .bedrock_invoke import BedrockInvoke, BedrockInvokeStream  # noqa: F401
 from .sagemaker import SageMakerEndpoint, SageMakerStreamEndpoint  # noqa: F401

--- a/llmeter/endpoints/base.py
+++ b/llmeter/endpoints/base.py
@@ -9,6 +9,7 @@ payload preparation, timing, error handling, and metadata back-fill.  Apply it
 to every concrete ``invoke`` in an :class:`Endpoint` subclass.
 """
 
+import copy
 import functools
 import importlib
 import json
@@ -122,27 +123,36 @@ def llmeter_invoke(fn):
         class MyEndpoint(Endpoint):
             @llmeter_invoke
             def invoke(self, payload: dict) -> InvocationResponse:
+                start_t = time.perf_counter()
                 raw = self._client.call(**payload)
-                return self.parse_response(raw, self._start_t)
+                return self.parse_response(raw, start_t)
 
     The wrapper performs the following steps around the decorated function:
 
     1. Calls :meth:`~Endpoint.prepare_payload` to merge ``**kwargs`` and
        inject provider-specific fields.
-    2. Records ``self._start_t`` via :func:`time.perf_counter`.
-    3. Calls the inner ``invoke``.
-    4. On exception, converts it to an error :class:`InvocationResponse`.
-    5. Back-fills ``time_to_last_token``, ``input_payload``,
+    2. Calls the inner ``invoke``.
+    3. On exception, converts it to an error :class:`InvocationResponse`.
+    4. Back-fills ``time_to_last_token``, ``input_payload``,
        ``input_prompt``, ``id``, and ``request_time`` if the subclass
        didn't set them.
+
+    .. note::
+
+       The inner ``invoke`` should capture its own ``start_t`` via
+       :func:`time.perf_counter` and pass it to :meth:`parse_response`.
+       The decorator independently tracks timing for the
+       ``time_to_last_token`` back-fill.
     """
 
     @functools.wraps(fn)
     def wrapper(self: "Endpoint", payload: dict, **kw: Any) -> InvocationResponse:
         prepared = self.prepare_payload(payload, **kw)
-        self._last_payload = prepared
+        # Snapshot before the API call for _parse_payload, which runs after
+        # the inner invoke — by which point the client may have mutated the dict.
+        saved_payload = copy.deepcopy(prepared)
         request_time = datetime.now(timezone.utc)
-        self._start_t = time.perf_counter()
+        start_t = time.perf_counter()
         try:
             response = fn(self, prepared)
         except Exception as e:
@@ -155,13 +165,13 @@ def llmeter_invoke(fn):
             )
 
         if response.time_to_last_token is None and response.error is None:
-            response.time_to_last_token = time.perf_counter() - self._start_t
+            response.time_to_last_token = time.perf_counter() - start_t
 
         if response.input_payload is None:
             response.input_payload = prepared
         if response.input_prompt is None:
             try:
-                response.input_prompt = self._parse_payload(prepared)
+                response.input_prompt = self._parse_payload(saved_payload)
             except Exception:
                 logger.debug("_parse_payload failed; leaving input_prompt as None")
         if response.id is None:
@@ -213,18 +223,18 @@ class Endpoint(ABC):
 
             @llmeter_invoke
             def invoke(self, payload: dict) -> InvocationResponse:
+                start_t = time.perf_counter()
                 raw = self._client.call(**payload)
-                return self.parse_response(raw, self._start_t)
+                return self.parse_response(raw, start_t)
 
         The :func:`llmeter_invoke` wrapper provides:
 
         * **Payload preparation** — calls :meth:`prepare_payload` before the
           inner function, so ``**kwargs`` are merged and provider-specific
           fields (``model``, ``modelId``, etc.) are set.
-        * **Timing** — ``self._start_t`` is set immediately before the call
-          and ``time_to_last_token`` is back-filled on the response if the
-          subclass didn't set it (streaming endpoints typically set it during
-          stream consumption).
+        * **Timing** — ``time_to_last_token`` is back-filled on the response
+          if the subclass didn't set it (streaming endpoints typically set it
+          during stream consumption).
         * **Error handling** — unhandled exceptions are caught, logged, and
           converted to an error :class:`InvocationResponse`.
         * **Metadata back-fill** — ``input_payload`` and ``input_prompt`` are
@@ -262,8 +272,7 @@ class Endpoint(ABC):
                 client.  The type varies by provider (e.g. ``ChatCompletion``,
                 ``dict``, a streaming iterator).
             start_t: The :func:`time.perf_counter` timestamp captured
-                immediately before the API call (also available as
-                ``self._start_t``).
+                immediately before the API call in the ``invoke`` method.
 
         Returns:
             InvocationResponse: Parsed response with at least

--- a/llmeter/endpoints/base.py
+++ b/llmeter/endpoints/base.py
@@ -16,6 +16,7 @@ import json
 import logging
 import time
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from typing import Any
@@ -113,7 +114,7 @@ class InvocationResponse:
         return asdict(self)
 
 
-def llmeter_invoke(fn):
+def llmeter_invoke(fn: Callable[..., Any]) -> Callable[..., InvocationResponse]:
     """Decorator that wraps an :meth:`Endpoint.invoke` implementation with
     payload preparation, timing, error handling, and metadata back-fill.
 
@@ -177,7 +178,9 @@ def llmeter_invoke(fn):
 
         return response
 
-    wrapper._is_llmeter_invoke = True
+    # Add a private marker to indicate that the wrapping happened:
+    # (We don't currently use this for anything except unit tests)
+    wrapper._is_llmeter_invoke = True  # type: ignore
     return wrapper
 
 

--- a/llmeter/endpoints/base.py
+++ b/llmeter/endpoints/base.py
@@ -7,6 +7,8 @@ You can also use these classes to implement your own custom `Endpoint` types.
 
 import importlib
 import json
+import logging
+import time
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
 from typing import Any
@@ -17,6 +19,8 @@ from upath.types import ReadablePathLike, WritablePathLike
 
 from ..json_utils import llmeter_default_serializer
 from ..utils import ensure_path
+
+logger = logging.getLogger(__name__)
 
 
 # @dataclass(slots=True)
@@ -32,6 +36,7 @@ class InvocationResponse:
         time_to_first_token (float): The time taken to receive the first token of the response in seconds.
         num_tokens_output (Optional[int]): The number of tokens in the response.
         num_tokens_input (Optional[int]): The number of tokens in the invocation payload.
+        num_tokens_input_cached (Optional[int]): The number of input tokens served from cache (prompt caching).
         input_prompt (str): The input prompt used in the invocation.
         time_per_output_token (float): The average time taken to generate each token in the response.
         error (str): Any error that occurred during invocation.
@@ -45,6 +50,7 @@ class InvocationResponse:
     time_to_last_token: float | None = None
     num_tokens_input: int | None = None
     num_tokens_output: int | None = None
+    num_tokens_input_cached: int | None = None
     time_per_output_token: float | None = None
     error: str | None = None
     retries: int | None = None
@@ -123,22 +129,162 @@ class Endpoint(ABC):
 
     @abstractmethod
     def invoke(self, payload: dict) -> InvocationResponse:
-        """
-        Invoke the endpoint with the given payload.
+        """Invoke the endpoint with the given payload.
 
-        This method must be implemented by subclasses to define how the endpoint
-        is invoked and how the response is processed.
+        Subclasses implement this with their provider-specific API call,
+        passing the raw response to :meth:`parse_response`.  The payload
+        received here has already been through :meth:`prepare_payload`, so
+        ``**kwargs`` have been merged and provider-specific fields
+        (``model``, ``modelId``, etc.) are set.
+
+        The base class automatically wraps every subclass implementation with:
+
+        * **Timing** — ``self._start_t`` is set immediately before the call
+          and ``time_to_last_token`` is back-filled on the response if the
+          subclass didn't set it (streaming endpoints typically set it during
+          stream consumption).
+        * **Error handling** — unhandled exceptions are caught, logged, and
+          converted to an error :class:`InvocationResponse`.
+        * **Metadata back-fill** — ``input_payload`` and ``input_prompt`` are
+          guaranteed to be set on the returned response (success or error),
+          using the prepared payload.
 
         Args:
-            payload (Dict): The input payload for the model.
+            payload: The prepared input payload for the model.
 
         Returns:
-            InvocationResponse: An object containing the model's response and associated metrics.
-
-        Raises:
-            NotImplementedError: If the method is not implemented by a subclass.
+            InvocationResponse: An object containing the model's response and
+                associated metrics.
         """
         raise NotImplementedError
+
+    @abstractmethod
+    def parse_response(self, raw_response: Any, start_t: float) -> InvocationResponse:
+        """Parse the raw API response into an :class:`InvocationResponse`.
+
+        Subclasses implement this to extract the generated text, token counts,
+        timing information, and any other provider-specific metadata from the
+        raw object returned by the API client.
+
+        This method is called from :meth:`invoke` after the API call.
+        Exceptions raised here will be caught by the base-class ``invoke``
+        wrapper and converted to an error response automatically.
+
+        Non-streaming endpoints can ignore ``start_t`` — the wrapper
+        back-fills ``time_to_last_token`` automatically.  Streaming endpoints
+        use it to compute ``time_to_first_token`` and ``time_to_last_token``
+        during stream consumption.
+
+        Args:
+            raw_response: The raw response object from the provider's API
+                client.  The type varies by provider (e.g. ``ChatCompletion``,
+                ``dict``, a streaming iterator).
+            start_t: The :func:`time.perf_counter` timestamp captured
+                immediately before the API call (also available as
+                ``self._start_t``).
+
+        Returns:
+            InvocationResponse: Parsed response with at least
+                ``response_text`` populated.
+        """
+        raise NotImplementedError
+
+    def prepare_payload(self, payload: dict, **kwargs: Any) -> dict:
+        """Prepare the payload before sending it to the API.
+
+        This method is called by the ``invoke`` wrapper before the actual
+        invocation.  Subclasses can override it to merge ``**kwargs``, inject
+        provider-specific fields (``model``, ``modelId``, streaming options,
+        etc.), or apply any other transformation.
+
+        The default implementation returns *payload* unchanged (ignoring
+        ``**kwargs``).
+
+        Args:
+            payload: The raw input payload from the caller.
+            **kwargs: Additional keyword arguments from the caller.
+
+        Returns:
+            dict: The final payload to send to the API.
+        """
+        return payload
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+
+        # Wrap the subclass invoke (if it defines one) with prepare_payload,
+        # error handling, and metadata back-fill.
+        if "invoke" not in cls.__dict__:
+            return
+
+        inner = cls.__dict__["invoke"]
+
+        if not callable(inner) or isinstance(inner, (classmethod, staticmethod)):
+            return
+
+        def invoke(self: "Endpoint", payload: dict, **kw: Any) -> InvocationResponse:
+            prepared = self.prepare_payload(payload, **kw)
+            self._last_payload = prepared
+            self._start_t = time.perf_counter()
+            try:
+                response = inner(self, prepared)
+            except Exception as e:
+                logger.exception("Endpoint invocation failed: %s", e)
+                response = InvocationResponse.error_output(
+                    input_payload=prepared,
+                    id=uuid4().hex,
+                    error=str(e),
+                )
+
+            # Back-fill time_to_last_token if the subclass didn't set it
+            # (streaming endpoints typically set it during stream consumption).
+            if response.time_to_last_token is None and response.error is None:
+                response.time_to_last_token = time.perf_counter() - self._start_t
+
+            if response.input_payload is None:
+                response.input_payload = prepared
+            if response.input_prompt is None:
+                try:
+                    response.input_prompt = self._parse_payload(prepared)
+                except Exception:
+                    logger.debug("_parse_payload failed; leaving input_prompt as None")
+            if response.id is None:
+                response.id = uuid4().hex
+
+            return response
+
+        invoke.__name__ = inner.__name__
+        invoke.__qualname__ = inner.__qualname__
+        invoke.__doc__ = inner.__doc__
+        invoke.__module__ = inner.__module__
+        cls.invoke = invoke  # type: ignore[attr-defined]
+
+    def _parse_payload(self, payload: dict) -> str | dict | None:
+        """Extract the user-facing input text from an API request payload.
+
+        The ``invoke`` wrapper calls this automatically to populate
+        :pyattr:`InvocationResponse.input_prompt`.  That field serves two
+        purposes:
+
+        * **Observability** — it records *what* was sent to the model in a
+          human-readable form, separate from the full API payload (which may
+          contain binary media, inference config, etc.).
+        * **Token counting fallback** — when the API response does not include
+          an input-token count, the :class:`~llmeter.runner.Runner` tokenizes
+          ``input_prompt`` to estimate it.
+
+        Subclasses should override this to navigate their provider-specific
+        payload structure and return the concatenated message text.  The
+        default implementation returns ``None`` (no prompt extracted).
+
+        Args:
+            payload: The prepared request payload (after :meth:`prepare_payload`).
+
+        Returns:
+            The extracted prompt text, or ``None`` if extraction is not
+            possible.
+        """
+        return None
 
     @staticmethod
     def create_payload(*args: Any, **kwargs: Any) -> Any:

--- a/llmeter/endpoints/base.py
+++ b/llmeter/endpoints/base.py
@@ -2,11 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Base classes used across the different LLM endpoint types offered by LLMeter
 
-You can also use these classes to implement your own custom `Endpoint` types.
-
-The :func:`llmeter_invoke` decorator wraps a concrete ``invoke`` method with
-payload preparation, timing, error handling, and metadata back-fill.  Apply it
-to every concrete ``invoke`` in an :class:`Endpoint` subclass.
+You can also use these classes to implement your own custom `Endpoint` integrations.
 """
 
 import copy
@@ -19,7 +15,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Generic, TypeVar
 from uuid import uuid4
 
 from upath import UPath as Path
@@ -44,11 +40,11 @@ class InvocationResponse:
         time_to_first_token (float): The time taken to receive the first token of the response in seconds.
         num_tokens_output (Optional[int]): The number of tokens in the response.
         num_tokens_input (Optional[int]): The number of tokens in the invocation payload.
-        num_tokens_input_cached (Optional[int]): The number of input tokens served from cache (prompt caching).
+        num_tokens_input_cached: The number of input tokens served from cache (prompt caching).
         input_prompt (str): The input prompt used in the invocation.
         time_per_output_token (float): The average time taken to generate each token in the response.
         error (str): Any error that occurred during invocation.
-        request_time (datetime): The wall-clock time when the request was sent.
+        request_time: The wall-clock time when the request was sent.
     """
 
     response_text: str | None
@@ -114,83 +110,131 @@ class InvocationResponse:
         return asdict(self)
 
 
-def llmeter_invoke(fn: Callable[..., Any]) -> Callable[..., InvocationResponse]:
-    """Decorator that wraps an :meth:`Endpoint.invoke` implementation with
-    payload preparation, timing, error handling, and metadata back-fill.
-
-    Apply this to every concrete ``invoke`` method in an :class:`Endpoint`
-    subclass::
-
-        class MyEndpoint(Endpoint):
-            @llmeter_invoke
-            def invoke(self, payload: dict) -> Any:
-                return self._client.call(**payload)
-
-    The wrapper performs the following steps around the decorated function:
-
-    1. Calls :meth:`~Endpoint.prepare_payload` to merge ``**kwargs`` and
-       inject provider-specific fields.
-    2. Captures ``start_t`` via :func:`time.perf_counter`.
-    3. Calls the inner ``invoke`` which returns the raw API response.
-    4. Calls :meth:`~Endpoint.parse_response` with the raw response and
-       ``start_t``.
-    5. On exception (from either step 3 or 4), converts it to an error
-       :class:`InvocationResponse`.
-    6. Back-fills ``time_to_last_token``, ``input_payload``,
-       ``input_prompt``, ``id``, and ``request_time`` if the subclass
-       didn't set them.
-    """
-
-    @functools.wraps(fn)
-    def wrapper(self: "Endpoint", payload: dict, **kw: Any) -> InvocationResponse:
-        prepared = self.prepare_payload(payload, **kw)
-        # Snapshot before the API call for _parse_payload, which runs after
-        # the inner invoke — by which point the client may have mutated the dict.
-        saved_payload = copy.deepcopy(prepared)
-        request_time = datetime.now(timezone.utc)
-        start_t = time.perf_counter()
-        try:
-            raw_response = fn(self, prepared)
-            response = self.parse_response(raw_response, start_t)
-        except Exception as e:
-            logger.exception("Endpoint invocation failed: %s", e)
-            response = InvocationResponse.error_output(
-                input_payload=prepared,
-                id=uuid4().hex,
-                error=str(e),
-                request_time=request_time,
-            )
-
-        if response.time_to_last_token is None and response.error is None:
-            response.time_to_last_token = time.perf_counter() - start_t
-
-        if response.input_payload is None:
-            response.input_payload = prepared
-        if response.input_prompt is None:
-            try:
-                response.input_prompt = self._parse_payload(saved_payload)
-            except Exception:
-                logger.debug("_parse_payload failed; leaving input_prompt as None")
-        if response.id is None:
-            response.id = uuid4().hex
-        if response.request_time is None:
-            response.request_time = request_time
-
-        return response
-
-    # Add a private marker to indicate that the wrapping happened:
-    # (We don't currently use this for anything except unit tests)
-    wrapper._is_llmeter_invoke = True  # type: ignore
-    return wrapper
+TRawResponse = TypeVar("TRawResponse", bound=Any)
 
 
-class Endpoint(ABC):
+class Endpoint(ABC, Generic[TRawResponse]):
     """
     An abstract base class for endpoint implementations.
 
-    This class defines the basic structure and interface for all endpoint classes.
-    It provides abstract methods that must be implemented by subclasses.
+    We strongly recommend using the
+    [`llmeter_invoke`][llmeter.endpoints.base.Endpoint.llmeter_invoke] decorator to implement
+    custom endpoints as shown below - which wraps payload pre-processing, response parsing, and
+    error handling around a core invoke function you provide.
+
+    Example:
+        ```python
+        class MyCustomEndpoint(Endpoint[MyAISDKRawReturnType]):
+            @Endpoint.llmeter_invoke
+            def invoke(self, payload: dict) -> MyAISDKRawReturnType:
+                # Just the raw AI / SDK call goes here:
+                raw: MyAISDKRawReturnType = self._my_cool_api_client.call(**payload)
+                return raw
+
+            def process_raw_response(
+                self,
+                raw_response: MyAISDKRawReturnType,
+                start_t: float,
+                response: InvocationResponse
+            ):
+                # llmeter_invoke wrapper automatically calls process_raw_response,
+                # in which you should parse the outputs onto `response`
+                response.id = raw_response["ResponseId"]
+                ...
+        ```
+
+    See [`llmeter_invoke`][llmeter.endpoints.base.Endpoint.llmeter_invoke] and
+    [`process_raw_response`][llmeter.endpoints.base.Endpoint.process_raw_response]for more info.
+
+    You can also implement:
+
+    - [`create_payload`][llmeter.endpoints.base.Endpoint.create_payload] convenience method to
+        simplify building payload objects for your endpoint - for example converting a simple input
+        prompt to a full request object with other required parameters.
+    - [`prepare_payload`][llmeter.endpoints.base.Endpoint.prepare_payload] in case you need to do
+        any request payload pre-processing **outside** the timer that measures response speed
     """
+
+    @classmethod
+    def llmeter_invoke(
+        cls,
+        call_endpoint: Callable[..., TRawResponse],
+    ) -> Callable[..., InvocationResponse]:
+        """Wrap a raw model API call with pre+postprocessing and error handling
+
+        This decorator wraps around a function that *only* does the core model call, to add the
+        full range of steps that LLMeter Endpoints are expected to handle as part of `invoke`:
+
+        1. **Before** starting the response timer, calls your class'
+            [`prepare_payload`](llmeter.endpoints.base.Endpoint.prepare_payload) method to
+            transform the input payload, if required
+        2. Initialises an [`InvocationResponse`](llmeter.endpoints.base.InvocationResponse) with
+            the timestamp of the request.
+        3. Calls the wrapped function to fetch the raw API response
+        4. Calls your class'
+            [`process_raw_response`](llmeter.endpoints.base.Endpoint.process_raw_response) method
+            to incrementally parse fields from the raw response to the target `InvocationResponse`
+        5. In case of any unhandled errors during API call or response processing, logs and sets
+            `response.error`
+        6. Automatically backfills the following fields on the parsed response, if missing:
+            - `id` (as a generated UUID)
+            - `input_payload` (the final payload sent to the API)
+            - `input_prompt` (via
+                [`_parse_payload`](llmeter.endpoints.base.Endpoint._parse_payload) method)
+            - `time_to_last_token`
+
+        Args:
+            call_endpoint: The function to wrap. Should be a method that takes a `payload: dict`
+                and returns a `raw_response` object for input to `process_raw_response`
+
+        Returns:
+            A wrapped function that implements the full `invoke` logic.
+        """
+
+        @functools.wraps(call_endpoint)
+        def wrapper(self: "Endpoint", payload: dict) -> InvocationResponse:
+            prepared = self.prepare_payload(payload)
+            # Snapshot before the API call for _parse_payload, which runs after
+            # the inner invoke — by which point the client may have mutated the dict.
+            saved_payload = copy.deepcopy(prepared)
+            default_response_id = uuid4().hex
+            response = InvocationResponse(
+                id=default_response_id,
+                request_time=datetime.now(timezone.utc),
+                response_text=None,
+            )
+            start_t = time.perf_counter()
+            try:
+                raw_response: TRawResponse = call_endpoint(self, prepared)
+                self.process_raw_response(raw_response, start_t, response)
+                default_end_t = time.perf_counter()
+            except Exception as e:
+                default_end_t = time.perf_counter()
+                logger.exception("Endpoint invocation failed: %s", response.error or e)
+                if not response.error:
+                    response.error = str(e)
+
+            if response.id is None:
+                # Just in case user's parsing logic accidentally cleared the default ID provided:
+                response.id = default_response_id
+
+            if response.time_to_last_token is None and response.error is None:
+                response.time_to_last_token = default_end_t - start_t
+
+            if response.input_payload is None:
+                response.input_payload = prepared
+            if response.input_prompt is None:
+                try:
+                    response.input_prompt = self._parse_payload(saved_payload)
+                except Exception:
+                    logger.debug("_parse_payload failed; leaving input_prompt as None")
+
+            return response
+
+        # Add a private marker to indicate that the wrapping happened:
+        # (We don't currently use this for anything except unit tests)
+        wrapper._is_llmeter_invoke = True  # type: ignore
+        return wrapper
 
     @abstractmethod
     def __init__(
@@ -212,90 +256,112 @@ class Endpoint(ABC):
         self.provider = provider
 
     @abstractmethod
-    def invoke(self, payload: dict) -> Any:
-        """Make the API call and return the raw provider response.
+    def invoke(self, payload: dict) -> InvocationResponse:
+        """Call a model and return a full parsed response with error handling
 
-        Subclasses implement this with their provider-specific API call.
-        Decorate the concrete implementation with :func:`llmeter_invoke`
-        to get automatic payload preparation, timing, error handling,
-        response parsing, and metadata back-fill::
+        !!! info
+            We strongly encourage to use the
+            [`llmeter_invoke`](llmeter.endpoints.base.Endpoint.llmeter_invoke) decorator to implement
+            your invoke method with proper orchestration and error handling.
 
-            @llmeter_invoke
-            def invoke(self, payload: dict) -> Any:
-                return self._client.call(**payload)
+        `Endpoint.invoke` should:
 
-        The :func:`llmeter_invoke` wrapper:
+        1. Call `prepare_payload` to transform the input payload
+        2. Invoke your actual target endpoint
+        3. Parse the results onto an
+            [`InvocationResponse`](llmeter.endpoints.base.InvocationResponse) object (preferably
+            via [`process_raw_response`](llmeter.endpoints.base.Endpoint.process_raw_response))
+        4. Populate `.error` and as many other response fields as possible, in the event that an
+            error occurs during model calling or response processing
 
-        1. Calls :meth:`prepare_payload` before the inner function.
-        2. Captures ``start_t`` for timing.
-        3. Calls this method to get the raw API response.
-        4. Passes the raw response to :meth:`parse_response`.
-        5. Back-fills ``time_to_last_token``, ``input_payload``,
-           ``input_prompt``, ``id``, and ``request_time``.
-        6. Catches exceptions from both this method and ``parse_response``.
+        The `llmeter_invoke` decorator handles this flow for you - so you'll need to re-implement
+        the steps if you choose not to use it.
 
         Args:
-            payload: The prepared input payload for the model.
+            payload: The input payload for the model.
 
         Returns:
-            The raw response from the provider's API client (e.g.
-            ``ChatCompletion``, ``dict``, a streaming iterator).
+            response: The final `InvocationResponse`, including all the information that could be
+                parsed from the API response - even in case of an error (when the ``error`` field
+                should also be set)
         """
         raise NotImplementedError
 
-    @abstractmethod
-    def parse_response(self, raw_response: Any, start_t: float) -> InvocationResponse:
-        """Parse the raw API response into an :class:`InvocationResponse`.
+    def prepare_payload(self, payload: dict) -> dict:
+        """Transform the payload before sending it to the API.
 
-        Subclasses implement this to extract the generated text, token counts,
-        timing information, and any other provider-specific metadata from the
-        raw object returned by the API client.
+        You can use it to enforce any transformations you need between the input dataset/payload
+        and what actually gets sent to the model, that should not be counted in the response time
+        measurement. For example: Setting fixed parameters required by the endpoint e.g.
+        `streaming: False`.
 
-        Called by the :func:`llmeter_invoke` wrapper after :meth:`invoke`.
-        Exceptions raised here are caught by the wrapper and converted to an
-        error response automatically.
+        This method is called by the
+        [`llmeter_invoke`](llmeter.endpoints.base.Endpoint.llmeter_invoke) wrapper *before*
+        starting the timer that measures response latency.
 
-        Non-streaming endpoints can ignore ``start_t`` — the wrapper
-        back-fills ``time_to_last_token`` automatically.  Streaming endpoints
-        use it to compute ``time_to_first_token`` and ``time_to_last_token``
-        during stream consumption.
+        !!! warning
+            If you made a custom :meth:`invoke` implementation **without** using the
+            :meth:`llmeter_invoke` decorator - check whether your implementation actually calls
+            this `prepare_payload` method or not!
 
-        Args:
-            raw_response: The raw response object returned by :meth:`invoke`.
-            start_t: :func:`time.perf_counter` timestamp captured immediately
-                before the API call.
-
-        Returns:
-            InvocationResponse with at least ``response_text`` populated.
-        """
-        raise NotImplementedError
-
-    def prepare_payload(self, payload: dict, **kwargs: Any) -> dict:
-        """Prepare the payload before sending it to the API.
-
-        This method is called by the ``invoke`` wrapper before the actual
-        invocation.  Subclasses can override it to merge ``**kwargs``, inject
-        provider-specific fields (``model``, ``modelId``, streaming options,
-        etc.), or apply any other transformation.
-
-        The default implementation returns *payload* unchanged (ignoring
-        ``**kwargs``).
+        The default implementation returns ``payload`` unchanged
 
         Args:
             payload: The raw input payload from the caller.
-            **kwargs: Additional keyword arguments from the caller.
 
         Returns:
             dict: The final payload to send to the API.
         """
         return payload
 
+    @abstractmethod
+    def process_raw_response(
+        self,
+        raw_response: TRawResponse,
+        start_t: float,
+        response: InvocationResponse,
+    ) -> None:
+        """Parse a raw API response onto `InvocationResponse` fields
+
+        Subclasses implement this to extract LLMeter data points (such as time to first and last
+        token, output text, number of input/output tokens, etc.) from raw model responses.
+
+        !!! warning
+            If you made a custom :meth:`invoke` implementation **without** using the
+            :meth:`llmeter_invoke` decorator - check whether your implementation actually calls
+            this `process_raw_response` method or not!
+
+        This function does not return a value, but is instead expected to incrementally populate
+        properties on the provided draft ``response`` object.
+
+        In this way, partial data will be stored even if an error occurs later during processing.
+        For example if a stream times out, or a guardrail intervenes - we might still be able to
+        capture a unique ID initially pulled from the response header.
+
+        See [`llmeter_invoke`](llmeter.endpoints.base.Endpoint.llmeter_invoke) for more details
+        about which fields of `InvocationResponse` are automatically populated for you.
+
+        Args:
+            raw_response: The raw response object (returned by your `invoke` method before it's
+                wrapped with `llmeter_invoke`)
+            start_t: `time.perf_counter` timestamp captured immediately before the API call.
+                Use this to calculate and populate `response.time_to_last_token` and (if in
+                streaming mode) `response.time_to_first_token`.
+            response: The LLMeter response object to be populated **in-place**.
+
+        Raises:
+            Exception: If something goes wrong during response streaming or parsing,
+                implementations can just raise an error. The :meth:`llmeter_invoke` wrapper will
+                populate ``response.error`` and ``response.time_to_last_token`` if they're not set
+                already.
+        """
+        raise NotImplementedError
+
     def _parse_payload(self, payload: dict) -> str | dict | None:
         """Extract the user-facing input text from an API request payload.
 
-        The ``invoke`` wrapper calls this automatically to populate
-        :pyattr:`InvocationResponse.input_prompt`.  That field serves two
-        purposes:
+        The `invoke` wrapper calls this automatically to populate
+        `InvocationResponse.input_prompt`.  That field serves two purposes:
 
         * **Observability** — it records *what* was sent to the model in a
           human-readable form, separate from the full API payload (which may
@@ -306,13 +372,13 @@ class Endpoint(ABC):
 
         Subclasses should override this to navigate their provider-specific
         payload structure and return the concatenated message text.  The
-        default implementation returns ``None`` (no prompt extracted).
+        default implementation returns `None` (no prompt extracted).
 
         Args:
-            payload: The prepared request payload (after :meth:`prepare_payload`).
+            payload: The prepared request payload (after `prepare_payload`).
 
         Returns:
-            The extracted prompt text, or ``None`` if extraction is not
+            The extracted prompt text, or `None` if extraction is not
             possible.
         """
         return None

--- a/llmeter/endpoints/base.py
+++ b/llmeter/endpoints/base.py
@@ -3,8 +3,13 @@
 """Base classes used across the different LLM endpoint types offered by LLMeter
 
 You can also use these classes to implement your own custom `Endpoint` types.
+
+The :func:`llmeter_invoke` decorator wraps a concrete ``invoke`` method with
+payload preparation, timing, error handling, and metadata back-fill.  Apply it
+to every concrete ``invoke`` in an :class:`Endpoint` subclass.
 """
 
+import functools
 import importlib
 import json
 import logging
@@ -107,6 +112,69 @@ class InvocationResponse:
         return asdict(self)
 
 
+def llmeter_invoke(fn):
+    """Decorator that wraps an :meth:`Endpoint.invoke` implementation with
+    payload preparation, timing, error handling, and metadata back-fill.
+
+    Apply this to every concrete ``invoke`` method in an :class:`Endpoint`
+    subclass::
+
+        class MyEndpoint(Endpoint):
+            @llmeter_invoke
+            def invoke(self, payload: dict) -> InvocationResponse:
+                raw = self._client.call(**payload)
+                return self.parse_response(raw, self._start_t)
+
+    The wrapper performs the following steps around the decorated function:
+
+    1. Calls :meth:`~Endpoint.prepare_payload` to merge ``**kwargs`` and
+       inject provider-specific fields.
+    2. Records ``self._start_t`` via :func:`time.perf_counter`.
+    3. Calls the inner ``invoke``.
+    4. On exception, converts it to an error :class:`InvocationResponse`.
+    5. Back-fills ``time_to_last_token``, ``input_payload``,
+       ``input_prompt``, ``id``, and ``request_time`` if the subclass
+       didn't set them.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(self: "Endpoint", payload: dict, **kw: Any) -> InvocationResponse:
+        prepared = self.prepare_payload(payload, **kw)
+        self._last_payload = prepared
+        request_time = datetime.now(timezone.utc)
+        self._start_t = time.perf_counter()
+        try:
+            response = fn(self, prepared)
+        except Exception as e:
+            logger.exception("Endpoint invocation failed: %s", e)
+            response = InvocationResponse.error_output(
+                input_payload=prepared,
+                id=uuid4().hex,
+                error=str(e),
+                request_time=request_time,
+            )
+
+        if response.time_to_last_token is None and response.error is None:
+            response.time_to_last_token = time.perf_counter() - self._start_t
+
+        if response.input_payload is None:
+            response.input_payload = prepared
+        if response.input_prompt is None:
+            try:
+                response.input_prompt = self._parse_payload(prepared)
+            except Exception:
+                logger.debug("_parse_payload failed; leaving input_prompt as None")
+        if response.id is None:
+            response.id = uuid4().hex
+        if response.request_time is None:
+            response.request_time = request_time
+
+        return response
+
+    wrapper._is_llmeter_invoke = True
+    return wrapper
+
+
 class Endpoint(ABC):
     """
     An abstract base class for endpoint implementations.
@@ -139,13 +207,20 @@ class Endpoint(ABC):
         """Invoke the endpoint with the given payload.
 
         Subclasses implement this with their provider-specific API call,
-        passing the raw response to :meth:`parse_response`.  The payload
-        received here has already been through :meth:`prepare_payload`, so
-        ``**kwargs`` have been merged and provider-specific fields
-        (``model``, ``modelId``, etc.) are set.
+        passing the raw response to :meth:`parse_response`.  Decorate the
+        concrete implementation with :func:`llmeter_invoke` to get automatic
+        payload preparation, timing, error handling, and metadata back-fill::
 
-        The base class automatically wraps every subclass implementation with:
+            @llmeter_invoke
+            def invoke(self, payload: dict) -> InvocationResponse:
+                raw = self._client.call(**payload)
+                return self.parse_response(raw, self._start_t)
 
+        The :func:`llmeter_invoke` wrapper provides:
+
+        * **Payload preparation** — calls :meth:`prepare_payload` before the
+          inner function, so ``**kwargs`` are merged and provider-specific
+          fields (``model``, ``modelId``, etc.) are set.
         * **Timing** — ``self._start_t`` is set immediately before the call
           and ``time_to_last_token`` is back-filled on the response if the
           subclass didn't set it (streaming endpoints typically set it during
@@ -215,60 +290,6 @@ class Endpoint(ABC):
             dict: The final payload to send to the API.
         """
         return payload
-
-    def __init_subclass__(cls, **kwargs: Any) -> None:
-        super().__init_subclass__(**kwargs)
-
-        # Wrap the subclass invoke (if it defines one) with prepare_payload,
-        # error handling, and metadata back-fill.
-        if "invoke" not in cls.__dict__:
-            return
-
-        inner = cls.__dict__["invoke"]
-
-        if not callable(inner) or isinstance(inner, (classmethod, staticmethod)):
-            return
-
-        def invoke(self: "Endpoint", payload: dict, **kw: Any) -> InvocationResponse:
-            prepared = self.prepare_payload(payload, **kw)
-            self._last_payload = prepared
-            request_time = datetime.now(timezone.utc)
-            self._start_t = time.perf_counter()
-            try:
-                response = inner(self, prepared)
-            except Exception as e:
-                logger.exception("Endpoint invocation failed: %s", e)
-                response = InvocationResponse.error_output(
-                    input_payload=prepared,
-                    id=uuid4().hex,
-                    error=str(e),
-                    request_time=request_time,
-                )
-
-            # Back-fill time_to_last_token if the subclass didn't set it
-            # (streaming endpoints typically set it during stream consumption).
-            if response.time_to_last_token is None and response.error is None:
-                response.time_to_last_token = time.perf_counter() - self._start_t
-
-            if response.input_payload is None:
-                response.input_payload = prepared
-            if response.input_prompt is None:
-                try:
-                    response.input_prompt = self._parse_payload(prepared)
-                except Exception:
-                    logger.debug("_parse_payload failed; leaving input_prompt as None")
-            if response.id is None:
-                response.id = uuid4().hex
-            if response.request_time is None:
-                response.request_time = request_time
-
-            return response
-
-        invoke.__name__ = inner.__name__
-        invoke.__qualname__ = inner.__qualname__
-        invoke.__doc__ = inner.__doc__
-        invoke.__module__ = inner.__module__
-        cls.invoke = invoke  # type: ignore[attr-defined]
 
     def _parse_payload(self, payload: dict) -> str | dict | None:
         """Extract the user-facing input text from an API request payload.

--- a/llmeter/endpoints/base.py
+++ b/llmeter/endpoints/base.py
@@ -11,6 +11,7 @@ import logging
 import time
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
 from typing import Any
 from uuid import uuid4
 
@@ -40,6 +41,7 @@ class InvocationResponse:
         input_prompt (str): The input prompt used in the invocation.
         time_per_output_token (float): The average time taken to generate each token in the response.
         error (str): Any error that occurred during invocation.
+        request_time (datetime): The wall-clock time when the request was sent.
     """
 
     response_text: str | None
@@ -54,6 +56,7 @@ class InvocationResponse:
     time_per_output_token: float | None = None
     error: str | None = None
     retries: int | None = None
+    request_time: datetime | None = None
 
     def to_json(self, default=llmeter_default_serializer, **kwargs) -> str:
         """Serialize this response to a JSON string.
@@ -75,7 +78,10 @@ class InvocationResponse:
 
     @staticmethod
     def error_output(
-        input_payload: dict | None = None, error=None, id: str | None = None
+        input_payload: dict | None = None,
+        error=None,
+        id: str | None = None,
+        request_time: datetime | None = None,
     ) -> "InvocationResponse":
         return InvocationResponse(
             id=id or uuid4().hex,
@@ -83,6 +89,7 @@ class InvocationResponse:
             input_payload=input_payload,
             time_to_last_token=None,
             error="invocation failed" if error is None else str(error),
+            request_time=request_time,
         )
 
     def __repr__(self):
@@ -225,6 +232,7 @@ class Endpoint(ABC):
         def invoke(self: "Endpoint", payload: dict, **kw: Any) -> InvocationResponse:
             prepared = self.prepare_payload(payload, **kw)
             self._last_payload = prepared
+            request_time = datetime.now(timezone.utc)
             self._start_t = time.perf_counter()
             try:
                 response = inner(self, prepared)
@@ -234,6 +242,7 @@ class Endpoint(ABC):
                     input_payload=prepared,
                     id=uuid4().hex,
                     error=str(e),
+                    request_time=request_time,
                 )
 
             # Back-fill time_to_last_token if the subclass didn't set it
@@ -250,6 +259,8 @@ class Endpoint(ABC):
                     logger.debug("_parse_payload failed; leaving input_prompt as None")
             if response.id is None:
                 response.id = uuid4().hex
+            if response.request_time is None:
+                response.request_time = request_time
 
             return response
 

--- a/llmeter/endpoints/base.py
+++ b/llmeter/endpoints/base.py
@@ -122,27 +122,22 @@ def llmeter_invoke(fn):
 
         class MyEndpoint(Endpoint):
             @llmeter_invoke
-            def invoke(self, payload: dict) -> InvocationResponse:
-                start_t = time.perf_counter()
-                raw = self._client.call(**payload)
-                return self.parse_response(raw, start_t)
+            def invoke(self, payload: dict) -> Any:
+                return self._client.call(**payload)
 
     The wrapper performs the following steps around the decorated function:
 
     1. Calls :meth:`~Endpoint.prepare_payload` to merge ``**kwargs`` and
        inject provider-specific fields.
-    2. Calls the inner ``invoke``.
-    3. On exception, converts it to an error :class:`InvocationResponse`.
-    4. Back-fills ``time_to_last_token``, ``input_payload``,
+    2. Captures ``start_t`` via :func:`time.perf_counter`.
+    3. Calls the inner ``invoke`` which returns the raw API response.
+    4. Calls :meth:`~Endpoint.parse_response` with the raw response and
+       ``start_t``.
+    5. On exception (from either step 3 or 4), converts it to an error
+       :class:`InvocationResponse`.
+    6. Back-fills ``time_to_last_token``, ``input_payload``,
        ``input_prompt``, ``id``, and ``request_time`` if the subclass
        didn't set them.
-
-    .. note::
-
-       The inner ``invoke`` should capture its own ``start_t`` via
-       :func:`time.perf_counter` and pass it to :meth:`parse_response`.
-       The decorator independently tracks timing for the
-       ``time_to_last_token`` back-fill.
     """
 
     @functools.wraps(fn)
@@ -154,7 +149,8 @@ def llmeter_invoke(fn):
         request_time = datetime.now(timezone.utc)
         start_t = time.perf_counter()
         try:
-            response = fn(self, prepared)
+            raw_response = fn(self, prepared)
+            response = self.parse_response(raw_response, start_t)
         except Exception as e:
             logger.exception("Endpoint invocation failed: %s", e)
             response = InvocationResponse.error_output(
@@ -213,40 +209,34 @@ class Endpoint(ABC):
         self.provider = provider
 
     @abstractmethod
-    def invoke(self, payload: dict) -> InvocationResponse:
-        """Invoke the endpoint with the given payload.
+    def invoke(self, payload: dict) -> Any:
+        """Make the API call and return the raw provider response.
 
-        Subclasses implement this with their provider-specific API call,
-        passing the raw response to :meth:`parse_response`.  Decorate the
-        concrete implementation with :func:`llmeter_invoke` to get automatic
-        payload preparation, timing, error handling, and metadata back-fill::
+        Subclasses implement this with their provider-specific API call.
+        Decorate the concrete implementation with :func:`llmeter_invoke`
+        to get automatic payload preparation, timing, error handling,
+        response parsing, and metadata back-fill::
 
             @llmeter_invoke
-            def invoke(self, payload: dict) -> InvocationResponse:
-                start_t = time.perf_counter()
-                raw = self._client.call(**payload)
-                return self.parse_response(raw, start_t)
+            def invoke(self, payload: dict) -> Any:
+                return self._client.call(**payload)
 
-        The :func:`llmeter_invoke` wrapper provides:
+        The :func:`llmeter_invoke` wrapper:
 
-        * **Payload preparation** — calls :meth:`prepare_payload` before the
-          inner function, so ``**kwargs`` are merged and provider-specific
-          fields (``model``, ``modelId``, etc.) are set.
-        * **Timing** — ``time_to_last_token`` is back-filled on the response
-          if the subclass didn't set it (streaming endpoints typically set it
-          during stream consumption).
-        * **Error handling** — unhandled exceptions are caught, logged, and
-          converted to an error :class:`InvocationResponse`.
-        * **Metadata back-fill** — ``input_payload`` and ``input_prompt`` are
-          guaranteed to be set on the returned response (success or error),
-          using the prepared payload.
+        1. Calls :meth:`prepare_payload` before the inner function.
+        2. Captures ``start_t`` for timing.
+        3. Calls this method to get the raw API response.
+        4. Passes the raw response to :meth:`parse_response`.
+        5. Back-fills ``time_to_last_token``, ``input_payload``,
+           ``input_prompt``, ``id``, and ``request_time``.
+        6. Catches exceptions from both this method and ``parse_response``.
 
         Args:
             payload: The prepared input payload for the model.
 
         Returns:
-            InvocationResponse: An object containing the model's response and
-                associated metrics.
+            The raw response from the provider's API client (e.g.
+            ``ChatCompletion``, ``dict``, a streaming iterator).
         """
         raise NotImplementedError
 
@@ -258,9 +248,9 @@ class Endpoint(ABC):
         timing information, and any other provider-specific metadata from the
         raw object returned by the API client.
 
-        This method is called from :meth:`invoke` after the API call.
-        Exceptions raised here will be caught by the base-class ``invoke``
-        wrapper and converted to an error response automatically.
+        Called by the :func:`llmeter_invoke` wrapper after :meth:`invoke`.
+        Exceptions raised here are caught by the wrapper and converted to an
+        error response automatically.
 
         Non-streaming endpoints can ignore ``start_t`` — the wrapper
         back-fills ``time_to_last_token`` automatically.  Streaming endpoints
@@ -268,15 +258,12 @@ class Endpoint(ABC):
         during stream consumption.
 
         Args:
-            raw_response: The raw response object from the provider's API
-                client.  The type varies by provider (e.g. ``ChatCompletion``,
-                ``dict``, a streaming iterator).
-            start_t: The :func:`time.perf_counter` timestamp captured
-                immediately before the API call in the ``invoke`` method.
+            raw_response: The raw response object returned by :meth:`invoke`.
+            start_t: :func:`time.perf_counter` timestamp captured immediately
+                before the API call.
 
         Returns:
-            InvocationResponse: Parsed response with at least
-                ``response_text`` populated.
+            InvocationResponse with at least ``response_text`` populated.
         """
         raise NotImplementedError
 

--- a/llmeter/endpoints/bedrock.py
+++ b/llmeter/endpoints/bedrock.py
@@ -25,7 +25,7 @@ from ..prompt_utils import (
     MediaContent,
     VideoContent,
 )
-from .base import Endpoint, InvocationResponse
+from .base import Endpoint, InvocationResponse, llmeter_invoke
 
 logger = logging.getLogger(__name__)
 
@@ -318,6 +318,7 @@ class BedrockConverse(BedrockBase):
             retries=retries,
         )
 
+    @llmeter_invoke
     def invoke(self, payload: dict) -> InvocationResponse:
         """Invoke the Bedrock converse API with the given payload."""
         client_response = self._bedrock_client.converse(**payload)  # type: ignore
@@ -332,6 +333,7 @@ class BedrockConverse(BedrockBase):
 
 
 class BedrockConverseStream(BedrockConverse):
+    @llmeter_invoke
     def invoke(self, payload: dict) -> InvocationResponse:
         client_response = self._bedrock_client.converse_stream(**payload)  # type: ignore
         return self.parse_response(client_response, self._start_t)

--- a/llmeter/endpoints/bedrock.py
+++ b/llmeter/endpoints/bedrock.py
@@ -13,11 +13,9 @@ Alternatively, see:
 import logging
 import time
 from typing import Any
-from uuid import uuid4
 
 import boto3
 from botocore.config import Config
-from botocore.exceptions import ClientError
 
 from ..prompt_utils import (
     AudioContent,
@@ -30,6 +28,20 @@ from ..prompt_utils import (
 from .base import Endpoint, InvocationResponse
 
 logger = logging.getLogger(__name__)
+
+# Error event types that can appear in Bedrock streaming responses.
+# Shared by both ConverseStream and InvokeModelWithResponseStream APIs.
+# See: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ResponseStream.html
+BEDROCK_STREAM_ERROR_TYPES = frozenset(
+    {
+        "internalServerException",
+        "modelStreamErrorException",
+        "modelTimeoutException",
+        "serviceUnavailableException",
+        "throttlingException",
+        "validationException",
+    }
+)
 
 
 def _mime_to_format(mime_type: str) -> str | None:
@@ -274,211 +286,110 @@ class BedrockBase(Endpoint):
 
 
 class BedrockConverse(BedrockBase):
-    def _parse_converse_response(self, response: dict) -> InvocationResponse:
-        """
-        Parse the response from a Bedrock converse API call.
+    def parse_response(self, response: dict, start_t: float) -> InvocationResponse:
+        """Parse the response from a Bedrock converse API call.
 
         Args:
-            response (dict): Raw response from the Bedrock API containing output text and metadata
+            response: Raw response from the Bedrock API.
+            start_t: The timestamp when the request was initiated.
 
         Returns:
-            InvocationResponse: Parsed response containing the generated text and metadata
-
-        Raises:
-            KeyError: If required fields are missing from the response
-            TypeError: If response fields have unexpected types
+            InvocationResponse with the generated text and metadata.
         """
-        try:
-            # Direct dictionary access and single-level assignment for better performance
-            output = response["output"]["message"]["content"][0]["text"]
-            if not isinstance(output, str):
-                raise TypeError("Expected string for output text")
+        output = response["output"]["message"]["content"][0]["text"]
+        if not isinstance(output, str):
+            raise TypeError("Expected string for output text")
 
-            usage = response.get("usage", {})
-            retries = response["ResponseMetadata"]["RetryAttempts"]
+        usage = response.get("usage") or {}
+        retries = response["ResponseMetadata"]["RetryAttempts"]
 
-            return InvocationResponse(
-                id=uuid4().hex,
-                response_text=output,
-                num_tokens_input=usage.get("inputTokens"),
-                num_tokens_output=usage.get("outputTokens"),
-                retries=retries,
-            )
+        return InvocationResponse(
+            id=response["ResponseMetadata"].get("RequestId"),
+            response_text=output,
+            num_tokens_input=usage.get("inputTokens")
+            if isinstance(usage, dict)
+            else None,
+            num_tokens_output=usage.get("outputTokens")
+            if isinstance(usage, dict)
+            else None,
+            num_tokens_input_cached=usage.get("cacheReadInputTokens")
+            if isinstance(usage, dict)
+            else None,
+            retries=retries,
+        )
 
-        except KeyError as e:
-            logger.error(f"Missing required field in response: {e}")
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Missing required field: {e}",
-            )
+    def invoke(self, payload: dict) -> InvocationResponse:
+        """Invoke the Bedrock converse API with the given payload."""
+        client_response = self._bedrock_client.converse(**payload)  # type: ignore
+        return self.parse_response(client_response, self._start_t)  # type: ignore
 
-        except TypeError as e:
-            logger.error(f"Unexpected type in response: {e}")
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Type error in response: {e}",
-            )
-
-        except Exception as e:
-            logger.error(f"Error parsing converse response: {e}")
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Response parsing error: {e}",
-            )
-
-    def invoke(self, payload: dict, **kwargs: Any) -> InvocationResponse:
-        """
-        Invoke the Bedrock converse API with the given payload.
-
-        Args:
-            payload (dict): The payload containing the request parameters
-            **kwargs: Additional keyword arguments to include in the payload
-
-        Returns:
-            InvocationResponse: Response object containing generated text and metadata
-
-        Raises:
-            ClientError: If there is an error calling the Bedrock API
-            ValueError: If payload is invalid
-            TypeError: If payload is not a dictionary
-        """
-        if not isinstance(payload, dict):
-            raise TypeError("Payload must be a dictionary")
-
-        try:
-            payload = {**kwargs, **payload}
-            if payload.get("inferenceConfig") is None:
-                payload["inferenceConfig"] = self._inference_config or {}
-
-            payload["modelId"] = self.model_id
-            try:
-                start_t = time.perf_counter()
-                client_response = self._bedrock_client.converse(**payload)  # type: ignore
-                time_to_last_token = time.perf_counter() - start_t
-            except ClientError as e:
-                logger.error(f"Bedrock API error: {e}")
-                return InvocationResponse.error_output(
-                    input_payload=payload, id=uuid4().hex, error=str(e)
-                )
-            except Exception as e:
-                logger.error(f"Unexpected error during API call: {e}")
-                return InvocationResponse.error_output(
-                    input_payload=payload, id=uuid4().hex, error=str(e)
-                )
-
-            response = self._parse_converse_response(client_response)  # type: ignore
-            response.input_payload = payload
-            response.input_prompt = self._parse_payload(payload)
-            response.time_to_last_token = time_to_last_token
-            return response
-
-        except Exception as e:
-            logger.error(f"Error in invoke method: {e}")
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-
-
-class BedrockConverseStream(BedrockConverse):
-    def invoke(self, payload: dict, **kwargs: Any) -> InvocationResponse:
+    def prepare_payload(self, payload, **kwargs):
         payload = {**kwargs, **payload}
         if payload.get("inferenceConfig") is None:
             payload["inferenceConfig"] = self._inference_config or {}
-
         payload["modelId"] = self.model_id
-        start_t = time.perf_counter()
-        try:
-            client_response = self._bedrock_client.converse_stream(**payload)  # type: ignore
-        except (ClientError, Exception) as e:
-            logger.error(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-        response = self._parse_conversation_stream(client_response, start_t)
-        response.input_payload = payload
-        response.input_prompt = self._parse_payload(payload)
-        return response
+        return payload
 
-    def _parse_conversation_stream(
-        self, client_response, start_t: float
-    ) -> InvocationResponse:
-        """
-        Parse the streaming response from Bedrock conversation API.
+
+class BedrockConverseStream(BedrockConverse):
+    def invoke(self, payload: dict) -> InvocationResponse:
+        client_response = self._bedrock_client.converse_stream(**payload)  # type: ignore
+        return self.parse_response(client_response, self._start_t)
+
+    def parse_response(self, client_response, start_t: float) -> InvocationResponse:
+        """Parse the streaming response from Bedrock conversation API.
 
         Args:
-            client_response (dict): The raw response from the Bedrock API
-            start_t (float): The timestamp when the request was initiated
+            client_response: The raw response from the Bedrock API.
+            start_t: The timestamp when the request was initiated.
 
         Returns:
-            InvocationResponse: Parsed response containing the generated text and metadata
-
-        Raises:
-            KeyError: If required fields are missing from the response
-            TypeError: If response fields have unexpected types
+            InvocationResponse with the generated text and metadata.
         """
         time_flag = True
         time_to_first_token = None
         time_to_last_token = None
         output_text = ""
         metadata = None
+        error = None
 
-        try:
-            for chunk in client_response["stream"]:
-                if "contentBlockDelta" in chunk:
-                    delta_text = chunk["contentBlockDelta"]["delta"].get("text", "")
-                    if not isinstance(delta_text, str):
-                        raise TypeError("Expected string for delta text")
-                    output_text += delta_text or ""
-                    if time_flag:
-                        time_to_first_token = time.perf_counter() - start_t
-                        time_flag = False
+        for chunk in client_response["stream"]:
+            if "contentBlockDelta" in chunk:
+                delta_text = chunk["contentBlockDelta"]["delta"].get("text", "")
+                if not isinstance(delta_text, str):
+                    raise TypeError("Expected string for delta text")
+                output_text += delta_text or ""
+                if time_flag:
+                    time_to_first_token = time.perf_counter() - start_t
+                    time_flag = False
 
-                if "contentBlockStop" in chunk:
-                    time_to_last_token = time.perf_counter() - start_t
+            if "contentBlockStop" in chunk:
+                time_to_last_token = time.perf_counter() - start_t
 
-                if "metadata" in chunk:
-                    metadata = chunk["metadata"]
+            if "metadata" in chunk:
+                metadata = chunk["metadata"]
 
-            response = InvocationResponse(
-                id=uuid4().hex,
-                response_text=output_text,
-                time_to_last_token=time_to_last_token,
-                time_to_first_token=time_to_first_token,
-            )
+            # Detect Bedrock stream error events
+            for error_type in BEDROCK_STREAM_ERROR_TYPES:
+                if error_type in chunk:
+                    error = f"Bedrock {error_type}: {chunk[error_type]['message']}"
+                    logger.error(error)
+                    break
 
-            if metadata:
-                # The latency provided by Bedrock is at the service endpoint time, not client side
-                # time_to_last_token = metadata.get("metrics", {}).get("latencyMs")
-                try:
-                    usage = metadata.get("usage", {})
-                    response.num_tokens_input = usage.get("inputTokens")
-                    response.num_tokens_output = usage.get("outputTokens")
-                except Exception as e:
-                    logger.error(f"Error parsing metadata: {e}")
-                    return InvocationResponse.error_output(
-                        id=uuid4().hex,
-                        error=f"Metadata parsing error: {e}",
-                    )
+        response = InvocationResponse(
+            id=client_response["ResponseMetadata"].get("RequestId"),
+            response_text=output_text,
+            time_to_last_token=time_to_last_token,
+            time_to_first_token=time_to_first_token,
+            error=error,
+        )
 
-            response.retries = client_response["ResponseMetadata"]["RetryAttempts"]
+        if metadata:
+            usage = metadata.get("usage", {})
+            response.num_tokens_input = usage.get("inputTokens")
+            response.num_tokens_output = usage.get("outputTokens")
+            response.num_tokens_input_cached = usage.get("cacheReadInputTokens")
 
-            return response
+        response.retries = client_response["ResponseMetadata"]["RetryAttempts"]
 
-        except KeyError as e:
-            logger.error(f"Missing required field in response: {e}")
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Missing required field: {e}",
-            )
-        except TypeError as e:
-            logger.error(f"Unexpected type in response: {e}")
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Type error in response: {e}",
-            )
-        except Exception as e:
-            logger.error(f"Error parsing conversation stream: {e}")
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Stream parsing error: {e}",
-            )
+        return response

--- a/llmeter/endpoints/bedrock.py
+++ b/llmeter/endpoints/bedrock.py
@@ -286,7 +286,7 @@ class BedrockBase(Endpoint):
 
 
 class BedrockConverse(BedrockBase):
-    def parse_response(self, response: dict, start_t: float) -> InvocationResponse:
+    def parse_response(self, raw_response: dict, start_t: float) -> InvocationResponse:
         """Parse the response from a Bedrock converse API call.
 
         Args:
@@ -296,15 +296,15 @@ class BedrockConverse(BedrockBase):
         Returns:
             InvocationResponse with the generated text and metadata.
         """
-        output = response["output"]["message"]["content"][0]["text"]
+        output = raw_response["output"]["message"]["content"][0]["text"]
         if not isinstance(output, str):
             raise TypeError("Expected string for output text")
 
-        usage = response.get("usage") or {}
-        retries = response["ResponseMetadata"]["RetryAttempts"]
+        usage = raw_response.get("usage") or {}
+        retries = raw_response["ResponseMetadata"]["RetryAttempts"]
 
         return InvocationResponse(
-            id=response["ResponseMetadata"].get("RequestId"),
+            id=raw_response["ResponseMetadata"].get("RequestId"),
             response_text=output,
             num_tokens_input=usage.get("inputTokens")
             if isinstance(usage, dict)
@@ -319,10 +319,10 @@ class BedrockConverse(BedrockBase):
         )
 
     @llmeter_invoke
-    def invoke(self, payload: dict) -> InvocationResponse:
+    def invoke(self, payload: dict):
         """Invoke the Bedrock converse API with the given payload."""
         client_response = self._bedrock_client.converse(**payload)  # type: ignore
-        return client_response  # type: ignore
+        return client_response
 
     def prepare_payload(self, payload, **kwargs):
         payload = {**kwargs, **payload}
@@ -334,11 +334,11 @@ class BedrockConverse(BedrockBase):
 
 class BedrockConverseStream(BedrockConverse):
     @llmeter_invoke
-    def invoke(self, payload: dict) -> InvocationResponse:
+    def invoke(self, payload: dict):
         client_response = self._bedrock_client.converse_stream(**payload)  # type: ignore
         return client_response
 
-    def parse_response(self, client_response, start_t: float) -> InvocationResponse:
+    def parse_response(self, raw_response, start_t: float) -> InvocationResponse:
         """Parse the streaming response from Bedrock conversation API.
 
         Args:
@@ -355,7 +355,7 @@ class BedrockConverseStream(BedrockConverse):
         metadata = None
         error = None
 
-        for chunk in client_response["stream"]:
+        for chunk in raw_response["stream"]:
             if "contentBlockDelta" in chunk:
                 delta_text = chunk["contentBlockDelta"]["delta"].get("text", "")
                 if not isinstance(delta_text, str):
@@ -379,7 +379,7 @@ class BedrockConverseStream(BedrockConverse):
                     break
 
         response = InvocationResponse(
-            id=client_response["ResponseMetadata"].get("RequestId"),
+            id=raw_response["ResponseMetadata"].get("RequestId"),
             response_text=output_text,
             time_to_last_token=time_to_last_token,
             time_to_first_token=time_to_first_token,
@@ -392,6 +392,6 @@ class BedrockConverseStream(BedrockConverse):
             response.num_tokens_output = usage.get("outputTokens")
             response.num_tokens_input_cached = usage.get("cacheReadInputTokens")
 
-        response.retries = client_response["ResponseMetadata"]["RetryAttempts"]
+        response.retries = raw_response["ResponseMetadata"]["RetryAttempts"]
 
         return response

--- a/llmeter/endpoints/bedrock.py
+++ b/llmeter/endpoints/bedrock.py
@@ -321,9 +321,8 @@ class BedrockConverse(BedrockBase):
     @llmeter_invoke
     def invoke(self, payload: dict) -> InvocationResponse:
         """Invoke the Bedrock converse API with the given payload."""
-        start_t = time.perf_counter()
         client_response = self._bedrock_client.converse(**payload)  # type: ignore
-        return self.parse_response(client_response, start_t)  # type: ignore
+        return client_response  # type: ignore
 
     def prepare_payload(self, payload, **kwargs):
         payload = {**kwargs, **payload}
@@ -336,9 +335,8 @@ class BedrockConverse(BedrockBase):
 class BedrockConverseStream(BedrockConverse):
     @llmeter_invoke
     def invoke(self, payload: dict) -> InvocationResponse:
-        start_t = time.perf_counter()
         client_response = self._bedrock_client.converse_stream(**payload)  # type: ignore
-        return self.parse_response(client_response, start_t)
+        return client_response
 
     def parse_response(self, client_response, start_t: float) -> InvocationResponse:
         """Parse the streaming response from Bedrock conversation API.

--- a/llmeter/endpoints/bedrock.py
+++ b/llmeter/endpoints/bedrock.py
@@ -321,8 +321,9 @@ class BedrockConverse(BedrockBase):
     @llmeter_invoke
     def invoke(self, payload: dict) -> InvocationResponse:
         """Invoke the Bedrock converse API with the given payload."""
+        start_t = time.perf_counter()
         client_response = self._bedrock_client.converse(**payload)  # type: ignore
-        return self.parse_response(client_response, self._start_t)  # type: ignore
+        return self.parse_response(client_response, start_t)  # type: ignore
 
     def prepare_payload(self, payload, **kwargs):
         payload = {**kwargs, **payload}
@@ -335,8 +336,9 @@ class BedrockConverse(BedrockBase):
 class BedrockConverseStream(BedrockConverse):
     @llmeter_invoke
     def invoke(self, payload: dict) -> InvocationResponse:
+        start_t = time.perf_counter()
         client_response = self._bedrock_client.converse_stream(**payload)  # type: ignore
-        return self.parse_response(client_response, self._start_t)
+        return self.parse_response(client_response, start_t)
 
     def parse_response(self, client_response, start_t: float) -> InvocationResponse:
         """Parse the streaming response from Bedrock conversation API.

--- a/llmeter/endpoints/bedrock.py
+++ b/llmeter/endpoints/bedrock.py
@@ -395,19 +395,19 @@ class BedrockConverseStream(BedrockBase[ConverseStreamResponseTypeDef]):
             if "metadata" in chunk:
                 usage = chunk["metadata"].get("usage", {})
                 input_tokens = usage.get("inputTokens")
-                if input_tokens:
+                if input_tokens is not None:
                     if response.num_tokens_input is None:
                         response.num_tokens_input = input_tokens
                     else:
                         response.num_tokens_input += input_tokens
                 output_tokens = usage.get("outputTokens")
-                if output_tokens:
+                if output_tokens is not None:
                     if response.num_tokens_output is None:
                         response.num_tokens_output = output_tokens
                     else:
                         response.num_tokens_output += output_tokens
                 cache_read_input_tokens = usage.get("cacheReadInputTokens")
-                if cache_read_input_tokens:
+                if cache_read_input_tokens is not None:
                     if response.num_tokens_input_cached is None:
                         response.num_tokens_input_cached = cache_read_input_tokens
                     else:

--- a/llmeter/endpoints/bedrock.py
+++ b/llmeter/endpoints/bedrock.py
@@ -12,10 +12,19 @@ Alternatively, see:
 
 import logging
 import time
-from typing import Any
+from typing import Any, Generic, TypeVar
 
 import boto3
 from botocore.config import Config
+
+try:
+    from mypy_boto3_bedrock_runtime.type_defs import (
+        ConverseResponseTypeDef,
+        ConverseStreamResponseTypeDef,
+    )
+except ImportError:
+    ConverseResponseTypeDef = TypeVar("ConverseResponseTypeDef")
+    ConverseStreamResponseTypeDef = TypeVar("ConverseStreamResponseTypeDef")
 
 from ..prompt_utils import (
     AudioContent,
@@ -25,7 +34,7 @@ from ..prompt_utils import (
     MediaContent,
     VideoContent,
 )
-from .base import Endpoint, InvocationResponse, llmeter_invoke
+from .base import Endpoint, InvocationResponse
 
 logger = logging.getLogger(__name__)
 
@@ -113,7 +122,15 @@ def _build_content_blocks(items: list[ContentItem]) -> list[dict]:
     return blocks
 
 
-class BedrockBase(Endpoint):
+TBedrockConverseResponseBase = TypeVar(
+    "TBedrockConverseResponseBase",
+    bound=ConverseResponseTypeDef | ConverseStreamResponseTypeDef,
+)
+
+
+class BedrockBase(
+    Endpoint[TBedrockConverseResponseBase], Generic[TBedrockConverseResponseBase]
+):
     """Base class for interacting with Amazon Bedrock endpoints.
 
     This class provides core functionality for making requests to Amazon Bedrock
@@ -284,9 +301,29 @@ class BedrockBase(Endpoint):
         }
         return payload
 
+    def prepare_payload(self, payload):
+        """Enforce required properties on the input to Bedrock Converse* APIs
 
-class BedrockConverse(BedrockBase):
-    def parse_response(self, raw_response: dict, start_t: float) -> InvocationResponse:
+        In particular, ensure `modelId` is set in line with this Endpoint's configured model ID
+        and apply `self._inference_config` if no config was explicitly set on the payload.
+        """
+        payload = {**payload}
+        if payload.get("inferenceConfig") is None:
+            payload["inferenceConfig"] = self._inference_config or {}
+        payload["modelId"] = self.model_id
+        return payload
+
+
+class BedrockConverse(BedrockBase[ConverseResponseTypeDef]):
+    @BedrockBase.llmeter_invoke
+    def invoke(self, payload: dict) -> ConverseResponseTypeDef:
+        """Invoke the Bedrock converse API with the given payload."""
+        client_response = self._bedrock_client.converse(**payload)  # type: ignore
+        return client_response
+
+    def process_raw_response(
+        self, raw_response, start_t: float, response: InvocationResponse
+    ) -> None:
         """Parse the response from a Bedrock converse API call.
 
         Args:
@@ -296,50 +333,33 @@ class BedrockConverse(BedrockBase):
         Returns:
             InvocationResponse with the generated text and metadata.
         """
-        output = raw_response["output"]["message"]["content"][0]["text"]
-        if not isinstance(output, str):
-            raise TypeError("Expected string for output text")
+        resp_meta = raw_response.get("ResponseMetadata", {})
+        response.id = resp_meta.get("RequestId")
+        response.retries = resp_meta.get("RetryAttempts")
 
-        usage = raw_response.get("usage") or {}
-        retries = raw_response["ResponseMetadata"]["RetryAttempts"]
+        text_parts = [
+            part["text"]
+            for part in raw_response["output"]["message"]["content"]
+            if "text" in part
+        ]
+        response.response_text = "".join(text_parts)
 
-        return InvocationResponse(
-            id=raw_response["ResponseMetadata"].get("RequestId"),
-            response_text=output,
-            num_tokens_input=usage.get("inputTokens")
-            if isinstance(usage, dict)
-            else None,
-            num_tokens_output=usage.get("outputTokens")
-            if isinstance(usage, dict)
-            else None,
-            num_tokens_input_cached=usage.get("cacheReadInputTokens")
-            if isinstance(usage, dict)
-            else None,
-            retries=retries,
-        )
-
-    @llmeter_invoke
-    def invoke(self, payload: dict):
-        """Invoke the Bedrock converse API with the given payload."""
-        client_response = self._bedrock_client.converse(**payload)  # type: ignore
-        return client_response
-
-    def prepare_payload(self, payload, **kwargs):
-        payload = {**kwargs, **payload}
-        if payload.get("inferenceConfig") is None:
-            payload["inferenceConfig"] = self._inference_config or {}
-        payload["modelId"] = self.model_id
-        return payload
+        usage = raw_response.get("usage", {})
+        response.num_tokens_input = usage.get("inputTokens")
+        response.num_tokens_input_cached = usage.get("cacheReadInputTokens")
+        response.num_tokens_output = usage.get("outputTokens")
 
 
-class BedrockConverseStream(BedrockConverse):
-    @llmeter_invoke
+class BedrockConverseStream(BedrockBase[ConverseStreamResponseTypeDef]):
+    @Endpoint.llmeter_invoke
     def invoke(self, payload: dict):
         client_response = self._bedrock_client.converse_stream(**payload)  # type: ignore
         return client_response
 
-    def parse_response(self, raw_response, start_t: float) -> InvocationResponse:
-        """Parse the streaming response from Bedrock conversation API.
+    def process_raw_response(
+        self, raw_response, start_t: float, response: InvocationResponse
+    ) -> None:
+        """Parse the streaming response from a Bedrock ConverseStream API call
 
         Args:
             client_response: The raw response from the Bedrock API.
@@ -348,50 +368,55 @@ class BedrockConverseStream(BedrockConverse):
         Returns:
             InvocationResponse with the generated text and metadata.
         """
-        time_flag = True
-        time_to_first_token = None
-        time_to_last_token = None
-        output_text = ""
-        metadata = None
-        error = None
+        response.id = raw_response["ResponseMetadata"].get("RequestId")
+        response.retries = raw_response["ResponseMetadata"]["RetryAttempts"]
+
+        any_content_received = False
 
         for chunk in raw_response["stream"]:
+            now = time.perf_counter()
+
             if "contentBlockDelta" in chunk:
                 delta_text = chunk["contentBlockDelta"]["delta"].get("text", "")
                 if not isinstance(delta_text, str):
                     raise TypeError("Expected string for delta text")
-                output_text += delta_text or ""
-                if time_flag:
-                    time_to_first_token = time.perf_counter() - start_t
-                    time_flag = False
+                if not any_content_received:
+                    response.time_to_first_token = now - start_t
+                    any_content_received = True
+                if delta_text:
+                    if response.response_text is None:
+                        response.response_text = delta_text
+                    else:
+                        response.response_text += delta_text
 
             if "contentBlockStop" in chunk:
-                time_to_last_token = time.perf_counter() - start_t
+                response.time_to_last_token = now - start_t
 
             if "metadata" in chunk:
-                metadata = chunk["metadata"]
+                usage = chunk["metadata"].get("usage", {})
+                input_tokens = usage.get("inputTokens")
+                if input_tokens:
+                    if response.num_tokens_input is None:
+                        response.num_tokens_input = input_tokens
+                    else:
+                        response.num_tokens_input += input_tokens
+                output_tokens = usage.get("outputTokens")
+                if output_tokens:
+                    if response.num_tokens_output is None:
+                        response.num_tokens_output = output_tokens
+                    else:
+                        response.num_tokens_output += output_tokens
+                cache_read_input_tokens = usage.get("cacheReadInputTokens")
+                if cache_read_input_tokens:
+                    if response.num_tokens_input_cached is None:
+                        response.num_tokens_input_cached = cache_read_input_tokens
+                    else:
+                        response.num_tokens_input_cached += cache_read_input_tokens
 
             # Detect Bedrock stream error events
             for error_type in BEDROCK_STREAM_ERROR_TYPES:
                 if error_type in chunk:
-                    error = f"Bedrock {error_type}: {chunk[error_type]['message']}"
-                    logger.error(error)
-                    break
-
-        response = InvocationResponse(
-            id=raw_response["ResponseMetadata"].get("RequestId"),
-            response_text=output_text,
-            time_to_last_token=time_to_last_token,
-            time_to_first_token=time_to_first_token,
-            error=error,
-        )
-
-        if metadata:
-            usage = metadata.get("usage", {})
-            response.num_tokens_input = usage.get("inputTokens")
-            response.num_tokens_output = usage.get("outputTokens")
-            response.num_tokens_input_cached = usage.get("cacheReadInputTokens")
-
-        response.retries = raw_response["ResponseMetadata"]["RetryAttempts"]
-
-        return response
+                    response.time_to_last_token = now - start_t
+                    raise RuntimeError(
+                        f"Bedrock {error_type}: {chunk[error_type]['message']}"
+                    )

--- a/llmeter/endpoints/bedrock_invoke.py
+++ b/llmeter/endpoints/bedrock_invoke.py
@@ -5,14 +5,13 @@ import json
 import logging
 import time
 from typing import Any
-from uuid import uuid4
 
 import boto3
 import jmespath
 from botocore.config import Config
-from botocore.exceptions import ClientError
 
 from .base import Endpoint, InvocationResponse
+from .bedrock import BEDROCK_STREAM_ERROR_TYPES
 
 logger = logging.getLogger(__name__)
 
@@ -169,132 +168,59 @@ class BedrockInvoke(Endpoint):
             logger.exception("Failed to create InvokeModel payload")
             raise RuntimeError(f"Failed to create payload: {str(e)}") from e
 
-    def _parse_response(self, response: dict) -> InvocationResponse:
-        """
-        Parse the response from a Bedrock InvokeModel API call.
+    def parse_response(self, response: dict, start_t: float) -> InvocationResponse:
+        """Parse the response from a Bedrock InvokeModel API call.
 
         Args:
-            response (dict): Raw response from the Bedrock API containing output text and metadata
+            response: Raw response from the Bedrock API.
+            start_t: The timestamp when the request was initiated.
 
         Returns:
-            InvocationResponse: Parsed response containing the generated text and metadata
-
-        Raises:
-            KeyError: If required fields are missing from the response
-            TypeError: If response fields have unexpected types
+            InvocationResponse with the generated text and metadata.
         """
-        try:
-            response_body_json = response["body"].read().decode("utf-8")
-            response_body = json.loads(response_body_json)
-        except json.JSONDecodeError as e:
-            logger.exception(
-                "Error parsing response as JSON. Accept header='%s'",
-                response.get("accept"),
-            )
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Failed to parse endpoint response as JSON: {e}",
-            )
+        response_body_json = response["body"].read().decode("utf-8")
+        response_body = json.loads(response_body_json)
 
-        try:
-            response_text = jmespath.search(self.generated_text_jmespath, response_body)
-            if isinstance(response_text, list):
-                response_text = "\n".join(response_text)
+        response_text = jmespath.search(self.generated_text_jmespath, response_body)
+        if isinstance(response_text, list):
+            response_text = "\n".join(response_text)
 
-            id = response_body.get("id", uuid4().hex)
-            retries = response.get("ResponseMetadata", {}).get("RetryAttempts")
-            num_tokens_input = (
-                jmespath.search(self.input_token_count_jmespath, response_body)
-                if self.input_token_count_jmespath
-                else None
-            )
-            num_tokens_output = (
-                jmespath.search(self.generated_token_count_jmespath, response_body)
-                if self.generated_token_count_jmespath
-                else None
-            )
+        id = response_body.get("id") or response.get("ResponseMetadata", {}).get(
+            "RequestId"
+        )
+        retries = response.get("ResponseMetadata", {}).get("RetryAttempts")
+        num_tokens_input = (
+            jmespath.search(self.input_token_count_jmespath, response_body)
+            if self.input_token_count_jmespath
+            else None
+        )
+        num_tokens_output = (
+            jmespath.search(self.generated_token_count_jmespath, response_body)
+            if self.generated_token_count_jmespath
+            else None
+        )
 
-            return InvocationResponse(
-                id=id,
-                response_text=response_text,
-                num_tokens_input=num_tokens_input,
-                num_tokens_output=num_tokens_output,
-                retries=retries,
-            )
-
-        except KeyError as e:
-            logger.exception(f"Missing required field in response: {e}")
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Missing required field: {e}",
-            )
-
-        except TypeError as e:
-            logger.exception(f"Unexpected type in response: {e}")
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Type error in response: {e}",
-            )
-
-        except Exception as e:
-            logger.exception(f"Error parsing InvokeModel response: {e}")
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Response parsing error: {e}",
-            )
+        return InvocationResponse(
+            id=id,
+            response_text=response_text,
+            num_tokens_input=num_tokens_input,
+            num_tokens_output=num_tokens_output,
+            retries=retries,
+        )
 
     def invoke(self, payload: dict) -> InvocationResponse:
-        """Invoke the Bedrock InvokeModel API with the given payload.
+        """Invoke the Bedrock InvokeModel API with the given payload."""
+        req_body = json.dumps(payload).encode("utf-8")
 
-        Args:
-            payload (dict): The payload containing the request parameters
-
-        Returns:
-            InvocationResponse: Response object containing generated text and metadata
-
-        Raises:
-            ClientError: If there is an error calling the Bedrock API
-            ValueError: If payload is invalid
-            TypeError: If payload is not a dictionary
-        """
-        if not isinstance(payload, dict):
-            raise TypeError("Payload must be a dictionary")
-
-        try:
-            req_body = json.dumps(payload).encode("utf-8")
-            try:
-                start_t = time.perf_counter()
-                client_response = self._bedrock_client.invoke_model(  # type: ignore
-                    accept="application/json",
-                    body=req_body,
-                    contentType="application/json",
-                    modelId=self.model_id,
-                    # TODO: Provide config for other optional arguments
-                    # trace, guardrailIdentifier/Version, performanceConfigLatency, serviceTier
-                )
-                time_to_last_token = time.perf_counter() - start_t
-            except ClientError as e:
-                logger.error(f"Bedrock API error: {e}")
-                return InvocationResponse.error_output(
-                    input_payload=payload, id=uuid4().hex, error=str(e)
-                )
-            except Exception as e:
-                logger.error(f"Unexpected error during API call: {e}")
-                return InvocationResponse.error_output(
-                    input_payload=payload, id=uuid4().hex, error=str(e)
-                )
-
-            response = self._parse_response(client_response)  # type: ignore
-            response.input_payload = payload
-            response.input_prompt = self._parse_payload(payload)
-            response.time_to_last_token = time_to_last_token
-            return response
-
-        except Exception as e:
-            logger.error(f"Error in invoke method: {e}")
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
+        client_response = self._bedrock_client.invoke_model(  # type: ignore
+            accept="application/json",
+            body=req_body,
+            contentType="application/json",
+            modelId=self.model_id,
+            # TODO: Provide config for other optional arguments
+            # trace, guardrailIdentifier/Version, performanceConfigLatency, serviceTier
+        )
+        return self.parse_response(client_response, self._start_t)  # type: ignore
 
 
 class BedrockInvokeStream(BedrockInvoke):
@@ -354,138 +280,86 @@ class BedrockInvokeStream(BedrockInvoke):
 
     def invoke(self, payload: dict) -> InvocationResponse:
         req_body = json.dumps(payload).encode("utf-8")
-        try:
-            start_t = time.perf_counter()
-            client_response = self._bedrock_client.invoke_model_with_response_stream(  # type: ignore
-                accept="application/json",
-                body=req_body,
-                contentType="application/json",
-                modelId=self.model_id,
-                # TODO: Provide config for other optional arguments
-                # trace, guardrailIdentifier/Version, performanceConfigLatency, serviceTier
-            )
-        except (ClientError, Exception) as e:
-            logger.error(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-        response = self._parse_response_stream(client_response, start_t)
-        response.input_payload = payload
-        response.input_prompt = self._parse_payload(payload)
-        return response
 
-    def _parse_response_stream(
-        self, client_response, start_t: float
-    ) -> InvocationResponse:
-        """Parse the streaming response from Bedrock InovkeModel API.
+        client_response = self._bedrock_client.invoke_model_with_response_stream(  # type: ignore
+            accept="application/json",
+            body=req_body,
+            contentType="application/json",
+            modelId=self.model_id,
+            # TODO: Provide config for other optional arguments
+            # trace, guardrailIdentifier/Version, performanceConfigLatency, serviceTier
+        )
+        return self.parse_response(client_response, self._start_t)
+
+    def parse_response(self, client_response, start_t: float) -> InvocationResponse:
+        """Parse the streaming response from Bedrock InvokeModel API.
 
         Args:
-            client_response (dict): The raw response from the Bedrock API
-            start_t (float): The timestamp when the request was initiated
+            client_response: The raw response from the Bedrock API.
+            start_t: The timestamp when the request was initiated.
 
         Returns:
-            InvocationResponse: Parsed response containing the generated text and metadata
-
-        Raises:
-            KeyError: If required fields are missing from the response
-            TypeError: If response fields have unexpected types
+            InvocationResponse with the generated text and metadata.
         """
         output_text = ""
         chunks = []
         time_to_first_token = None
         time_to_last_token = None
+        error = None
 
-        try:
-            for event in client_response["body"]:
-                if "chunk" in event:
-                    chunk_bytes = event["chunk"]["bytes"]
-                    chunk_data = json.loads(chunk_bytes)
-                    chunk_text = jmespath.search(
-                        self.generated_text_jmespath, chunk_data
-                    )
-                    if isinstance(chunk_text, list):
-                        chunk_text = "".join(chunk_text)
-                    if chunk_text:
-                        now = time.perf_counter()
-                        if time_to_first_token is None:
-                            time_to_first_token = now - start_t
-                        time_to_last_token = now - start_t
-                        output_text += chunk_text
-                    chunks.append(chunk_data)
-                else:
-                    for etype in (
-                        "internalServerException",
-                        "modelStreamErrorException",
-                        "validationException",
-                        "throttlingException",
-                        "modelTimeoutException",
-                        "serviceUnavailableException",
-                    ):
-                        if etype in event:
-                            msg = f"Bedrock {etype}: {event[etype]['message']}"
-                            logger.error(msg)
-                            return InvocationResponse.error_output(
-                                id=uuid4().hex,
-                                error=msg,
-                            )
-                    # Unknown event type - probably an error
-                    return InvocationResponse.error_output(
-                        id=uuid4().hex,
-                        error=f"Unknown event type in response stream: {event}",
-                    )
+        for event in client_response["body"]:
+            if "chunk" in event:
+                chunk_bytes = event["chunk"]["bytes"]
+                chunk_data = json.loads(chunk_bytes)
+                chunk_text = jmespath.search(self.generated_text_jmespath, chunk_data)
+                if isinstance(chunk_text, list):
+                    chunk_text = "".join(chunk_text)
+                if chunk_text:
+                    now = time.perf_counter()
+                    if time_to_first_token is None:
+                        time_to_first_token = now - start_t
+                    time_to_last_token = now - start_t
+                    output_text += chunk_text
+                chunks.append(chunk_data)
+            else:
+                # Non-chunk events: check for Bedrock error events, skip
+                # everything else (e.g. messageStart, contentBlockStart).
+                for error_type in BEDROCK_STREAM_ERROR_TYPES:
+                    if error_type in event:
+                        error = f"Bedrock {error_type}: {event[error_type]['message']}"
+                        logger.error(error)
+                        break
 
-            # Post-process additional data from chunks:
-            # (Which we do after performance timing, to avoid counting JMESPath overhead)
-            num_tokens_input = None
-            num_tokens_output = None
-            resp_id = None
-            for chunk in chunks:
-                if "id" in chunk:
-                    resp_id = chunk["id"]
-                # Usage counts should only appear once in the stream. We'll overwrite if duplicated:
-                chk_tokens_input = (
-                    jmespath.search(self.input_token_count_jmespath, chunk)
-                    if self.input_token_count_jmespath
-                    else None
-                )
-                if chk_tokens_input is not None:
-                    num_tokens_input = chk_tokens_input
-                chk_tokens_output = (
-                    jmespath.search(self.generated_token_count_jmespath, chunk)
-                    if self.generated_token_count_jmespath
-                    else None
-                )
-                if chk_tokens_output is not None:
-                    num_tokens_output = chk_tokens_output
+        # Post-process additional data from chunks
+        # (after performance timing, to avoid counting JMESPath overhead)
+        num_tokens_input = None
+        num_tokens_output = None
+        resp_id = None
+        for chunk in chunks:
+            if "id" in chunk:
+                resp_id = chunk["id"]
+            chk_tokens_input = (
+                jmespath.search(self.input_token_count_jmespath, chunk)
+                if self.input_token_count_jmespath
+                else None
+            )
+            if chk_tokens_input is not None:
+                num_tokens_input = chk_tokens_input
+            chk_tokens_output = (
+                jmespath.search(self.generated_token_count_jmespath, chunk)
+                if self.generated_token_count_jmespath
+                else None
+            )
+            if chk_tokens_output is not None:
+                num_tokens_output = chk_tokens_output
 
-            response = InvocationResponse(
-                id=resp_id or uuid4().hex,
-                response_text=output_text,
-                time_to_first_token=time_to_first_token,
-                time_to_last_token=time_to_last_token,
-                num_tokens_input=num_tokens_input,
-                num_tokens_output=num_tokens_output,
-                retries=client_response.get("ResponseMetadata", {}).get(
-                    "RetryAttempts"
-                ),
-            )
-            return response
-
-        except KeyError as e:
-            logger.error(f"Missing required field in response: {e}")
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Missing required field: {e}",
-            )
-        except TypeError as e:
-            logger.error(f"Unexpected type in response: {e}")
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Type error in response: {e}",
-            )
-        except Exception as e:
-            logger.error(f"Error parsing response stream: {e}")
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Stream parsing error: {e}",
-            )
+        return InvocationResponse(
+            id=resp_id or client_response.get("ResponseMetadata", {}).get("RequestId"),
+            response_text=output_text,
+            time_to_first_token=time_to_first_token,
+            time_to_last_token=time_to_last_token,
+            num_tokens_input=num_tokens_input,
+            num_tokens_output=num_tokens_output,
+            error=error,
+            retries=client_response.get("ResponseMetadata", {}).get("RetryAttempts"),
+        )

--- a/llmeter/endpoints/bedrock_invoke.py
+++ b/llmeter/endpoints/bedrock_invoke.py
@@ -4,59 +4,50 @@
 import json
 import logging
 import time
-from typing import Any
+from typing import Any, Generic, TypeVar
 
 import boto3
 import jmespath
 from botocore.config import Config
 
-from .base import Endpoint, InvocationResponse, llmeter_invoke
+try:
+    from mypy_boto3_bedrock_runtime.type_defs import (
+        InvokeModelResponseTypeDef,
+        InvokeModelWithResponseStreamResponseTypeDef,
+    )
+except ImportError:
+    InvokeModelResponseTypeDef = TypeVar("InvokeModelResponseTypeDef")
+    InvokeModelWithResponseStreamResponseTypeDef = TypeVar(
+        "InvokeModelWithResponseStreamResponseTypeDef"
+    )
+
+from .base import Endpoint, InvocationResponse
 from .bedrock import BEDROCK_STREAM_ERROR_TYPES
 
 logger = logging.getLogger(__name__)
 
+TBedrockInvokeResponse = TypeVar(
+    "TBedrockInvokeResponse",
+    bound=InvokeModelResponseTypeDef | InvokeModelWithResponseStreamResponseTypeDef,
+)
 
-class BedrockInvoke(Endpoint):
-    """LLMeter Endpoint for Amazon Bedrock InvokeModel API (non-streaming)"""
 
+class BedrockInvokeBase(
+    Endpoint[TBedrockInvokeResponse], Generic[TBedrockInvokeResponse]
+):
     def __init__(
         self,
         model_id: str,
+        generated_text_jmespath: str,
+        input_text_jmespath: str,
+        generated_token_count_jmespath: str | None = None,
+        input_token_count_jmespath: str | None = None,
         endpoint_name: str | None = None,
         region: str | None = None,
         bedrock_boto3_client: Any = None,
         max_attempts: int = 3,
-        generated_text_jmespath: str = "choices[0].message.content",
-        generated_token_count_jmespath: str | None = "usage.completion_tokens",
-        input_text_jmespath: str = "messages[].content[].text",
-        input_token_count_jmespath: str | None = "usage.prompt_tokens",
     ):
-        """Create a BedrockInvoke Endpoint
-
-        The default ..._jmespath parameters assume your target model uses an OpenAI
-        ChatCompletions-like API, which is true for many (but not all) Bedrock models. You'll need
-        to override these if targeting a model with different request/response format.
-
-        Args:
-            model_id:
-                The identifier for the model to use
-            endpoint_name:
-                Name of the endpoint. Defaults to None.
-            region:
-                AWS region to use. Defaults to bedrock_boto3_client's, or configured from AWS CLI.
-            bedrock_boto3_client:
-                Optional pre-configured boto3 client, otherwise one will be created.
-            max_attempts:
-                Maximum number of retry attempts. Defaults to 3.
-            generated_text_jmespath:
-                JMESPath query to extract generated text from model response.
-            generated_token_count_jmespath:
-                JMESPath query to extract generated token count from model response.
-            input_text_jmespath:
-                JMESPath query to extract input text from the model request payload.
-            input_token_count_jmespath:
-                JMESPath query to extract input token count from the response.
-        """
+        """Shared constructor logic for Bedrock Invoke*-API endpoints"""
         super().__init__(
             model_id=model_id,
             endpoint_name=endpoint_name or "amazon bedrock",
@@ -168,48 +159,100 @@ class BedrockInvoke(Endpoint):
             logger.exception("Failed to create InvokeModel payload")
             raise RuntimeError(f"Failed to create payload: {str(e)}") from e
 
-    def parse_response(self, raw_response: dict, start_t: float) -> InvocationResponse:
+
+class BedrockInvoke(BedrockInvokeBase[InvokeModelResponseTypeDef]):
+    """LLMeter Endpoint for Amazon Bedrock InvokeModel API (non-streaming)"""
+
+    def __init__(
+        self,
+        model_id: str,
+        endpoint_name: str | None = None,
+        region: str | None = None,
+        bedrock_boto3_client: Any = None,
+        max_attempts: int = 3,
+        generated_text_jmespath: str = "choices[0].message.content",
+        generated_token_count_jmespath: str | None = "usage.completion_tokens",
+        input_text_jmespath: str = "messages[].content[].text",
+        input_token_count_jmespath: str | None = "usage.prompt_tokens",
+    ):
+        """Create a Bedrock InvokeModel API-based Endpoint
+
+        The default ..._jmespath parameters assume your target model uses an OpenAI
+        ChatCompletions-like API, which is true for many (but not all) Bedrock models. You'll need
+        to override these if targeting a model with different request/response format.
+
+        Args:
+            model_id:
+                The identifier for the model to use
+            endpoint_name:
+                Name of the endpoint. Defaults to None.
+            region:
+                AWS region to use. Defaults to bedrock_boto3_client's, or configured from AWS CLI.
+            bedrock_boto3_client:
+                Optional pre-configured boto3 client, otherwise one will be created.
+            max_attempts:
+                Maximum number of retry attempts. Defaults to 3.
+            generated_text_jmespath:
+                JMESPath query to extract generated text from model response.
+            generated_token_count_jmespath:
+                JMESPath query to extract generated token count from model response.
+            input_text_jmespath:
+                JMESPath query to extract input text from the model request payload.
+            input_token_count_jmespath:
+                JMESPath query to extract input token count from the response.
+        """
+        super().__init__(
+            model_id=model_id,
+            endpoint_name=endpoint_name,
+            region=region,
+            bedrock_boto3_client=bedrock_boto3_client,
+            max_attempts=max_attempts,
+            generated_text_jmespath=generated_text_jmespath,
+            generated_token_count_jmespath=generated_token_count_jmespath,
+            input_text_jmespath=input_text_jmespath,
+            input_token_count_jmespath=input_token_count_jmespath,
+        )
+
+    def process_raw_response(
+        self, raw_response, start_t: float, response: InvocationResponse
+    ) -> None:
         """Parse the response from a Bedrock InvokeModel API call.
 
         Args:
-            response: Raw response from the Bedrock API.
+            raw_response: Raw response from the Bedrock API.
             start_t: The timestamp when the request was initiated.
-
-        Returns:
-            InvocationResponse with the generated text and metadata.
+            response: LLMeter InvocationResponse object on which results will be saved (in-place)
         """
         response_body_json = raw_response["body"].read().decode("utf-8")
+        # Stop timer as soon as response is fully received, before parsing out components:
+        response.time_to_last_token = time.perf_counter() - start_t
+
         response_body = json.loads(response_body_json)
+
+        response.id = response_body.get("id") or raw_response.get(
+            "ResponseMetadata", {}
+        ).get("RequestId")
+        response.retries = raw_response.get("ResponseMetadata", {}).get("RetryAttempts")
 
         response_text = jmespath.search(self.generated_text_jmespath, response_body)
         if isinstance(response_text, list):
             response_text = "\n".join(response_text)
+        response.response_text = response_text
 
-        id = response_body.get("id") or raw_response.get("ResponseMetadata", {}).get(
-            "RequestId"
-        )
-        retries = raw_response.get("ResponseMetadata", {}).get("RetryAttempts")
-        num_tokens_input = (
+        response.num_tokens_input = (
             jmespath.search(self.input_token_count_jmespath, response_body)
             if self.input_token_count_jmespath
             else None
         )
-        num_tokens_output = (
+        response.num_tokens_output = (
             jmespath.search(self.generated_token_count_jmespath, response_body)
             if self.generated_token_count_jmespath
             else None
         )
+        # TODO: Count cache read tokens if returned by this endpoint?
 
-        return InvocationResponse(
-            id=id,
-            response_text=response_text,
-            num_tokens_input=num_tokens_input,
-            num_tokens_output=num_tokens_output,
-            retries=retries,
-        )
-
-    @llmeter_invoke
-    def invoke(self, payload: dict):
+    @BedrockInvokeBase.llmeter_invoke
+    def invoke(self, payload: dict) -> InvokeModelResponseTypeDef:
         """Invoke the Bedrock InvokeModel API with the given payload."""
         req_body = json.dumps(payload).encode("utf-8")
 
@@ -224,7 +267,9 @@ class BedrockInvoke(Endpoint):
         return client_response
 
 
-class BedrockInvokeStream(BedrockInvoke):
+class BedrockInvokeStream(
+    BedrockInvokeBase[InvokeModelWithResponseStreamResponseTypeDef]
+):
     """LLMeter Endpoint for Amazon Bedrock InvokeModelWithResponseStream API"""
 
     def __init__(
@@ -241,7 +286,7 @@ class BedrockInvokeStream(BedrockInvoke):
         input_token_count_jmespath: str
         | None = '"amazon-bedrock-invocationMetrics".inputTokenCount',
     ):
-        """Create a BedrockInvokeStream Endpoint
+        """Create a Bedrock InvokeModelWithResponseStream API-based Endpoint
 
         The default ..._jmespath parameters assume your target model uses an OpenAI
         ChatCompletions-like streaming API, which is true for many (but not all) Bedrock models.
@@ -279,11 +324,15 @@ class BedrockInvokeStream(BedrockInvoke):
             input_token_count_jmespath=input_token_count_jmespath,
         )
 
-    @llmeter_invoke
+    @BedrockInvokeBase.llmeter_invoke
     def invoke(self, payload: dict):
+        # Note we've *deliberately chosen* to keep this JSON serialization in the invoke method
+        # (which is timed) and not prepare_payload (which would avoid timing), on the basis that
+        # every endpoint/SDK will ultimately need to convert the payload dict to a serialized
+        # representation for transport, so it's only fair.
         req_body = json.dumps(payload).encode("utf-8")
 
-        client_response = self._bedrock_client.invoke_model_with_response_stream(  # type: ignore
+        client_response = self._bedrock_client.invoke_model_with_response_stream(
             accept="application/json",
             body=req_body,
             contentType="application/json",
@@ -293,8 +342,10 @@ class BedrockInvokeStream(BedrockInvoke):
         )
         return client_response
 
-    def parse_response(self, raw_response, start_t: float) -> InvocationResponse:
-        """Parse the streaming response from Bedrock InvokeModel API.
+    def process_raw_response(
+        self, raw_response, start_t: float, response: InvocationResponse
+    ) -> None:
+        """Parse the streaming response from Bedrock InvokeModelWithResponseStream API.
 
         Args:
             client_response: The raw response from the Bedrock API.
@@ -303,65 +354,60 @@ class BedrockInvokeStream(BedrockInvoke):
         Returns:
             InvocationResponse with the generated text and metadata.
         """
-        output_text = ""
         chunks = []
-        time_to_first_token = None
-        time_to_last_token = None
-        error = None
+        resp_meta = raw_response.get("ResponseMetadata", {})
+        response.id = resp_meta.get("RequestId")
+        response.retries = resp_meta.get("RetryAttempts")
+        response.time_to_first_token = None
+        response.time_to_last_token = None
 
         for event in raw_response["body"]:
+            now = time.perf_counter()
             if "chunk" in event:
                 chunk_bytes = event["chunk"]["bytes"]
                 chunk_data = json.loads(chunk_bytes)
+                if "id" in chunk_data:
+                    response.id = chunk_data["id"]
                 chunk_text = jmespath.search(self.generated_text_jmespath, chunk_data)
                 if isinstance(chunk_text, list):
                     chunk_text = "".join(chunk_text)
                 if chunk_text:
-                    now = time.perf_counter()
-                    if time_to_first_token is None:
-                        time_to_first_token = now - start_t
-                    time_to_last_token = now - start_t
-                    output_text += chunk_text
+                    if response.time_to_first_token is None:
+                        response.time_to_first_token = now - start_t
+                    response.time_to_last_token = now - start_t
+                    if response.response_text is None:
+                        response.response_text = chunk_text
+                    else:
+                        response.response_text += chunk_text
                 chunks.append(chunk_data)
             else:
                 # Non-chunk events: check for Bedrock error events, skip
                 # everything else (e.g. messageStart, contentBlockStart).
                 for error_type in BEDROCK_STREAM_ERROR_TYPES:
                     if error_type in event:
-                        error = f"Bedrock {error_type}: {event[error_type]['message']}"
-                        logger.error(error)
+                        response.error = (
+                            f"Bedrock {error_type}: {event[error_type]['message']}"
+                        )
+                        response.time_to_last_token = now - start_t
+                        # We don't throw error here yet , because we still want to try and loop
+                        # through the received chunks again below.
                         break
 
-        # Post-process additional data from chunks
+        # Post-process additional (token count) data from chunks
         # (after performance timing, to avoid counting JMESPath overhead)
-        num_tokens_input = None
-        num_tokens_output = None
-        resp_id = None
+        # TODO: Count cache read tokens if returned by this endpoint?
         for chunk in chunks:
-            if "id" in chunk:
-                resp_id = chunk["id"]
             chk_tokens_input = (
                 jmespath.search(self.input_token_count_jmespath, chunk)
                 if self.input_token_count_jmespath
                 else None
             )
             if chk_tokens_input is not None:
-                num_tokens_input = chk_tokens_input
+                response.num_tokens_input = chk_tokens_input
             chk_tokens_output = (
                 jmespath.search(self.generated_token_count_jmespath, chunk)
                 if self.generated_token_count_jmespath
                 else None
             )
             if chk_tokens_output is not None:
-                num_tokens_output = chk_tokens_output
-
-        return InvocationResponse(
-            id=resp_id or raw_response.get("ResponseMetadata", {}).get("RequestId"),
-            response_text=output_text,
-            time_to_first_token=time_to_first_token,
-            time_to_last_token=time_to_last_token,
-            num_tokens_input=num_tokens_input,
-            num_tokens_output=num_tokens_output,
-            error=error,
-            retries=raw_response.get("ResponseMetadata", {}).get("RetryAttempts"),
-        )
+                response.num_tokens_output = chk_tokens_output

--- a/llmeter/endpoints/bedrock_invoke.py
+++ b/llmeter/endpoints/bedrock_invoke.py
@@ -168,7 +168,7 @@ class BedrockInvoke(Endpoint):
             logger.exception("Failed to create InvokeModel payload")
             raise RuntimeError(f"Failed to create payload: {str(e)}") from e
 
-    def parse_response(self, response: dict, start_t: float) -> InvocationResponse:
+    def parse_response(self, raw_response: dict, start_t: float) -> InvocationResponse:
         """Parse the response from a Bedrock InvokeModel API call.
 
         Args:
@@ -178,17 +178,17 @@ class BedrockInvoke(Endpoint):
         Returns:
             InvocationResponse with the generated text and metadata.
         """
-        response_body_json = response["body"].read().decode("utf-8")
+        response_body_json = raw_response["body"].read().decode("utf-8")
         response_body = json.loads(response_body_json)
 
         response_text = jmespath.search(self.generated_text_jmespath, response_body)
         if isinstance(response_text, list):
             response_text = "\n".join(response_text)
 
-        id = response_body.get("id") or response.get("ResponseMetadata", {}).get(
+        id = response_body.get("id") or raw_response.get("ResponseMetadata", {}).get(
             "RequestId"
         )
-        retries = response.get("ResponseMetadata", {}).get("RetryAttempts")
+        retries = raw_response.get("ResponseMetadata", {}).get("RetryAttempts")
         num_tokens_input = (
             jmespath.search(self.input_token_count_jmespath, response_body)
             if self.input_token_count_jmespath
@@ -209,7 +209,7 @@ class BedrockInvoke(Endpoint):
         )
 
     @llmeter_invoke
-    def invoke(self, payload: dict) -> InvocationResponse:
+    def invoke(self, payload: dict):
         """Invoke the Bedrock InvokeModel API with the given payload."""
         req_body = json.dumps(payload).encode("utf-8")
 
@@ -221,7 +221,7 @@ class BedrockInvoke(Endpoint):
             # TODO: Provide config for other optional arguments
             # trace, guardrailIdentifier/Version, performanceConfigLatency, serviceTier
         )
-        return client_response  # type: ignore
+        return client_response
 
 
 class BedrockInvokeStream(BedrockInvoke):
@@ -280,7 +280,7 @@ class BedrockInvokeStream(BedrockInvoke):
         )
 
     @llmeter_invoke
-    def invoke(self, payload: dict) -> InvocationResponse:
+    def invoke(self, payload: dict):
         req_body = json.dumps(payload).encode("utf-8")
 
         client_response = self._bedrock_client.invoke_model_with_response_stream(  # type: ignore
@@ -293,7 +293,7 @@ class BedrockInvokeStream(BedrockInvoke):
         )
         return client_response
 
-    def parse_response(self, client_response, start_t: float) -> InvocationResponse:
+    def parse_response(self, raw_response, start_t: float) -> InvocationResponse:
         """Parse the streaming response from Bedrock InvokeModel API.
 
         Args:
@@ -309,7 +309,7 @@ class BedrockInvokeStream(BedrockInvoke):
         time_to_last_token = None
         error = None
 
-        for event in client_response["body"]:
+        for event in raw_response["body"]:
             if "chunk" in event:
                 chunk_bytes = event["chunk"]["bytes"]
                 chunk_data = json.loads(chunk_bytes)
@@ -356,12 +356,12 @@ class BedrockInvokeStream(BedrockInvoke):
                 num_tokens_output = chk_tokens_output
 
         return InvocationResponse(
-            id=resp_id or client_response.get("ResponseMetadata", {}).get("RequestId"),
+            id=resp_id or raw_response.get("ResponseMetadata", {}).get("RequestId"),
             response_text=output_text,
             time_to_first_token=time_to_first_token,
             time_to_last_token=time_to_last_token,
             num_tokens_input=num_tokens_input,
             num_tokens_output=num_tokens_output,
             error=error,
-            retries=client_response.get("ResponseMetadata", {}).get("RetryAttempts"),
+            retries=raw_response.get("ResponseMetadata", {}).get("RetryAttempts"),
         )

--- a/llmeter/endpoints/bedrock_invoke.py
+++ b/llmeter/endpoints/bedrock_invoke.py
@@ -211,6 +211,7 @@ class BedrockInvoke(Endpoint):
     @llmeter_invoke
     def invoke(self, payload: dict) -> InvocationResponse:
         """Invoke the Bedrock InvokeModel API with the given payload."""
+        start_t = time.perf_counter()
         req_body = json.dumps(payload).encode("utf-8")
 
         client_response = self._bedrock_client.invoke_model(  # type: ignore
@@ -221,7 +222,7 @@ class BedrockInvoke(Endpoint):
             # TODO: Provide config for other optional arguments
             # trace, guardrailIdentifier/Version, performanceConfigLatency, serviceTier
         )
-        return self.parse_response(client_response, self._start_t)  # type: ignore
+        return self.parse_response(client_response, start_t)  # type: ignore
 
 
 class BedrockInvokeStream(BedrockInvoke):
@@ -281,6 +282,7 @@ class BedrockInvokeStream(BedrockInvoke):
 
     @llmeter_invoke
     def invoke(self, payload: dict) -> InvocationResponse:
+        start_t = time.perf_counter()
         req_body = json.dumps(payload).encode("utf-8")
 
         client_response = self._bedrock_client.invoke_model_with_response_stream(  # type: ignore
@@ -291,7 +293,7 @@ class BedrockInvokeStream(BedrockInvoke):
             # TODO: Provide config for other optional arguments
             # trace, guardrailIdentifier/Version, performanceConfigLatency, serviceTier
         )
-        return self.parse_response(client_response, self._start_t)
+        return self.parse_response(client_response, start_t)
 
     def parse_response(self, client_response, start_t: float) -> InvocationResponse:
         """Parse the streaming response from Bedrock InvokeModel API.

--- a/llmeter/endpoints/bedrock_invoke.py
+++ b/llmeter/endpoints/bedrock_invoke.py
@@ -211,7 +211,6 @@ class BedrockInvoke(Endpoint):
     @llmeter_invoke
     def invoke(self, payload: dict) -> InvocationResponse:
         """Invoke the Bedrock InvokeModel API with the given payload."""
-        start_t = time.perf_counter()
         req_body = json.dumps(payload).encode("utf-8")
 
         client_response = self._bedrock_client.invoke_model(  # type: ignore
@@ -222,7 +221,7 @@ class BedrockInvoke(Endpoint):
             # TODO: Provide config for other optional arguments
             # trace, guardrailIdentifier/Version, performanceConfigLatency, serviceTier
         )
-        return self.parse_response(client_response, start_t)  # type: ignore
+        return client_response  # type: ignore
 
 
 class BedrockInvokeStream(BedrockInvoke):
@@ -282,7 +281,6 @@ class BedrockInvokeStream(BedrockInvoke):
 
     @llmeter_invoke
     def invoke(self, payload: dict) -> InvocationResponse:
-        start_t = time.perf_counter()
         req_body = json.dumps(payload).encode("utf-8")
 
         client_response = self._bedrock_client.invoke_model_with_response_stream(  # type: ignore
@@ -293,7 +291,7 @@ class BedrockInvokeStream(BedrockInvoke):
             # TODO: Provide config for other optional arguments
             # trace, guardrailIdentifier/Version, performanceConfigLatency, serviceTier
         )
-        return self.parse_response(client_response, start_t)
+        return client_response
 
     def parse_response(self, client_response, start_t: float) -> InvocationResponse:
         """Parse the streaming response from Bedrock InvokeModel API.

--- a/llmeter/endpoints/bedrock_invoke.py
+++ b/llmeter/endpoints/bedrock_invoke.py
@@ -10,7 +10,7 @@ import boto3
 import jmespath
 from botocore.config import Config
 
-from .base import Endpoint, InvocationResponse
+from .base import Endpoint, InvocationResponse, llmeter_invoke
 from .bedrock import BEDROCK_STREAM_ERROR_TYPES
 
 logger = logging.getLogger(__name__)
@@ -208,6 +208,7 @@ class BedrockInvoke(Endpoint):
             retries=retries,
         )
 
+    @llmeter_invoke
     def invoke(self, payload: dict) -> InvocationResponse:
         """Invoke the Bedrock InvokeModel API with the given payload."""
         req_body = json.dumps(payload).encode("utf-8")
@@ -278,6 +279,7 @@ class BedrockInvokeStream(BedrockInvoke):
             input_token_count_jmespath=input_token_count_jmespath,
         )
 
+    @llmeter_invoke
     def invoke(self, payload: dict) -> InvocationResponse:
         req_body = json.dumps(payload).encode("utf-8")
 

--- a/llmeter/endpoints/litellm.py
+++ b/llmeter/endpoints/litellm.py
@@ -6,7 +6,6 @@ import logging
 import os
 import time
 from typing import Any, Sequence
-from uuid import uuid4
 
 import litellm
 from litellm import CustomStreamWrapper, completion
@@ -44,6 +43,11 @@ class LiteLLMBase(Endpoint):
     def _parse_payload(self, payload):
         return json.dumps(payload.get("messages"))
 
+    def prepare_payload(self, payload, **kwargs):
+        if kwargs:
+            payload = {**payload, **kwargs}
+        return payload
+
     @staticmethod
     def create_payload(
         user_message: str | Sequence[str],
@@ -76,25 +80,14 @@ class LiteLLMBase(Endpoint):
 
 
 class LiteLLM(LiteLLMBase):
-    def invoke(self, payload, **kwargs):
-        try:
-            response = completion(model=self.litellm_model, **payload, **kwargs)
-            if not isinstance(response, ModelResponse):
-                raise ValueError(f"Expected ModelResponse, got {type(response)}")
-            response = self._parse_converse_response(response)
-            response.input_prompt = self._parse_payload(payload)
-            return response
+    def invoke(self, payload):
+        response = completion(model=self.litellm_model, **payload)
+        if not isinstance(response, ModelResponse):
+            raise ValueError(f"Expected ModelResponse, got {type(response)}")
+        return self.parse_response(response, self._start_t)
 
-        except Exception as e:
-            logger.exception(e)
-            response = InvocationResponse.error_output(
-                input_payload=payload, error=str(e), id=uuid4().hex
-            )
-            response.input_prompt = self._parse_payload(payload)
-            return response
-
-    def _parse_converse_response(
-        self, client_response: ModelResponse
+    def parse_response(
+        self, client_response: ModelResponse, start_t: float
     ) -> InvocationResponse:
         response = InvocationResponse(
             id=client_response.id,
@@ -111,15 +104,21 @@ class LiteLLM(LiteLLMBase):
 
 
 class LiteLLMStreaming(LiteLLMBase):
-    def invoke(self, payload, **kwargs):
+    def invoke(self, payload):
+        response = completion(model=self.litellm_model, **payload)
+
+        if not isinstance(response, CustomStreamWrapper):
+            raise ValueError(f"Expected CustomStreamWrapper, got {type(response)}")
+        return self.parse_response(response, self._start_t)
+
+    def prepare_payload(self, payload, **kwargs):
         # Make a copy of payload to avoid modifying the original
         payload_copy = payload.copy()
 
-        # Create a clean kwargs dict without conflicting parameters
-        clean_kwargs = {}
+        # Merge kwargs, excluding stream-related keys (we control those)
         for key, value in kwargs.items():
             if key not in ["stream", "stream_options"]:
-                clean_kwargs[key] = value
+                payload_copy[key] = value
 
         # Ensure streaming is enabled
         payload_copy["stream"] = True
@@ -131,30 +130,12 @@ class LiteLLMStreaming(LiteLLMBase):
         elif "stream_options" not in payload_copy:
             payload_copy["stream_options"] = {"include_usage": True}
         else:
-            # Merge with existing stream_options in payload if present
             existing_options = payload_copy.get("stream_options", {})
             payload_copy["stream_options"] = {**existing_options, "include_usage": True}
 
-        try:
-            start_t = time.perf_counter()
-            response = completion(
-                model=self.litellm_model, **payload_copy, **clean_kwargs
-            )
-        except Exception as e:
-            logger.exception(e)
-            response = InvocationResponse.error_output(
-                input_payload=payload, error=str(e), id=uuid4().hex
-            )
-            response.input_prompt = self._parse_payload(payload)
-            return response
+        return payload_copy
 
-        if not isinstance(response, CustomStreamWrapper):
-            raise ValueError(f"Expected CustomStreamWrapper, got {type(response)}")
-        response = self._parse_stream(response, start_t)
-        response.input_prompt = self._parse_payload(payload)
-        return response
-
-    def _parse_stream(
+    def parse_response(
         self, client_response: CustomStreamWrapper, start_t: float
     ) -> InvocationResponse:
         usage = None

--- a/llmeter/endpoints/litellm.py
+++ b/llmeter/endpoints/litellm.py
@@ -85,14 +85,14 @@ class LiteLLM(LiteLLMBase):
         return completion(model=self.litellm_model, **payload)
 
     def parse_response(
-        self, client_response: ModelResponse, start_t: float
+        self, raw_response: ModelResponse, start_t: float
     ) -> InvocationResponse:
         response = InvocationResponse(
-            id=client_response.id,
-            response_text=client_response.choices[0].message.content,  # type: ignore
+            id=raw_response.id,
+            response_text=raw_response.choices[0].message.content,  # type: ignore
         )
         try:
-            usage = client_response.usage  # type: ignore
+            usage = raw_response.usage  # type: ignore
             response.num_tokens_input = usage.prompt_tokens
             response.num_tokens_output = usage.completion_tokens
         except AttributeError:
@@ -131,7 +131,7 @@ class LiteLLMStreaming(LiteLLMBase):
         return payload_copy
 
     def parse_response(
-        self, client_response: CustomStreamWrapper, start_t: float
+        self, raw_response: CustomStreamWrapper, start_t: float
     ) -> InvocationResponse:
         usage = None
         time_flag = True
@@ -139,7 +139,7 @@ class LiteLLMStreaming(LiteLLMBase):
         output_text = ""
         id = None
 
-        for chunk in client_response:
+        for chunk in raw_response:
             content = chunk.choices[0].delta.content or ""  # type: ignore
             output_text += content
 

--- a/llmeter/endpoints/litellm.py
+++ b/llmeter/endpoints/litellm.py
@@ -5,14 +5,14 @@ import json
 import logging
 import os
 import time
-from typing import Any, Sequence
+from typing import Any, Generic, Sequence, TypeVar
 
 import litellm
 from litellm import CustomStreamWrapper, completion
 from litellm.types.utils import ModelResponse
 from litellm.utils import get_llm_provider  # type: ignore
 
-from . import Endpoint, InvocationResponse, llmeter_invoke
+from . import Endpoint, InvocationResponse
 
 logger = logging.getLogger(__name__)
 
@@ -23,8 +23,15 @@ litellm.suppress_debug_info = True
 os.environ["LITELLM_LOG"] = "CRITICAL"
 os.environ["LITELLM_DONT_SHOW_FEEDBACK_BOX"] = "true"
 
+TLiteLLMResponseBase = TypeVar(
+    "TLiteLLMResponseBase",
+    bound=CustomStreamWrapper | ModelResponse,
+)
 
-class LiteLLMBase(Endpoint):
+
+class LiteLLMBase(Endpoint[TLiteLLMResponseBase], Generic[TLiteLLMResponseBase]):
+    """Base class for (streaming or non-streaming) LiteLLM-based Endpoints"""
+
     def __init__(
         self,
         litellm_model: str,
@@ -42,11 +49,6 @@ class LiteLLMBase(Endpoint):
 
     def _parse_payload(self, payload):
         return json.dumps(payload.get("messages"))
-
-    def prepare_payload(self, payload, **kwargs):
-        if kwargs:
-            payload = {**payload, **kwargs}
-        return payload
 
     @staticmethod
     def create_payload(
@@ -79,18 +81,29 @@ class LiteLLMBase(Endpoint):
         return payload
 
 
-class LiteLLM(LiteLLMBase):
-    @llmeter_invoke
-    def invoke(self, payload):
-        return completion(model=self.litellm_model, **payload)
+class LiteLLM(LiteLLMBase[ModelResponse]):
+    """Endpoint for LiteLLM SDK-based models (non-streaming mode)"""
 
-    def parse_response(
-        self, raw_response: ModelResponse, start_t: float
-    ) -> InvocationResponse:
-        response = InvocationResponse(
-            id=raw_response.id,
-            response_text=raw_response.choices[0].message.content,  # type: ignore
-        )
+    @LiteLLMBase.llmeter_invoke
+    def invoke(self, payload) -> ModelResponse:
+        # In non-streaming mode, completion always returns a ModelResponse:
+        return completion(**payload)  # type: ignore
+
+    def prepare_payload(self, payload: dict) -> dict:
+        # Make a copy of payload to avoid modifying the original
+        payload_copy = payload.copy()
+        # Ensure correct model ID
+        payload_copy["model"] = self.litellm_model
+        # Ensure streaming is disabled
+        payload_copy["stream"] = False
+        return payload_copy
+
+    def process_raw_response(
+        self, raw_response, start_t: float, response: InvocationResponse
+    ) -> None:
+        response.time_to_last_token = time.perf_counter() - start_t
+        response.id = raw_response.id
+
         try:
             usage = raw_response.usage  # type: ignore
             response.num_tokens_input = usage.prompt_tokens
@@ -98,73 +111,61 @@ class LiteLLM(LiteLLMBase):
         except AttributeError:
             pass
 
-        return response
+        response.response_text = raw_response.choices[0].message.content
 
 
-class LiteLLMStreaming(LiteLLMBase):
-    @llmeter_invoke
-    def invoke(self, payload):
-        return completion(model=self.litellm_model, **payload)
+class LiteLLMStreaming(LiteLLMBase[CustomStreamWrapper]):
+    @LiteLLMBase.llmeter_invoke
+    def invoke(self, payload) -> CustomStreamWrapper:
+        # In streaming mode, completion always returns a CustomStreamWrapper:
+        return completion(**payload)  # type: ignore
 
-    def prepare_payload(self, payload, **kwargs):
+    def prepare_payload(self, payload):
         # Make a copy of payload to avoid modifying the original
         payload_copy = payload.copy()
 
-        # Merge kwargs, excluding stream-related keys (we control those)
-        for key, value in kwargs.items():
-            if key not in ["stream", "stream_options"]:
-                payload_copy[key] = value
+        # Ensure correct model ID
+        payload_copy["model"] = self.litellm_model
 
         # Ensure streaming is enabled
         payload_copy["stream"] = True
 
-        # Handle stream_options - merge if exists in kwargs, otherwise set default
-        if "stream_options" in kwargs:
-            existing_options = kwargs.get("stream_options", {})
-            payload_copy["stream_options"] = {**existing_options, "include_usage": True}
-        elif "stream_options" not in payload_copy:
-            payload_copy["stream_options"] = {"include_usage": True}
-        else:
-            existing_options = payload_copy.get("stream_options", {})
-            payload_copy["stream_options"] = {**existing_options, "include_usage": True}
+        # Ensure stream_options includes usage
+        existing_options = payload_copy.get("stream_options", {})
+        payload_copy["stream_options"] = {**existing_options, "include_usage": True}
 
         return payload_copy
 
-    def parse_response(
-        self, raw_response: CustomStreamWrapper, start_t: float
-    ) -> InvocationResponse:
+    def process_raw_response(
+        self,
+        raw_response: CustomStreamWrapper,
+        start_t: float,
+        response: InvocationResponse,
+    ) -> None:
         usage = None
-        time_flag = True
-        time_to_first_token = None
-        output_text = ""
-        id = None
+        got_chunk_id = False
 
         for chunk in raw_response:
-            content = chunk.choices[0].delta.content or ""  # type: ignore
-            output_text += content
+            now = time.perf_counter()
 
-            # Record time to first token only when we get actual content
-            if time_flag and content:
-                time_to_first_token = time.perf_counter() - start_t
-                time_flag = False
+            if not got_chunk_id and chunk.id is not None:
+                response.id = chunk.id
+                got_chunk_id = True
 
-            # Always capture the ID from the first chunk
-            if id is None:
-                id = chunk.id
+            content = chunk.choices[0].delta.content or ""
+            if content:
+                if response.response_text is None:
+                    response.response_text = content
+                    response.time_to_first_token = now - start_t
+                else:
+                    response.response_text += content
+                response.time_to_last_token = now - start_t
 
             try:
                 usage = chunk.usage  # type: ignore
             except AttributeError:
                 continue
 
-        time_to_last_token = time.perf_counter() - start_t
-
-        response = InvocationResponse(
-            id=id,
-            response_text=output_text,
-            num_tokens_input=usage and usage.prompt_tokens,
-            num_tokens_output=usage and usage.completion_tokens,
-            time_to_first_token=time_to_first_token,
-            time_to_last_token=time_to_last_token,
-        )
-        return response
+        if usage:
+            response.num_tokens_input = usage.prompt_tokens
+            response.num_tokens_output = usage.completion_tokens

--- a/llmeter/endpoints/litellm.py
+++ b/llmeter/endpoints/litellm.py
@@ -12,7 +12,7 @@ from litellm import CustomStreamWrapper, completion
 from litellm.types.utils import ModelResponse
 from litellm.utils import get_llm_provider  # type: ignore
 
-from . import Endpoint, InvocationResponse
+from . import Endpoint, InvocationResponse, llmeter_invoke
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +80,7 @@ class LiteLLMBase(Endpoint):
 
 
 class LiteLLM(LiteLLMBase):
+    @llmeter_invoke
     def invoke(self, payload):
         response = completion(model=self.litellm_model, **payload)
         if not isinstance(response, ModelResponse):
@@ -104,6 +105,7 @@ class LiteLLM(LiteLLMBase):
 
 
 class LiteLLMStreaming(LiteLLMBase):
+    @llmeter_invoke
     def invoke(self, payload):
         response = completion(model=self.litellm_model, **payload)
 

--- a/llmeter/endpoints/litellm.py
+++ b/llmeter/endpoints/litellm.py
@@ -82,10 +82,11 @@ class LiteLLMBase(Endpoint):
 class LiteLLM(LiteLLMBase):
     @llmeter_invoke
     def invoke(self, payload):
+        start_t = time.perf_counter()
         response = completion(model=self.litellm_model, **payload)
         if not isinstance(response, ModelResponse):
             raise ValueError(f"Expected ModelResponse, got {type(response)}")
-        return self.parse_response(response, self._start_t)
+        return self.parse_response(response, start_t)
 
     def parse_response(
         self, client_response: ModelResponse, start_t: float
@@ -107,11 +108,12 @@ class LiteLLM(LiteLLMBase):
 class LiteLLMStreaming(LiteLLMBase):
     @llmeter_invoke
     def invoke(self, payload):
+        start_t = time.perf_counter()
         response = completion(model=self.litellm_model, **payload)
 
         if not isinstance(response, CustomStreamWrapper):
             raise ValueError(f"Expected CustomStreamWrapper, got {type(response)}")
-        return self.parse_response(response, self._start_t)
+        return self.parse_response(response, start_t)
 
     def prepare_payload(self, payload, **kwargs):
         # Make a copy of payload to avoid modifying the original

--- a/llmeter/endpoints/litellm.py
+++ b/llmeter/endpoints/litellm.py
@@ -82,11 +82,7 @@ class LiteLLMBase(Endpoint):
 class LiteLLM(LiteLLMBase):
     @llmeter_invoke
     def invoke(self, payload):
-        start_t = time.perf_counter()
-        response = completion(model=self.litellm_model, **payload)
-        if not isinstance(response, ModelResponse):
-            raise ValueError(f"Expected ModelResponse, got {type(response)}")
-        return self.parse_response(response, start_t)
+        return completion(model=self.litellm_model, **payload)
 
     def parse_response(
         self, client_response: ModelResponse, start_t: float
@@ -108,12 +104,7 @@ class LiteLLM(LiteLLMBase):
 class LiteLLMStreaming(LiteLLMBase):
     @llmeter_invoke
     def invoke(self, payload):
-        start_t = time.perf_counter()
-        response = completion(model=self.litellm_model, **payload)
-
-        if not isinstance(response, CustomStreamWrapper):
-            raise ValueError(f"Expected CustomStreamWrapper, got {type(response)}")
-        return self.parse_response(response, start_t)
+        return completion(model=self.litellm_model, **payload)
 
     def prepare_payload(self, payload, **kwargs):
         # Make a copy of payload to avoid modifying the original

--- a/llmeter/endpoints/openai.py
+++ b/llmeter/endpoints/openai.py
@@ -6,7 +6,7 @@ import base64
 import logging
 import os
 import time
-from typing import Any, Literal, cast
+from typing import Any, Literal, Generic, Iterable, TypeVar, cast
 
 from openai import OpenAI
 from openai.types.chat import (
@@ -14,6 +14,10 @@ from openai.types.chat import (
     ChatCompletionChunk,
     ChatCompletionContentPartParam,
     CompletionCreateParams,
+)
+from openai.types.chat.completion_create_params import (
+    CompletionCreateParamsNonStreaming,
+    CompletionCreateParamsStreaming,
 )
 from openai.types.chat.chat_completion_content_part_param import (
     File as ChatCompletionFile,
@@ -24,7 +28,7 @@ from ..prompt_utils import (
     MediaContent,
     VideoContent,
 )
-from .base import Endpoint, InvocationResponse, llmeter_invoke
+from .base import Endpoint, InvocationResponse
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +42,10 @@ _MIME_TO_OPENAI_AUDIO_FMT: dict[str, Literal["mp3", "wav"]] = {
     "audio/mpeg": "mp3",
     "audio/wav": "wav",
 }
+
+TOpenAICompletionBase = TypeVar(
+    "TOpenAICompletionBase", bound=ChatCompletion | Iterable[ChatCompletionChunk]
+)
 
 
 def _make_openai_content_block(item: MediaContent) -> ChatCompletionContentPartParam:
@@ -106,7 +114,7 @@ def _build_content_blocks_openai(
     return blocks
 
 
-class OpenAIEndpoint(Endpoint):
+class OpenAIEndpoint(Endpoint[TOpenAICompletionBase], Generic[TOpenAICompletionBase]):
     """Base class for OpenAI API endpoints."""
 
     def __init__(
@@ -221,101 +229,92 @@ class OpenAIEndpoint(Endpoint):
         return cast(CompletionCreateParams, payload)
 
 
-class OpenAICompletionEndpoint(OpenAIEndpoint):
+class OpenAICompletionEndpoint(OpenAIEndpoint[ChatCompletion]):
     """Endpoint for OpenAI-compatible Chat Completion APIs (non-streaming mode)"""
 
-    @llmeter_invoke
-    def invoke(self, payload: CompletionCreateParams):
+    @OpenAIEndpoint.llmeter_invoke
+    def invoke(self, payload: CompletionCreateParamsNonStreaming) -> ChatCompletion:
         """Invoke the OpenAI chat completion API."""
         client_response: ChatCompletion = self._client.chat.completions.create(
             **payload
         )
         return client_response
 
-    def prepare_payload(self, payload, **kwargs):
-        payload = {**kwargs, **payload}
-        payload["model"] = self.model_id
-        return payload
+    def prepare_payload(self, payload):
+        """Ensure payload specifies correct model ID and streaming disabled"""
+        return {
+            **payload,
+            "model": self.model_id,
+            "stream": False,
+        }
 
-    def parse_response(self, raw_response: ChatCompletion, start_t: float):
+    def process_raw_response(
+        self, raw_response: ChatCompletion, start_t: float, response: InvocationResponse
+    ) -> None:
+        response.time_to_last_token = time.perf_counter() - start_t
+        response.id = raw_response.id
+
+        response.response_text = raw_response.choices[0].message.content
+
         usage = raw_response.usage
-        cached_tokens = None
-        if usage and usage.prompt_tokens_details:
-            cached_tokens = getattr(usage.prompt_tokens_details, "cached_tokens", None)
-        return InvocationResponse(
-            id=raw_response.id,
-            response_text=raw_response.choices[0].message.content,
-            num_tokens_input=usage and usage.prompt_tokens,
-            num_tokens_output=usage and usage.completion_tokens,
-            num_tokens_input_cached=cached_tokens,
-        )
+        if usage:
+            response.num_tokens_input = usage.prompt_tokens
+            response.num_tokens_output = usage.completion_tokens
+            if usage.prompt_tokens_details:
+                response.num_tokens_input_cached = getattr(
+                    usage.prompt_tokens_details, "cached_tokens", None
+                )
 
 
-class OpenAICompletionStreamEndpoint(OpenAIEndpoint):
+class OpenAICompletionStreamEndpoint(OpenAIEndpoint[Iterable[ChatCompletionChunk]]):
     """Endpoint for OpenAI-compatible Chat Completion APIs (streaming mode)"""
 
-    @llmeter_invoke
-    def invoke(self, payload: CompletionCreateParams):
+    @OpenAIEndpoint.llmeter_invoke
+    def invoke(self, payload: CompletionCreateParamsStreaming):
         """Invoke the OpenAI streaming chat completion API."""
         client_response = self._client.chat.completions.create(**payload)
         return client_response
 
-    def prepare_payload(self, payload, **kwargs):
-        payload = {**kwargs, **payload}
-        payload["model"] = self.model_id
-        if not payload.get("stream"):
-            payload["stream"] = True
+    def prepare_payload(self, payload):
+        """Ensure payload specifies correct model ID and streaming settings"""
+        payload = {
+            **payload,
+            "model": self.model_id,
+            "stream": True,
+        }
+        if not payload.get("stream_options"):
             payload["stream_options"] = {"include_usage": True}
         return payload
 
-    def parse_response(self, raw_response, start_t: float) -> InvocationResponse:
-        """Parse the streaming API response from OpenAI chat completion API.
-
-        Args:
-            client_response: Stream of ``ChatCompletionChunk`` objects
-            start_t: Start time of the API call in seconds
-
-        Returns:
-            InvocationResponse with concatenated text, token counts, TTFT and TTLT
-        """
-        prompt_tokens = None
-        completion_tokens = None
-        cached_tokens = None
-        response_text = ""
-        response_id = None
-        time_to_first_token = None
-
+    def process_raw_response(
+        self,
+        raw_response: Iterable[ChatCompletionChunk],
+        start_t: float,
+        response: InvocationResponse,
+    ) -> None:
+        """Parse the streaming API response from OpenAI chat completion API."""
+        got_chunk_id = False
         for chunk in raw_response:
-            chunk: ChatCompletionChunk
-            if response_id is None:
-                response_id = chunk.id
+            now = time.perf_counter()
+
+            if not got_chunk_id and chunk.id is not None:
+                response.id = chunk.id
+                got_chunk_id = True
 
             if chunk.choices:
                 content = chunk.choices[0].delta.content
                 if content:
-                    if time_to_first_token is None:
-                        time_to_first_token = time.perf_counter() - start_t
-                    response_text += content
+                    if response.response_text is None:
+                        response.time_to_first_token = now - start_t
+                        response.response_text = content
+                    else:
+                        response.response_text += content
+                    response.time_to_last_token = now - start_t
 
             if chunk.usage is not None:
-                prompt_tokens = chunk.usage.prompt_tokens
-                completion_tokens = chunk.usage.completion_tokens
+                response.num_tokens_input = chunk.usage.prompt_tokens
+                response.num_tokens_output = chunk.usage.completion_tokens
                 if chunk.usage.prompt_tokens_details:
-                    cached_tokens = getattr(
+                    response.num_tokens_input_cached = getattr(
                         chunk.usage.prompt_tokens_details, "cached_tokens", None
                     )
-
-        time_to_last_token = time.perf_counter() - start_t
-
-        if time_to_first_token is None:
-            time_to_first_token = time_to_last_token
-
-        return InvocationResponse(
-            id=response_id,
-            response_text=response_text,
-            num_tokens_input=prompt_tokens,
-            num_tokens_output=completion_tokens,
-            num_tokens_input_cached=cached_tokens,
-            time_to_first_token=time_to_first_token,
-            time_to_last_token=time_to_last_token,
-        )

--- a/llmeter/endpoints/openai.py
+++ b/llmeter/endpoints/openai.py
@@ -227,10 +227,11 @@ class OpenAICompletionEndpoint(OpenAIEndpoint):
     @llmeter_invoke
     def invoke(self, payload: CompletionCreateParams) -> InvocationResponse:
         """Invoke the OpenAI chat completion API."""
+        start_t = time.perf_counter()
         client_response: ChatCompletion = self._client.chat.completions.create(
             **payload
         )
-        return self.parse_response(client_response, self._start_t)
+        return self.parse_response(client_response, start_t)
 
     def prepare_payload(self, payload, **kwargs):
         payload = {**kwargs, **payload}
@@ -257,8 +258,9 @@ class OpenAICompletionStreamEndpoint(OpenAIEndpoint):
     @llmeter_invoke
     def invoke(self, payload: CompletionCreateParams) -> InvocationResponse:
         """Invoke the OpenAI streaming chat completion API."""
+        start_t = time.perf_counter()
         client_response = self._client.chat.completions.create(**payload)
-        return self.parse_response(client_response, self._start_t)
+        return self.parse_response(client_response, start_t)
 
     def prepare_payload(self, payload, **kwargs):
         payload = {**kwargs, **payload}

--- a/llmeter/endpoints/openai.py
+++ b/llmeter/endpoints/openai.py
@@ -6,10 +6,9 @@ import base64
 import logging
 import os
 import time
-from typing import Any, cast, Literal
-from uuid import uuid4
+from typing import Any, Literal, cast
 
-from openai import APIConnectionError, OpenAI
+from openai import OpenAI
 from openai.types.chat import (
     ChatCompletion,
     ChatCompletionChunk,
@@ -225,86 +224,49 @@ class OpenAIEndpoint(Endpoint):
 class OpenAICompletionEndpoint(OpenAIEndpoint):
     """Endpoint for OpenAI-compatible Chat Completion APIs (non-streaming mode)"""
 
-    def invoke(
-        self, payload: CompletionCreateParams, **kwargs: Any
-    ) -> InvocationResponse:
-        """Invoke the OpenAI chat completion API.
+    def invoke(self, payload: CompletionCreateParams) -> InvocationResponse:
+        """Invoke the OpenAI chat completion API."""
+        client_response: ChatCompletion = self._client.chat.completions.create(
+            **payload
+        )
+        return self.parse_response(client_response, self._start_t)
 
-        Args:
-            payload (CompletionCreateParams): Request payload
-            **kwargs (Any): Additional parameters for the request
-
-        Returns:
-            InvocationResponse: Response from the API
-        """
+    def prepare_payload(self, payload, **kwargs):
         payload = {**kwargs, **payload}
         payload["model"] = self.model_id
+        return payload
 
-        start_t = time.perf_counter()
-        try:
-            client_response: ChatCompletion = self._client.chat.completions.create(
-                **payload
-            )
-        except (APIConnectionError, Exception) as e:
-            logger.error(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-
-        response = self._parse_converse_response(client_response, start_t)
-        response.input_payload = payload
-        response.input_prompt = self._parse_payload(payload)
-        return response
-
-    def _parse_converse_response(self, client_response: ChatCompletion, start_t: float):
+    def parse_response(self, client_response: ChatCompletion, start_t: float):
         usage = client_response.usage
+        cached_tokens = None
+        if usage and usage.prompt_tokens_details:
+            cached_tokens = getattr(usage.prompt_tokens_details, "cached_tokens", None)
         return InvocationResponse(
             id=client_response.id,
             response_text=client_response.choices[0].message.content,
             num_tokens_input=usage and usage.prompt_tokens,
             num_tokens_output=usage and usage.completion_tokens,
-            time_to_last_token=time.perf_counter() - start_t,
+            num_tokens_input_cached=cached_tokens,
         )
 
 
 class OpenAICompletionStreamEndpoint(OpenAIEndpoint):
     """Endpoint for OpenAI-compatible Chat Completion APIs (streaming mode)"""
 
-    def invoke(
-        self, payload: CompletionCreateParams, **kwargs: Any
-    ) -> InvocationResponse:
-        """Invoke the OpenAI streaming chat completion API.
+    def invoke(self, payload: CompletionCreateParams) -> InvocationResponse:
+        """Invoke the OpenAI streaming chat completion API."""
+        client_response = self._client.chat.completions.create(**payload)
+        return self.parse_response(client_response, self._start_t)
 
-        Args:
-            payload (CompletionCreateParams): Request payload
-            **kwargs (Any): Additional parameters for the request
-
-        Returns:
-            InvocationResponse: Response from the API
-        """
+    def prepare_payload(self, payload, **kwargs):
         payload = {**kwargs, **payload}
         payload["model"] = self.model_id
-
         if not payload.get("stream"):
             payload["stream"] = True
             payload["stream_options"] = {"include_usage": True}
+        return payload
 
-        try:
-            start_t = time.perf_counter()
-            client_response = self._client.chat.completions.create(**payload)
-        except (APIConnectionError, Exception) as e:
-            logger.error(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-        response = self._parse_converse_stream_response(client_response, start_t)
-        response.input_payload = payload
-        response.input_prompt = self._parse_payload(payload)
-        return response
-
-    def _parse_converse_stream_response(
-        self, client_response, start_t: float
-    ) -> InvocationResponse:
+    def parse_response(self, client_response, start_t: float) -> InvocationResponse:
         """Parse the streaming API response from OpenAI chat completion API.
 
         Args:
@@ -316,6 +278,7 @@ class OpenAICompletionStreamEndpoint(OpenAIEndpoint):
         """
         prompt_tokens = None
         completion_tokens = None
+        cached_tokens = None
         response_text = ""
         response_id = None
         time_to_first_token = None
@@ -335,6 +298,10 @@ class OpenAICompletionStreamEndpoint(OpenAIEndpoint):
             if chunk.usage is not None:
                 prompt_tokens = chunk.usage.prompt_tokens
                 completion_tokens = chunk.usage.completion_tokens
+                if chunk.usage.prompt_tokens_details:
+                    cached_tokens = getattr(
+                        chunk.usage.prompt_tokens_details, "cached_tokens", None
+                    )
 
         time_to_last_token = time.perf_counter() - start_t
 
@@ -346,6 +313,7 @@ class OpenAICompletionStreamEndpoint(OpenAIEndpoint):
             response_text=response_text,
             num_tokens_input=prompt_tokens,
             num_tokens_output=completion_tokens,
+            num_tokens_input_cached=cached_tokens,
             time_to_first_token=time_to_first_token,
             time_to_last_token=time_to_last_token,
         )

--- a/llmeter/endpoints/openai.py
+++ b/llmeter/endpoints/openai.py
@@ -227,11 +227,10 @@ class OpenAICompletionEndpoint(OpenAIEndpoint):
     @llmeter_invoke
     def invoke(self, payload: CompletionCreateParams) -> InvocationResponse:
         """Invoke the OpenAI chat completion API."""
-        start_t = time.perf_counter()
         client_response: ChatCompletion = self._client.chat.completions.create(
             **payload
         )
-        return self.parse_response(client_response, start_t)
+        return client_response
 
     def prepare_payload(self, payload, **kwargs):
         payload = {**kwargs, **payload}
@@ -258,9 +257,8 @@ class OpenAICompletionStreamEndpoint(OpenAIEndpoint):
     @llmeter_invoke
     def invoke(self, payload: CompletionCreateParams) -> InvocationResponse:
         """Invoke the OpenAI streaming chat completion API."""
-        start_t = time.perf_counter()
         client_response = self._client.chat.completions.create(**payload)
-        return self.parse_response(client_response, start_t)
+        return client_response
 
     def prepare_payload(self, payload, **kwargs):
         payload = {**kwargs, **payload}

--- a/llmeter/endpoints/openai.py
+++ b/llmeter/endpoints/openai.py
@@ -225,7 +225,7 @@ class OpenAICompletionEndpoint(OpenAIEndpoint):
     """Endpoint for OpenAI-compatible Chat Completion APIs (non-streaming mode)"""
 
     @llmeter_invoke
-    def invoke(self, payload: CompletionCreateParams) -> InvocationResponse:
+    def invoke(self, payload: CompletionCreateParams):
         """Invoke the OpenAI chat completion API."""
         client_response: ChatCompletion = self._client.chat.completions.create(
             **payload
@@ -237,14 +237,14 @@ class OpenAICompletionEndpoint(OpenAIEndpoint):
         payload["model"] = self.model_id
         return payload
 
-    def parse_response(self, client_response: ChatCompletion, start_t: float):
-        usage = client_response.usage
+    def parse_response(self, raw_response: ChatCompletion, start_t: float):
+        usage = raw_response.usage
         cached_tokens = None
         if usage and usage.prompt_tokens_details:
             cached_tokens = getattr(usage.prompt_tokens_details, "cached_tokens", None)
         return InvocationResponse(
-            id=client_response.id,
-            response_text=client_response.choices[0].message.content,
+            id=raw_response.id,
+            response_text=raw_response.choices[0].message.content,
             num_tokens_input=usage and usage.prompt_tokens,
             num_tokens_output=usage and usage.completion_tokens,
             num_tokens_input_cached=cached_tokens,
@@ -255,7 +255,7 @@ class OpenAICompletionStreamEndpoint(OpenAIEndpoint):
     """Endpoint for OpenAI-compatible Chat Completion APIs (streaming mode)"""
 
     @llmeter_invoke
-    def invoke(self, payload: CompletionCreateParams) -> InvocationResponse:
+    def invoke(self, payload: CompletionCreateParams):
         """Invoke the OpenAI streaming chat completion API."""
         client_response = self._client.chat.completions.create(**payload)
         return client_response
@@ -268,7 +268,7 @@ class OpenAICompletionStreamEndpoint(OpenAIEndpoint):
             payload["stream_options"] = {"include_usage": True}
         return payload
 
-    def parse_response(self, client_response, start_t: float) -> InvocationResponse:
+    def parse_response(self, raw_response, start_t: float) -> InvocationResponse:
         """Parse the streaming API response from OpenAI chat completion API.
 
         Args:
@@ -285,7 +285,7 @@ class OpenAICompletionStreamEndpoint(OpenAIEndpoint):
         response_id = None
         time_to_first_token = None
 
-        for chunk in client_response:
+        for chunk in raw_response:
             chunk: ChatCompletionChunk
             if response_id is None:
                 response_id = chunk.id

--- a/llmeter/endpoints/openai.py
+++ b/llmeter/endpoints/openai.py
@@ -24,7 +24,7 @@ from ..prompt_utils import (
     MediaContent,
     VideoContent,
 )
-from .base import Endpoint, InvocationResponse
+from .base import Endpoint, InvocationResponse, llmeter_invoke
 
 logger = logging.getLogger(__name__)
 
@@ -224,6 +224,7 @@ class OpenAIEndpoint(Endpoint):
 class OpenAICompletionEndpoint(OpenAIEndpoint):
     """Endpoint for OpenAI-compatible Chat Completion APIs (non-streaming mode)"""
 
+    @llmeter_invoke
     def invoke(self, payload: CompletionCreateParams) -> InvocationResponse:
         """Invoke the OpenAI chat completion API."""
         client_response: ChatCompletion = self._client.chat.completions.create(
@@ -253,6 +254,7 @@ class OpenAICompletionEndpoint(OpenAIEndpoint):
 class OpenAICompletionStreamEndpoint(OpenAIEndpoint):
     """Endpoint for OpenAI-compatible Chat Completion APIs (streaming mode)"""
 
+    @llmeter_invoke
     def invoke(self, payload: CompletionCreateParams) -> InvocationResponse:
         """Invoke the OpenAI streaming chat completion API."""
         client_response = self._client.chat.completions.create(**payload)

--- a/llmeter/endpoints/openai_response.py
+++ b/llmeter/endpoints/openai_response.py
@@ -4,20 +4,14 @@
 import logging
 import time
 from collections.abc import Sequence
-from typing import cast, Any
-from uuid import uuid4
+from typing import Any, cast
 
 from openai import (
-    APIConnectionError,
-    AuthenticationError,
-    BadRequestError,
     OpenAI,
-    RateLimitError,
 )
 from openai.types.responses import Response, ResponseCreateParams
 from openai.types.responses.response_create_params import (
     ResponseCreateParamsNonStreaming,
-    ResponseCreateParamsStreaming,
 )
 
 from .base import Endpoint, InvocationResponse
@@ -53,60 +47,17 @@ class OpenAIResponseEndpoint(Endpoint):
         super().__init__(endpoint_name, model_id, provider=provider)
         self._client = OpenAI(api_key=api_key, **kwargs)
 
-    def invoke(
-        self, payload: ResponseCreateParamsNonStreaming, **kwargs
-    ) -> InvocationResponse:
-        """Invoke the Responses API.
+    def invoke(self, payload: ResponseCreateParamsNonStreaming) -> InvocationResponse:
+        """Invoke the Responses API."""
+        client_response = self._client.responses.create(**payload)
+        return self.parse_response(client_response, self._start_t)
 
-        Args:
-            payload: Request payload typed as
-                ``openai.types.responses.ResponseCreateParams``. You can build
-                this yourself using the OpenAI SDK types, or use the
-                ``create_payload`` convenience helper.
-            **kwargs: Additional parameters to merge with payload
-
-        Returns:
-            InvocationResponse with response text, timing, and token counts
-        """
-        # Merge kwargs with payload and add model_id
+    def prepare_payload(self, payload, **kwargs):
         payload = {**kwargs, **payload}  # type: ignore
         payload["model"] = self.model_id
+        return payload
 
-        start_t = time.perf_counter()
-        try:
-            client_response = self._client.responses.create(**payload)
-        except APIConnectionError as e:
-            logger.exception(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-        except AuthenticationError as e:
-            logger.exception(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-        except RateLimitError as e:
-            logger.exception(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-        except BadRequestError as e:
-            logger.exception(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-        except Exception as e:
-            logger.exception(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-
-        response = self._parse_response(client_response, start_t)
-        response.input_payload = payload
-        response.input_prompt = self._parse_payload(payload)
-        return response
-
-    def _parse_response(
+    def parse_response(
         self, client_response: Response, start_t: float
     ) -> InvocationResponse:
         """Parse Response API output into InvocationResponse.
@@ -122,16 +73,20 @@ class OpenAIResponseEndpoint(Endpoint):
 
         input_tokens = None
         output_tokens = None
+        cached_tokens = None
         if usage is not None:
             input_tokens = usage.input_tokens
             output_tokens = usage.output_tokens
+            details = getattr(usage, "input_tokens_details", None)
+            if details:
+                cached_tokens = getattr(details, "cached_tokens", None)
 
         return InvocationResponse(
             id=client_response.id,
             response_text=client_response.output_text,
             num_tokens_input=input_tokens,
             num_tokens_output=output_tokens,
-            time_to_last_token=time.perf_counter() - start_t,
+            num_tokens_input_cached=cached_tokens,
         )
 
     @staticmethod
@@ -236,63 +191,20 @@ class OpenAIResponseStreamEndpoint(OpenAIResponseEndpoint):
             **kwargs,
         )
 
-    def invoke(self, payload: ResponseCreateParams, **kwargs) -> InvocationResponse:
-        """Invoke the Responses API with streaming.
+    def invoke(self, payload: ResponseCreateParams) -> InvocationResponse:
+        """Invoke the Responses API with streaming."""
+        client_response = self._client.responses.create(**payload)
+        return self.parse_response(client_response, self._start_t)
 
-        Args:
-            payload: Request payload typed as
-                ``openai.types.responses.ResponseCreateParams``.
-            **kwargs: Additional parameters to merge with payload
-
-        Returns:
-            InvocationResponse with response text, timing (TTFT, TTLT), and token counts
-        """
-        # Merge kwargs with payload and add model_id
+    def prepare_payload(self, payload, **kwargs):
         payload = {**kwargs, **payload}
         payload["model"] = self.model_id
-
-        # Set streaming parameters
         if not payload.get("stream"):
             payload["stream"] = True
             payload["stream_options"] = {"include_usage": True}
+        return payload
 
-        try:
-            start_t = time.perf_counter()
-            client_response = self._client.responses.create(**payload)
-        except APIConnectionError as e:
-            logger.exception(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-        except AuthenticationError as e:
-            logger.exception(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-        except RateLimitError as e:
-            logger.exception(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-        except BadRequestError as e:
-            logger.exception(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-        except Exception as e:
-            logger.exception(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-
-        response = self._parse_stream_response(client_response, start_t)
-        response.input_payload = payload
-        response.input_prompt = self._parse_payload(payload)
-        return response
-
-    def _parse_stream_response(
-        self, client_response, start_t: float
-    ) -> InvocationResponse:
+    def parse_response(self, client_response, start_t: float) -> InvocationResponse:
         """Parse streaming Response API output into InvocationResponse.
 
         Processes typed events from the stream:
@@ -309,6 +221,7 @@ class OpenAIResponseStreamEndpoint(OpenAIResponseEndpoint):
         """
         input_tokens = None
         output_tokens = None
+        cached_tokens = None
         response_text = ""
         response_id = None
         time_to_first_token = None
@@ -327,6 +240,9 @@ class OpenAIResponseStreamEndpoint(OpenAIResponseEndpoint):
                 if usage is not None:
                     input_tokens = usage.input_tokens
                     output_tokens = usage.output_tokens
+                    details = getattr(usage, "input_tokens_details", None)
+                    if details:
+                        cached_tokens = getattr(details, "cached_tokens", None)
 
         time_to_last_token = time.perf_counter() - start_t
 
@@ -338,6 +254,7 @@ class OpenAIResponseStreamEndpoint(OpenAIResponseEndpoint):
             response_text=response_text,
             num_tokens_input=input_tokens,
             num_tokens_output=output_tokens,
+            num_tokens_input_cached=cached_tokens,
             time_to_first_token=time_to_first_token,
             time_to_last_token=time_to_last_token,
         )

--- a/llmeter/endpoints/openai_response.py
+++ b/llmeter/endpoints/openai_response.py
@@ -4,33 +4,31 @@
 import logging
 import time
 from collections.abc import Sequence
-from typing import Any, cast
+from typing import Any, Generic, Iterable, TypeVar, cast
 
-from openai import (
-    OpenAI,
-)
-from openai.types.responses import Response, ResponseCreateParams
+from openai import OpenAI
+from openai.types.responses import Response, ResponseCreateParams, ResponseStreamEvent
 from openai.types.responses.response_create_params import (
     ResponseCreateParamsNonStreaming,
+    ResponseCreateParamsStreaming,
 )
 
-from .base import Endpoint, InvocationResponse, llmeter_invoke
+from .base import Endpoint, InvocationResponse
 
 logger = logging.getLogger(__name__)
 
+TOpenAIResponseBase = TypeVar(
+    "TOpenAIResponseBase", bound=Response | Iterable[ResponseStreamEvent]
+)
 
-class OpenAIResponseEndpoint(Endpoint):
-    """Endpoint for OpenAI Responses API (non-streaming).
 
-    This endpoint provides access to OpenAI's newer Responses API which offers
-    structured outputs, better response format control, and improved multi-turn
-    conversation handling.
-    """
+class OpenAIEndpointBase(Endpoint[TOpenAIResponseBase], Generic[TOpenAIResponseBase]):
+    """Base class for OpenAI Responses API endpoints (streaming and non-streaming)"""
 
     def __init__(
         self,
+        endpoint_name: str,
         model_id: str,
-        endpoint_name: str = "openai-response",
         api_key: str | None = None,
         provider: str = "openai",
         **kwargs: Any,
@@ -38,57 +36,14 @@ class OpenAIResponseEndpoint(Endpoint):
         """Initialize Response API endpoint.
 
         Args:
+            endpoint_name: Name of the endpoint
             model_id: ID of the OpenAI model to use
-            endpoint_name: Name of the endpoint (default: "openai-response")
             api_key: OpenAI API key (optional, uses OPENAI_API_KEY env var if not provided)
             provider: Provider name (default: "openai")
             **kwargs: Additional arguments passed to OpenAI client
         """
         super().__init__(endpoint_name, model_id, provider=provider)
         self._client = OpenAI(api_key=api_key, **kwargs)
-
-    @llmeter_invoke
-    def invoke(self, payload: ResponseCreateParamsNonStreaming):
-        """Invoke the Responses API."""
-        client_response = self._client.responses.create(**payload)
-        return client_response
-
-    def prepare_payload(self, payload, **kwargs):
-        payload = {**kwargs, **payload}  # type: ignore
-        payload["model"] = self.model_id
-        return payload
-
-    def parse_response(
-        self, raw_response: Response, start_t: float
-    ) -> InvocationResponse:
-        """Parse Response API output into InvocationResponse.
-
-        Args:
-            client_response: Raw ``Response`` object from OpenAI Responses API
-            start_t: Start time of the API call
-
-        Returns:
-            InvocationResponse with extracted fields
-        """
-        usage = raw_response.usage
-
-        input_tokens = None
-        output_tokens = None
-        cached_tokens = None
-        if usage is not None:
-            input_tokens = usage.input_tokens
-            output_tokens = usage.output_tokens
-            details = getattr(usage, "input_tokens_details", None)
-            if details:
-                cached_tokens = getattr(details, "cached_tokens", None)
-
-        return InvocationResponse(
-            id=raw_response.id,
-            response_text=raw_response.output_text,
-            num_tokens_input=input_tokens,
-            num_tokens_output=output_tokens,
-            num_tokens_input_cached=cached_tokens,
-        )
 
     @staticmethod
     def create_payload(
@@ -160,7 +115,68 @@ class OpenAIResponseEndpoint(Endpoint):
         return ""
 
 
-class OpenAIResponseStreamEndpoint(OpenAIResponseEndpoint):
+class OpenAIResponseEndpoint(OpenAIEndpointBase[Response]):
+    """Endpoint for OpenAI Responses API (non-streaming).
+
+    This endpoint provides access to OpenAI's newer Responses API which offers
+    structured outputs, better response format control, and improved multi-turn
+    conversation handling.
+    """
+
+    def __init__(
+        self,
+        model_id: str,
+        endpoint_name: str = "openai-response",
+        api_key: str | None = None,
+        provider: str = "openai",
+        **kwargs: Any,
+    ):
+        """Initialize Response API endpoint.
+
+        Args:
+            model_id: ID of the OpenAI model to use
+            endpoint_name: Name of the endpoint (default: "openai-response")
+            api_key: OpenAI API key (optional, uses OPENAI_API_KEY env var if not provided)
+            provider: Provider name (default: "openai")
+            **kwargs: Additional arguments passed to OpenAI client
+        """
+        super().__init__(
+            endpoint_name, model_id, api_key=api_key, provider=provider, **kwargs
+        )
+
+    @OpenAIEndpointBase.llmeter_invoke
+    def invoke(self, payload: ResponseCreateParamsNonStreaming) -> Response:
+        """Invoke the Responses API."""
+        client_response = self._client.responses.create(**payload)
+        return client_response
+
+    def prepare_payload(self, payload):
+        """Ensure payload specifies correct model ID and streaming disabled"""
+        return {
+            **payload,
+            "model": self.model_id,
+            "stream": False,
+        }
+
+    def process_raw_response(
+        self, raw_response: Response, start_t: float, response: InvocationResponse
+    ) -> None:
+        response.time_to_last_token = time.perf_counter() - start_t
+        response.id = raw_response.id
+        response.response_text = raw_response.output_text
+
+        usage = raw_response.usage
+        if usage is not None:
+            response.num_tokens_input = usage.input_tokens
+            response.num_tokens_output = usage.output_tokens
+            details = getattr(usage, "input_tokens_details", None)
+            if details:
+                response.num_tokens_input_cached = getattr(
+                    details, "cached_tokens", None
+                )
+
+
+class OpenAIResponseStreamEndpoint(OpenAIEndpointBase[Iterable[ResponseStreamEvent]]):
     """Endpoint for OpenAI Responses API (streaming).
 
     This endpoint provides streaming access to OpenAI's Responses API, enabling
@@ -192,71 +208,53 @@ class OpenAIResponseStreamEndpoint(OpenAIResponseEndpoint):
             **kwargs,
         )
 
-    @llmeter_invoke
-    def invoke(self, payload: ResponseCreateParams):
+    @OpenAIEndpointBase.llmeter_invoke
+    def invoke(self, payload: ResponseCreateParamsStreaming):
         """Invoke the Responses API with streaming."""
         client_response = self._client.responses.create(**payload)
         return client_response
 
-    def prepare_payload(self, payload, **kwargs):
-        payload = {**kwargs, **payload}
-        payload["model"] = self.model_id
+    def prepare_payload(self, payload):
+        """Ensure payload specifies correct model ID and streaming options"""
+        payload = {**payload, "model": self.model_id}
         if not payload.get("stream"):
             payload["stream"] = True
             payload["stream_options"] = {"include_usage": True}
         return payload
 
-    def parse_response(self, raw_response, start_t: float) -> InvocationResponse:
+    def process_raw_response(
+        self,
+        raw_response: Iterable[ResponseStreamEvent],
+        start_t: float,
+        response: InvocationResponse,
+    ) -> None:
         """Parse streaming Response API output into InvocationResponse.
 
         Processes typed events from the stream:
         - ``ResponseCreatedEvent``: captures ``response.id``
         - ``ResponseTextDeltaEvent``: accumulates text deltas, records TTFT
         - ``ResponseCompletedEvent``: extracts usage from ``response.usage``
-
-        Args:
-            client_response: Streaming response from OpenAI Responses API
-            start_t: Start time of the API call
-
-        Returns:
-            InvocationResponse with extracted fields including TTFT
         """
-        input_tokens = None
-        output_tokens = None
-        cached_tokens = None
-        response_text = ""
-        response_id = None
-        time_to_first_token = None
-
         for event in raw_response:
+            now = time.perf_counter()
             if event.type == "response.created":
-                response_id = event.response.id
+                response.id = event.response.id
 
             elif event.type == "response.output_text.delta":
-                if time_to_first_token is None:
-                    time_to_first_token = time.perf_counter() - start_t
-                response_text += event.delta
+                if response.response_text is None:
+                    response.response_text = event.delta
+                    response.time_to_first_token = now - start_t
+                else:
+                    response.response_text += event.delta
+                response.time_to_last_token = now - start_t
 
             elif event.type == "response.completed":
                 usage = event.response.usage
                 if usage is not None:
-                    input_tokens = usage.input_tokens
-                    output_tokens = usage.output_tokens
+                    response.num_tokens_input = usage.input_tokens
+                    response.num_tokens_output = usage.output_tokens
                     details = getattr(usage, "input_tokens_details", None)
                     if details:
-                        cached_tokens = getattr(details, "cached_tokens", None)
-
-        time_to_last_token = time.perf_counter() - start_t
-
-        if time_to_first_token is None:
-            time_to_first_token = time_to_last_token
-
-        return InvocationResponse(
-            id=response_id,
-            response_text=response_text,
-            num_tokens_input=input_tokens,
-            num_tokens_output=output_tokens,
-            num_tokens_input_cached=cached_tokens,
-            time_to_first_token=time_to_first_token,
-            time_to_last_token=time_to_last_token,
-        )
+                        response.num_tokens_input_cached = getattr(
+                            details, "cached_tokens", None
+                        )

--- a/llmeter/endpoints/openai_response.py
+++ b/llmeter/endpoints/openai_response.py
@@ -50,8 +50,9 @@ class OpenAIResponseEndpoint(Endpoint):
     @llmeter_invoke
     def invoke(self, payload: ResponseCreateParamsNonStreaming) -> InvocationResponse:
         """Invoke the Responses API."""
+        start_t = time.perf_counter()
         client_response = self._client.responses.create(**payload)
-        return self.parse_response(client_response, self._start_t)
+        return self.parse_response(client_response, start_t)
 
     def prepare_payload(self, payload, **kwargs):
         payload = {**kwargs, **payload}  # type: ignore
@@ -195,8 +196,9 @@ class OpenAIResponseStreamEndpoint(OpenAIResponseEndpoint):
     @llmeter_invoke
     def invoke(self, payload: ResponseCreateParams) -> InvocationResponse:
         """Invoke the Responses API with streaming."""
+        start_t = time.perf_counter()
         client_response = self._client.responses.create(**payload)
-        return self.parse_response(client_response, self._start_t)
+        return self.parse_response(client_response, start_t)
 
     def prepare_payload(self, payload, **kwargs):
         payload = {**kwargs, **payload}

--- a/llmeter/endpoints/openai_response.py
+++ b/llmeter/endpoints/openai_response.py
@@ -14,7 +14,7 @@ from openai.types.responses.response_create_params import (
     ResponseCreateParamsNonStreaming,
 )
 
-from .base import Endpoint, InvocationResponse
+from .base import Endpoint, InvocationResponse, llmeter_invoke
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +47,7 @@ class OpenAIResponseEndpoint(Endpoint):
         super().__init__(endpoint_name, model_id, provider=provider)
         self._client = OpenAI(api_key=api_key, **kwargs)
 
+    @llmeter_invoke
     def invoke(self, payload: ResponseCreateParamsNonStreaming) -> InvocationResponse:
         """Invoke the Responses API."""
         client_response = self._client.responses.create(**payload)
@@ -191,6 +192,7 @@ class OpenAIResponseStreamEndpoint(OpenAIResponseEndpoint):
             **kwargs,
         )
 
+    @llmeter_invoke
     def invoke(self, payload: ResponseCreateParams) -> InvocationResponse:
         """Invoke the Responses API with streaming."""
         client_response = self._client.responses.create(**payload)

--- a/llmeter/endpoints/openai_response.py
+++ b/llmeter/endpoints/openai_response.py
@@ -50,9 +50,8 @@ class OpenAIResponseEndpoint(Endpoint):
     @llmeter_invoke
     def invoke(self, payload: ResponseCreateParamsNonStreaming) -> InvocationResponse:
         """Invoke the Responses API."""
-        start_t = time.perf_counter()
         client_response = self._client.responses.create(**payload)
-        return self.parse_response(client_response, start_t)
+        return client_response
 
     def prepare_payload(self, payload, **kwargs):
         payload = {**kwargs, **payload}  # type: ignore
@@ -196,9 +195,8 @@ class OpenAIResponseStreamEndpoint(OpenAIResponseEndpoint):
     @llmeter_invoke
     def invoke(self, payload: ResponseCreateParams) -> InvocationResponse:
         """Invoke the Responses API with streaming."""
-        start_t = time.perf_counter()
         client_response = self._client.responses.create(**payload)
-        return self.parse_response(client_response, start_t)
+        return client_response
 
     def prepare_payload(self, payload, **kwargs):
         payload = {**kwargs, **payload}

--- a/llmeter/endpoints/openai_response.py
+++ b/llmeter/endpoints/openai_response.py
@@ -48,7 +48,7 @@ class OpenAIResponseEndpoint(Endpoint):
         self._client = OpenAI(api_key=api_key, **kwargs)
 
     @llmeter_invoke
-    def invoke(self, payload: ResponseCreateParamsNonStreaming) -> InvocationResponse:
+    def invoke(self, payload: ResponseCreateParamsNonStreaming):
         """Invoke the Responses API."""
         client_response = self._client.responses.create(**payload)
         return client_response
@@ -59,7 +59,7 @@ class OpenAIResponseEndpoint(Endpoint):
         return payload
 
     def parse_response(
-        self, client_response: Response, start_t: float
+        self, raw_response: Response, start_t: float
     ) -> InvocationResponse:
         """Parse Response API output into InvocationResponse.
 
@@ -70,7 +70,7 @@ class OpenAIResponseEndpoint(Endpoint):
         Returns:
             InvocationResponse with extracted fields
         """
-        usage = client_response.usage
+        usage = raw_response.usage
 
         input_tokens = None
         output_tokens = None
@@ -83,8 +83,8 @@ class OpenAIResponseEndpoint(Endpoint):
                 cached_tokens = getattr(details, "cached_tokens", None)
 
         return InvocationResponse(
-            id=client_response.id,
-            response_text=client_response.output_text,
+            id=raw_response.id,
+            response_text=raw_response.output_text,
             num_tokens_input=input_tokens,
             num_tokens_output=output_tokens,
             num_tokens_input_cached=cached_tokens,
@@ -193,7 +193,7 @@ class OpenAIResponseStreamEndpoint(OpenAIResponseEndpoint):
         )
 
     @llmeter_invoke
-    def invoke(self, payload: ResponseCreateParams) -> InvocationResponse:
+    def invoke(self, payload: ResponseCreateParams):
         """Invoke the Responses API with streaming."""
         client_response = self._client.responses.create(**payload)
         return client_response
@@ -206,7 +206,7 @@ class OpenAIResponseStreamEndpoint(OpenAIResponseEndpoint):
             payload["stream_options"] = {"include_usage": True}
         return payload
 
-    def parse_response(self, client_response, start_t: float) -> InvocationResponse:
+    def parse_response(self, raw_response, start_t: float) -> InvocationResponse:
         """Parse streaming Response API output into InvocationResponse.
 
         Processes typed events from the stream:
@@ -228,7 +228,7 @@ class OpenAIResponseStreamEndpoint(OpenAIResponseEndpoint):
         response_id = None
         time_to_first_token = None
 
-        for event in client_response:
+        for event in raw_response:
             if event.type == "response.created":
                 response_id = event.response.id
 

--- a/llmeter/endpoints/sagemaker.py
+++ b/llmeter/endpoints/sagemaker.py
@@ -207,6 +207,7 @@ class SageMakerEndpoint(SageMakerBase):
     @llmeter_invoke
     def invoke(self, payload: dict) -> InvocationResponse:
         """Invoke the SageMaker endpoint with the given payload."""
+        start_t = time.perf_counter()
         json_payload = json.dumps(payload)
 
         client_response = self._sagemaker_runtime.invoke_endpoint(
@@ -214,7 +215,7 @@ class SageMakerEndpoint(SageMakerBase):
             ContentType="application/json",
             Body=bytes(json_payload, "utf-8"),
         )
-        return self.parse_response(client_response, self._start_t)
+        return self.parse_response(client_response, start_t)
 
 
 class SageMakerStreamEndpoint(SageMakerBase):
@@ -259,6 +260,7 @@ class SageMakerStreamEndpoint(SageMakerBase):
     @llmeter_invoke
     def invoke(self, payload: dict) -> InvocationResponse:
         """Invoke a SageMaker streaming endpoint with the given payload."""
+        start_t = time.perf_counter()
         json_payload = json.dumps(payload)
 
         client_response = self._sagemaker_runtime.invoke_endpoint_with_response_stream(
@@ -266,7 +268,7 @@ class SageMakerStreamEndpoint(SageMakerBase):
             Body=json_payload,
             ContentType="application/json",
         )
-        return self.parse_response(client_response, self._start_t)
+        return self.parse_response(client_response, start_t)
 
     def prepare_payload(self, payload, **kwargs):
         if "parameters" in payload:

--- a/llmeter/endpoints/sagemaker.py
+++ b/llmeter/endpoints/sagemaker.py
@@ -18,7 +18,7 @@ from ..prompt_utils import (
     MediaContent,
     VideoContent,
 )
-from .base import Endpoint, InvocationResponse
+from .base import Endpoint, InvocationResponse, llmeter_invoke
 
 logger = logging.getLogger(__name__)
 
@@ -204,6 +204,7 @@ class SageMakerEndpoint(SageMakerBase):
             retries=client_response.get("ResponseMetadata", {}).get("RetryAttempts"),
         )
 
+    @llmeter_invoke
     def invoke(self, payload: dict) -> InvocationResponse:
         """Invoke the SageMaker endpoint with the given payload."""
         json_payload = json.dumps(payload)
@@ -255,6 +256,7 @@ class SageMakerStreamEndpoint(SageMakerBase):
             retries=client_response.get("ResponseMetadata", {}).get("RetryAttempts"),
         )
 
+    @llmeter_invoke
     def invoke(self, payload: dict) -> InvocationResponse:
         """Invoke a SageMaker streaming endpoint with the given payload."""
         json_payload = json.dumps(payload)

--- a/llmeter/endpoints/sagemaker.py
+++ b/llmeter/endpoints/sagemaker.py
@@ -5,10 +5,23 @@ import io
 import json
 import logging
 import time
+from typing import Generic, TypeVar
 import warnings
 
 import boto3
 import jmespath
+
+try:
+    from mypy_boto3_sagemaker_runtime.type_defs import (
+        InvokeEndpointOutputTypeDef,
+        InvokeEndpointWithResponseStreamOutputTypeDef,
+    )
+except ImportError:
+    InvokeEndpointOutputTypeDef = TypeVar("InvokeEndpointOutputTypeDef")
+    InvokeEndpointWithResponseStreamOutputTypeDef = TypeVar(
+        "InvokeEndpointWithResponseStreamOutputTypeDef"
+    )
+
 
 from ..prompt_utils import (
     AudioContent,
@@ -18,9 +31,15 @@ from ..prompt_utils import (
     MediaContent,
     VideoContent,
 )
-from .base import Endpoint, InvocationResponse, llmeter_invoke
+from .base import Endpoint, InvocationResponse
 
 logger = logging.getLogger(__name__)
+
+
+TSageMakerResponseBase = TypeVar(
+    "TSageMakerResponseBase",
+    bound=InvokeEndpointOutputTypeDef | InvokeEndpointWithResponseStreamOutputTypeDef,
+)
 
 
 def _mime_to_sagemaker_format(mime_type: str) -> str | None:
@@ -72,11 +91,12 @@ def _build_content_blocks_sagemaker(items: list[ContentItem]) -> list[dict]:
     return blocks
 
 
-class SageMakerBase(Endpoint):
+class SageMakerBase(Endpoint[TSageMakerResponseBase], Generic[TSageMakerResponseBase]):
     def __init__(
         self,
         endpoint_name: str,
         model_id: str,
+        # TODO: generated & token count jmespaths not actually used by streaming yet
         generated_text_jmespath: str = "generated_text",
         input_text_jmespath: str = "inputs",
         token_count_jmespath: str | None = "details.generated_tokens",
@@ -106,6 +126,15 @@ class SageMakerBase(Endpoint):
             return jmespath.search(self.input_text_jmespath, payload)
         except Exception:
             return None
+
+
+class SageMakerEndpoint(SageMakerBase[InvokeEndpointOutputTypeDef]):
+    """
+    A class for handling invocations to a SageMaker endpoint.
+
+    This class extends SageMakerBase to provide functionality for invoking
+    a SageMaker endpoint and parsing its response.
+    """
 
     @staticmethod
     def create_payload(
@@ -163,49 +192,8 @@ class SageMakerBase(Endpoint):
         payload.update(kwargs)
         return payload
 
-
-class SageMakerEndpoint(SageMakerBase):
-    """
-    A class for handling invocations to a SageMaker endpoint.
-
-    This class extends SageMakerBase to provide functionality for invoking
-    a SageMaker endpoint and parsing its response.
-    """
-
-    def parse_response(self, raw_response, start_t: float) -> InvocationResponse:
-        """Parse the response from the SageMaker endpoint.
-
-        Args:
-            client_response: The raw response from the SageMaker endpoint.
-            start_t: The timestamp when the request was initiated.
-
-        Returns:
-            InvocationResponse with the generated text and metadata.
-        """
-        if raw_response is None:
-            return InvocationResponse(response_text=None)
-
-        client_response_body_json = raw_response["Body"].read().decode("utf-8")
-        client_response_body = json.loads(client_response_body_json)
-
-        response_text = jmespath.search(
-            self.generated_text_jmespath, client_response_body
-        )
-        num_tokens_output = None
-        if self.token_count_jmespath:
-            num_tokens_output = jmespath.search(
-                self.token_count_jmespath, client_response_body
-            )
-
-        return InvocationResponse(
-            id=raw_response.get("ResponseMetadata", {}).get("RequestId"),
-            response_text=response_text or "",
-            num_tokens_output=num_tokens_output if num_tokens_output else None,
-            retries=raw_response.get("ResponseMetadata", {}).get("RetryAttempts"),
-        )
-
-    @llmeter_invoke
-    def invoke(self, payload: dict) -> InvocationResponse:
+    @SageMakerBase.llmeter_invoke
+    def invoke(self, payload: dict) -> InvokeEndpointOutputTypeDef:
         """Invoke the SageMaker endpoint with the given payload."""
         json_payload = json.dumps(payload)
 
@@ -216,8 +204,36 @@ class SageMakerEndpoint(SageMakerBase):
         )
         return client_response
 
+    def process_raw_response(
+        self,
+        raw_response: InvokeEndpointOutputTypeDef,
+        start_t: float,
+        response: InvocationResponse,
+    ) -> None:
+        response.time_to_last_token = time.perf_counter()
 
-class SageMakerStreamEndpoint(SageMakerBase):
+        if raw_response is None:
+            response.error = "Null response from SageMaker endpoint"
+            return
+
+        raw_response_body_json = raw_response["Body"].read().decode("utf-8")
+        raw_response_body = json.loads(raw_response_body_json)
+        raw_response_meta = raw_response_body.get("ResponseMetadata", {})
+
+        response.id = raw_response_meta.get("RequestId")
+        response.retries = raw_response_meta.get("RetryAttempts")
+        response.response_text = jmespath.search(
+            self.generated_text_jmespath, raw_response_body
+        )
+        if self.token_count_jmespath:
+            response.num_tokens_output = jmespath.search(
+                self.token_count_jmespath, raw_response_body
+            )
+
+
+class SageMakerStreamEndpoint(
+    SageMakerBase[InvokeEndpointWithResponseStreamOutputTypeDef]
+):
     """
     A class for handling streaming invocations to a SageMaker endpoint.
 
@@ -225,39 +241,8 @@ class SageMakerStreamEndpoint(SageMakerBase):
     streaming responses from a SageMaker endpoint.
     """
 
-    def parse_response(self, raw_response, start_t: float) -> InvocationResponse:
-        """
-        Parse the streaming response from the SageMaker endpoint.
-
-        This method processes the streaming response, extracting tokens and
-        calculating various timing metrics.
-
-        Args:
-            client_response (dict): The raw response from the SageMaker endpoint.
-            start_t (float): The timestamp when the invocation started.
-
-        Returns:
-            InvocationResponse: An object containing the parsed response and metrics.
-        """
-        token_iterator = TokenIterator(raw_response["Body"])
-        first_token = next(token_iterator)
-        time_to_first_token = time.perf_counter() - start_t
-
-        response_text_tokens = [first_token] + [k for k in token_iterator]
-        time_to_last_token = time.perf_counter() - start_t
-        num_tokens_output = len(response_text_tokens)
-
-        return InvocationResponse(
-            id=raw_response.get("ResponseMetadata", {}).get("RequestId"),
-            response_text="".join(response_text_tokens),
-            time_to_first_token=time_to_first_token,
-            time_to_last_token=time_to_last_token,
-            num_tokens_output=num_tokens_output,
-            retries=raw_response.get("ResponseMetadata", {}).get("RetryAttempts"),
-        )
-
-    @llmeter_invoke
-    def invoke(self, payload: dict) -> InvocationResponse:
+    @SageMakerBase.llmeter_invoke
+    def invoke(self, payload: dict) -> InvokeEndpointWithResponseStreamOutputTypeDef:
         """Invoke a SageMaker streaming endpoint with the given payload."""
         json_payload = json.dumps(payload)
 
@@ -268,13 +253,38 @@ class SageMakerStreamEndpoint(SageMakerBase):
         )
         return client_response
 
-    def prepare_payload(self, payload, **kwargs):
+    def prepare_payload(self, payload):
         if "parameters" in payload:
             payload["parameters"].pop("decoder_input_details", None)
         if "stream" not in payload:
             warnings.warn("stream not specified in payload, defaulting to True")
             payload["stream"] = True
         return payload
+
+    def process_raw_response(
+        self,
+        raw_response: InvokeEndpointWithResponseStreamOutputTypeDef,
+        start_t: float,
+        response: InvocationResponse,
+    ) -> None:
+        response_meta = raw_response.get("ResponseMetadata", {})
+        response.id = response_meta.get("RequestId")
+        response.retries = response_meta.get("RetryAttempts")
+
+        token_iterator = TokenIterator(raw_response["Body"])
+        first_token = next(token_iterator)
+        response.time_to_first_token = time.perf_counter() - start_t
+
+        response_text_tokens = [first_token] + [k for k in token_iterator]
+        response.time_to_last_token = time.perf_counter() - start_t
+        response.response_text = "".join(response_text_tokens)
+
+        if token_iterator.details:
+            response.num_tokens_output = token_iterator.details.get(
+                "generated_tokens", 0
+            )
+        if response.num_tokens_output is None:
+            response.num_tokens_output = len(response_text_tokens)
 
     @staticmethod
     def create_payload(

--- a/llmeter/endpoints/sagemaker.py
+++ b/llmeter/endpoints/sagemaker.py
@@ -207,7 +207,6 @@ class SageMakerEndpoint(SageMakerBase):
     @llmeter_invoke
     def invoke(self, payload: dict) -> InvocationResponse:
         """Invoke the SageMaker endpoint with the given payload."""
-        start_t = time.perf_counter()
         json_payload = json.dumps(payload)
 
         client_response = self._sagemaker_runtime.invoke_endpoint(
@@ -215,7 +214,7 @@ class SageMakerEndpoint(SageMakerBase):
             ContentType="application/json",
             Body=bytes(json_payload, "utf-8"),
         )
-        return self.parse_response(client_response, start_t)
+        return client_response
 
 
 class SageMakerStreamEndpoint(SageMakerBase):
@@ -260,7 +259,6 @@ class SageMakerStreamEndpoint(SageMakerBase):
     @llmeter_invoke
     def invoke(self, payload: dict) -> InvocationResponse:
         """Invoke a SageMaker streaming endpoint with the given payload."""
-        start_t = time.perf_counter()
         json_payload = json.dumps(payload)
 
         client_response = self._sagemaker_runtime.invoke_endpoint_with_response_stream(
@@ -268,7 +266,7 @@ class SageMakerStreamEndpoint(SageMakerBase):
             Body=json_payload,
             ContentType="application/json",
         )
-        return self.parse_response(client_response, start_t)
+        return client_response
 
     def prepare_payload(self, payload, **kwargs):
         if "parameters" in payload:

--- a/llmeter/endpoints/sagemaker.py
+++ b/llmeter/endpoints/sagemaker.py
@@ -6,13 +6,10 @@ import json
 import logging
 import time
 import warnings
-from uuid import uuid4
 
 import boto3
 import jmespath
-from botocore.exceptions import ClientError
 
-from .base import Endpoint, InvocationResponse
 from ..prompt_utils import (
     AudioContent,
     ContentItem,
@@ -21,6 +18,7 @@ from ..prompt_utils import (
     MediaContent,
     VideoContent,
 )
+from .base import Endpoint, InvocationResponse
 
 logger = logging.getLogger(__name__)
 
@@ -174,85 +172,48 @@ class SageMakerEndpoint(SageMakerBase):
     a SageMaker endpoint and parsing its response.
     """
 
-    def _parse_client_response(self, client_response: dict | None) -> dict | None:
-        """
-        Parse the response from the SageMaker endpoint.
-
-        This method processes the raw response from the SageMaker endpoint,
-        extracting the generated text and token count if available.
+    def parse_response(self, client_response, start_t: float) -> InvocationResponse:
+        """Parse the response from the SageMaker endpoint.
 
         Args:
-            client_response (Dict | None): The raw response from the SageMaker endpoint.
+            client_response: The raw response from the SageMaker endpoint.
+            start_t: The timestamp when the request was initiated.
 
         Returns:
-            Dict | None: A dictionary containing the parsed response, or None if the input is None.
+            InvocationResponse with the generated text and metadata.
         """
-
         if client_response is None:
-            return None
+            return InvocationResponse(response_text=None)
+
         client_response_body_json = client_response["Body"].read().decode("utf-8")
         client_response_body = json.loads(client_response_body_json)
-        ret_dict = {
-            "output_text": jmespath.search(
-                self.generated_text_jmespath, client_response_body
-            )
-        }
+
+        response_text = jmespath.search(
+            self.generated_text_jmespath, client_response_body
+        )
+        num_tokens_output = None
         if self.token_count_jmespath:
-            ret_dict["num_tokens_output"] = jmespath.search(
+            num_tokens_output = jmespath.search(
                 self.token_count_jmespath, client_response_body
             )
-        return ret_dict
-
-    def invoke(self, payload: dict) -> InvocationResponse:
-        """
-        Invoke the SageMaker endpoint with the given payload.
-
-        This method sends a request to the SageMaker endpoint, processes the response,
-        and returns an InvocationResponse object with the results.
-
-        Args:
-            payload (Dict): The input payload for the model.
-
-        Returns:
-            InvocationResponse: An object containing the model's response and associated metrics.
-
-        Raises:
-            ClientError: If there's an error during the invocation of the SageMaker endpoint.
-            Exception: If there's any other error during the invocation or parsing of the response.
-        """
-
-        json_payload = json.dumps(payload)
-        input_prompt = self._parse_input(payload)
-
-        start_t = time.perf_counter()
-        try:
-            client_response = self._sagemaker_runtime.invoke_endpoint(
-                EndpointName=self.endpoint_name,
-                ContentType="application/json",
-                Body=bytes(json_payload, "utf-8"),
-            )
-        except (ClientError, Exception) as e:
-            logger.error(e)
-            return InvocationResponse.error_output(
-                input_payload=payload,
-                id=uuid4().hex,
-                error=str(e),
-            )
-
-        time_to_last_token = time.perf_counter() - start_t
-        parsed_response = self._parse_client_response(client_response)
-        if parsed_response:
-            response_text = parsed_response.get("output_text", "")
-            num_tokens_output = parsed_response.get("num_tokens_output", None)
 
         return InvocationResponse(
-            input_payload=payload,
-            id=uuid4().hex,
-            response_text=response_text,
-            time_to_last_token=time_to_last_token,
-            input_prompt=input_prompt,
+            id=client_response.get("ResponseMetadata", {}).get("RequestId"),
+            response_text=response_text or "",
             num_tokens_output=num_tokens_output if num_tokens_output else None,
+            retries=client_response.get("ResponseMetadata", {}).get("RetryAttempts"),
         )
+
+    def invoke(self, payload: dict) -> InvocationResponse:
+        """Invoke the SageMaker endpoint with the given payload."""
+        json_payload = json.dumps(payload)
+
+        client_response = self._sagemaker_runtime.invoke_endpoint(
+            EndpointName=self.endpoint_name,
+            ContentType="application/json",
+            Body=bytes(json_payload, "utf-8"),
+        )
+        return self.parse_response(client_response, self._start_t)
 
 
 class SageMakerStreamEndpoint(SageMakerBase):
@@ -263,9 +224,7 @@ class SageMakerStreamEndpoint(SageMakerBase):
     streaming responses from a SageMaker endpoint.
     """
 
-    def _parse_client_response(
-        self, client_response, start_t: float
-    ) -> InvocationResponse:
+    def parse_response(self, client_response, start_t: float) -> InvocationResponse:
         """
         Parse the streaming response from the SageMaker endpoint.
 
@@ -288,60 +247,32 @@ class SageMakerStreamEndpoint(SageMakerBase):
         num_tokens_output = len(response_text_tokens)
 
         return InvocationResponse(
-            id=uuid4().hex,
+            id=client_response.get("ResponseMetadata", {}).get("RequestId"),
             response_text="".join(response_text_tokens),
             time_to_first_token=time_to_first_token,
             time_to_last_token=time_to_last_token,
             num_tokens_output=num_tokens_output,
+            retries=client_response.get("ResponseMetadata", {}).get("RetryAttempts"),
         )
 
     def invoke(self, payload: dict) -> InvocationResponse:
-        """
-        Invoke a SageMaker endpoint with the given payload.
+        """Invoke a SageMaker streaming endpoint with the given payload."""
+        json_payload = json.dumps(payload)
 
-        This method sends a request to the SageMaker endpoint and handles
-        the streaming response.
+        client_response = self._sagemaker_runtime.invoke_endpoint_with_response_stream(
+            EndpointName=self.endpoint_name,
+            Body=json_payload,
+            ContentType="application/json",
+        )
+        return self.parse_response(client_response, self._start_t)
 
-        Args:
-            payload (Dict): The input payload for the model.
-
-        Returns:
-            InvocationResponse: An object containing the model's response and metrics.
-
-        Raises:
-            Exception: If there's an error during the invocation or parsing of the response.
-        """
-
-        _payload = payload
-        if "parameters" in _payload:
-            _payload["parameters"].pop("decoder_input_details", None)
-        if "stream" not in _payload:
+    def prepare_payload(self, payload, **kwargs):
+        if "parameters" in payload:
+            payload["parameters"].pop("decoder_input_details", None)
+        if "stream" not in payload:
             warnings.warn("stream not specified in payload, defaulting to True")
-            _payload["stream"] = True
-
-        json_payload = json.dumps(_payload)
-        input_prompt = self._parse_input(_payload)
-
-        start_t = time.perf_counter()
-        try:
-            client_response = (
-                self._sagemaker_runtime.invoke_endpoint_with_response_stream(
-                    EndpointName=self.endpoint_name,
-                    Body=json_payload,
-                    ContentType="application/json",
-                )
-            )
-        except Exception as e:
-            logger.error(e)
-            return InvocationResponse.error_output(input_payload=payload, error=str(e))
-
-        try:
-            response = self._parse_client_response(client_response, start_t)
-            response.input_payload = payload
-            response.input_prompt = input_prompt
-            return response
-        except Exception as e:
-            return InvocationResponse.error_output(input_payload=payload, error=str(e))
+            payload["stream"] = True
+        return payload
 
     @staticmethod
     def create_payload(

--- a/llmeter/endpoints/sagemaker.py
+++ b/llmeter/endpoints/sagemaker.py
@@ -172,7 +172,7 @@ class SageMakerEndpoint(SageMakerBase):
     a SageMaker endpoint and parsing its response.
     """
 
-    def parse_response(self, client_response, start_t: float) -> InvocationResponse:
+    def parse_response(self, raw_response, start_t: float) -> InvocationResponse:
         """Parse the response from the SageMaker endpoint.
 
         Args:
@@ -182,10 +182,10 @@ class SageMakerEndpoint(SageMakerBase):
         Returns:
             InvocationResponse with the generated text and metadata.
         """
-        if client_response is None:
+        if raw_response is None:
             return InvocationResponse(response_text=None)
 
-        client_response_body_json = client_response["Body"].read().decode("utf-8")
+        client_response_body_json = raw_response["Body"].read().decode("utf-8")
         client_response_body = json.loads(client_response_body_json)
 
         response_text = jmespath.search(
@@ -198,10 +198,10 @@ class SageMakerEndpoint(SageMakerBase):
             )
 
         return InvocationResponse(
-            id=client_response.get("ResponseMetadata", {}).get("RequestId"),
+            id=raw_response.get("ResponseMetadata", {}).get("RequestId"),
             response_text=response_text or "",
             num_tokens_output=num_tokens_output if num_tokens_output else None,
-            retries=client_response.get("ResponseMetadata", {}).get("RetryAttempts"),
+            retries=raw_response.get("ResponseMetadata", {}).get("RetryAttempts"),
         )
 
     @llmeter_invoke
@@ -225,7 +225,7 @@ class SageMakerStreamEndpoint(SageMakerBase):
     streaming responses from a SageMaker endpoint.
     """
 
-    def parse_response(self, client_response, start_t: float) -> InvocationResponse:
+    def parse_response(self, raw_response, start_t: float) -> InvocationResponse:
         """
         Parse the streaming response from the SageMaker endpoint.
 
@@ -239,7 +239,7 @@ class SageMakerStreamEndpoint(SageMakerBase):
         Returns:
             InvocationResponse: An object containing the parsed response and metrics.
         """
-        token_iterator = TokenIterator(client_response["Body"])
+        token_iterator = TokenIterator(raw_response["Body"])
         first_token = next(token_iterator)
         time_to_first_token = time.perf_counter() - start_t
 
@@ -248,12 +248,12 @@ class SageMakerStreamEndpoint(SageMakerBase):
         num_tokens_output = len(response_text_tokens)
 
         return InvocationResponse(
-            id=client_response.get("ResponseMetadata", {}).get("RequestId"),
+            id=raw_response.get("ResponseMetadata", {}).get("RequestId"),
             response_text="".join(response_text_tokens),
             time_to_first_token=time_to_first_token,
             time_to_last_token=time_to_last_token,
             num_tokens_output=num_tokens_output,
-            retries=client_response.get("ResponseMetadata", {}).get("RetryAttempts"),
+            retries=raw_response.get("ResponseMetadata", {}).get("RetryAttempts"),
         )
 
     @llmeter_invoke

--- a/llmeter/experiments.py
+++ b/llmeter/experiments.py
@@ -9,7 +9,7 @@ single [Run][llmeter.runner.Runner].
 import logging
 import os
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 from math import ceil
 from typing import Callable, Literal
 
@@ -141,7 +141,7 @@ class LoadTest:
         low_memory (bool): When ``True``, responses are written to disk but not kept in
             memory. Requires ``output_path``. Defaults to ``False``.
         progress_bar_stats (dict | None): Controls which live stats appear on the progress
-            bar. See ``RunningStats.DEFAULT_SNAPSHOT_STATS`` for the default.
+            bar. See ``DEFAULT_DISPLAY_STATS`` in ``llmeter.live_display`` for the default.
         output_path (os.PathLike | str | None): Where to save results.
         tokenizer (Tokenizer | None): Optional tokenizer for token counting.
         test_name (str | None): Name for this test. Defaults to current date/time.
@@ -187,9 +187,9 @@ class LoadTest:
     sequence_of_clients: list[int]
     min_requests_per_client: int = 1
     min_requests_per_run: int = 10
-    run_duration: int | float | None = None
+    run_duration: int | float | timedelta | None = None
     low_memory: bool = False
-    progress_bar_stats: dict[str, tuple[str, ...] | str] | None = None
+    progress_bar_stats: dict[str, str | tuple[str, str]] | None = None
     output_path: WritablePathLike | None = None
     tokenizer: Tokenizer | None = None
     test_name: str | None = None

--- a/llmeter/experiments.py
+++ b/llmeter/experiments.py
@@ -120,10 +120,66 @@ class LoadTestResult:
 
 @dataclass
 class LoadTest:
-    """Experiment to explore how performance changes at different concurrency levels
+    """Experiment to explore how performance changes at different concurrency levels.
 
     This experiment creates a series of Runs with different levels of concurrency, defined by
-    `sequence_of_clients`, and runs them one after the other.
+    ``sequence_of_clients``, and runs them one after the other.
+
+    By default, each run sends a fixed number of requests (count-bound). Set ``run_duration``
+    to run each concurrency level for a fixed number of seconds instead (time-bound), which
+    gives a more realistic picture of sustained throughput.
+
+    Attributes:
+        endpoint (Endpoint): The LLM endpoint to test.
+        payload (dict | list[dict]): The request payload(s) to send.
+        sequence_of_clients (list[int]): Concurrency levels to test.
+        min_requests_per_client (int): Minimum requests per client in count-bound mode.
+        min_requests_per_run (int): Minimum total requests per run in count-bound mode.
+        run_duration (int | float | None): When set, each concurrency level runs for this
+            many seconds instead of a fixed request count. Mutually exclusive with
+            ``min_requests_per_client`` / ``min_requests_per_run``.
+        low_memory (bool): When ``True``, responses are written to disk but not kept in
+            memory. Requires ``output_path``. Defaults to ``False``.
+        progress_bar_stats (dict | None): Controls which live stats appear on the progress
+            bar. See ``RunningStats.DEFAULT_SNAPSHOT_STATS`` for the default.
+        output_path (os.PathLike | str | None): Where to save results.
+        tokenizer (Tokenizer | None): Optional tokenizer for token counting.
+        test_name (str | None): Name for this test. Defaults to current date/time.
+        callbacks (list[Callback] | None): Optional callbacks.
+
+    Example::
+
+        # Count-bound: 10 requests per client at each concurrency level
+        load_test = LoadTest(
+            endpoint=my_endpoint,
+            payload=sample_payload,
+            sequence_of_clients=[1, 5, 10, 20],
+            min_requests_per_client=10,
+            output_path="outputs/load_test",
+        )
+        result = await load_test.run()
+        result.plot_results()
+
+        # Time-bound: 60 seconds per concurrency level
+        load_test = LoadTest(
+            endpoint=my_endpoint,
+            payload=sample_payload,
+            sequence_of_clients=[1, 5, 10, 20],
+            run_duration=60,
+            output_path="outputs/load_test",
+        )
+        result = await load_test.run()
+
+        # Time-bound with low-memory mode for large-scale tests
+        load_test = LoadTest(
+            endpoint=my_endpoint,
+            payload=sample_payload,
+            sequence_of_clients=[1, 5, 10, 20, 50],
+            run_duration=120,
+            low_memory=True,
+            output_path="outputs/large_load_test",
+        )
+        result = await load_test.run()
     """
 
     endpoint: Endpoint
@@ -131,6 +187,9 @@ class LoadTest:
     sequence_of_clients: list[int]
     min_requests_per_client: int = 1
     min_requests_per_run: int = 10
+    run_duration: int | float | None = None
+    low_memory: bool = False
+    progress_bar_stats: dict[str, tuple[str, ...] | str] | None = None
     output_path: WritablePathLike | None = None
     tokenizer: Tokenizer | None = None
     test_name: str | None = None
@@ -145,12 +204,39 @@ class LoadTest:
         return int(self.min_requests_per_client)
 
     async def run(self, output_path: WritablePathLike | None = None):
-        """Run the load test.
+        """Run the load test across all configured concurrency levels.
+
+        Creates a :class:`~llmeter.runner.Runner` and iterates through
+        ``sequence_of_clients``, running one test per concurrency level. In
+        time-bound mode (``run_duration`` is set), each level runs for a fixed
+        duration. In count-bound mode, each level sends a fixed number of
+        requests per client.
 
         Args:
             load_path: Optional (local or remote) folder to save results. If provided, individual
             Run results will be written to `{output_path}/{test_name}/{NNNNN-clients}` subfolders.
             Default: `self.output_path` if set, else no files will be saved.
+
+        Returns:
+            LoadTestResult: A result object containing one
+            :class:`~llmeter.results.Result` per concurrency level, keyed by
+            client count.
+
+        Example::
+
+            load_test = LoadTest(
+                endpoint=my_endpoint,
+                payload=sample_payload,
+                sequence_of_clients=[1, 5, 10],
+                run_duration=30,
+            )
+            result = await load_test.run(output_path="outputs/my_test")
+
+            # Access individual results by client count
+            result.results[5].stats["requests_per_minute"]
+
+            # Plot all standard charts
+            result.plot_results()
         """
         output_path = ensure_path(output_path or self.output_path)
         if output_path:
@@ -163,19 +249,34 @@ class LoadTest:
             output_path=test_output_path,
         )
 
-        self._results = [
-            await _runner.run(
-                payload=self.payload,
-                clients=c,
-                n_requests=self._get_n_requests(c),
-                run_name=f"{c:05.0f}-clients",
-                callbacks=self.callbacks,
-                output_path=test_output_path,
-            )
-            for c in tqdm(
-                self.sequence_of_clients, desc="Configurations", disable=_disable_tqdm
-            )
-        ]
+        self._results = []
+        for c in tqdm(
+            self.sequence_of_clients, desc="Configurations", disable=_disable_tqdm
+        ):
+            if self.run_duration is not None:
+                result = await _runner.run(
+                    payload=self.payload,
+                    clients=c,
+                    run_duration=self.run_duration,
+                    run_name=f"{c:05.0f}-clients",
+                    callbacks=self.callbacks,
+                    low_memory=self.low_memory,
+                    progress_bar_stats=self.progress_bar_stats,
+                    output_path=test_output_path,
+                )
+            else:
+                result = await _runner.run(
+                    payload=self.payload,
+                    clients=c,
+                    n_requests=self._get_n_requests(c),
+                    run_name=f"{c:05.0f}-clients",
+                    callbacks=self.callbacks,
+                    low_memory=self.low_memory,
+                    progress_bar_stats=self.progress_bar_stats,
+                    output_path=test_output_path,
+                )
+            self._results.append(result)
+
         return LoadTestResult(
             results={r.clients: r for r in self._results},
             test_name=self._test_name,

--- a/llmeter/json_utils.py
+++ b/llmeter/json_utils.py
@@ -60,7 +60,14 @@ def llmeter_default_serializer(obj: Any) -> Any:
         '{"ts": "2024-01-01T00:00:00"}'
     """
     if hasattr(obj, "to_dict") and callable(obj.to_dict):
-        return obj.to_dict()
+        result = obj.to_dict()
+        if not isinstance(result, dict):
+            # This check guards against infinite recursion in case something tries to serialize a
+            # MagicMock object with this function (in which to_dict returns another mock)
+            raise TypeError(
+                f"{type(obj).__name__}.to_dict() returned {type(result).__name__}, expected dict"
+            )
+        return result
     if isinstance(obj, bytes):
         return {"__llmeter_bytes__": base64.b64encode(obj).decode("utf-8")}
     if isinstance(obj, datetime):

--- a/llmeter/live_display.py
+++ b/llmeter/live_display.py
@@ -1,0 +1,238 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Live-updating stats display for test runs.
+
+Renders a compact table of running statistics that updates in-place during a run.
+In Jupyter notebooks, uses an HTML table via IPython.display. In terminals, falls
+back to a simple printed summary that overwrites itself.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from collections import OrderedDict
+
+logger = logging.getLogger(__name__)
+
+# Mapping from key substrings to (group_name, display_order).
+# Stats are grouped by the first matching pattern; unmatched keys go to "Other".
+_GROUP_PATTERNS: list[tuple[str, str]] = [
+    ("rpm", "Throughput"),
+    ("tps", "Throughput"),
+    ("ttft", "TTFT"),
+    ("ttlt", "TTLT"),
+    ("token", "Tokens"),
+    ("fail", "Errors"),
+]
+
+_GROUP_ORDER = ["Throughput", "TTFT", "TTLT", "Tokens", "Errors", "Other"]
+
+
+def _classify(key: str) -> str:
+    """Return the group name for a stat key based on substring matching.
+
+    Matches the key (case-insensitive) against ``_GROUP_PATTERNS``. The first
+    matching pattern determines the group. Unmatched keys are placed in
+    ``"Other"``.
+
+    Args:
+        key (str): The stat display label to classify (e.g. ``"p50_ttft"``).
+
+    Returns:
+        str: The group name (e.g. ``"TTFT"``, ``"Throughput"``, ``"Other"``).
+    """
+    key_lower = key.lower()
+    for pattern, group in _GROUP_PATTERNS:
+        if pattern in key_lower:
+            return group
+    return "Other"
+
+
+def _group_stats(stats: dict[str, str]) -> OrderedDict[str, list[tuple[str, str]]]:
+    """Organize stats into ordered groups for display.
+
+    Each stat key is classified via :func:`_classify` and placed into the
+    corresponding group. Groups are returned in the canonical order defined
+    by ``_GROUP_ORDER``, with empty groups omitted.
+
+    Args:
+        stats (dict[str, str]): Mapping of stat labels to formatted values.
+
+    Returns:
+        OrderedDict[str, list[tuple[str, str]]]: Groups in display order, where
+        each value is a list of ``(label, formatted_value)`` tuples.
+    """
+    groups: dict[str, list[tuple[str, str]]] = {}
+    for k, v in stats.items():
+        group = _classify(k)
+        groups.setdefault(group, []).append((k, v))
+    # Return in canonical order, skipping empty groups
+    return OrderedDict((g, groups[g]) for g in _GROUP_ORDER if g in groups)
+
+
+def _in_notebook() -> bool:
+    """Detect if we're running inside a Jupyter/IPython notebook.
+
+    Returns:
+        bool: ``True`` if the current IPython shell is a ``ZMQInteractiveShell``
+        (i.e. a Jupyter kernel), ``False`` otherwise or if IPython is not
+        installed.
+    """
+    try:
+        from IPython import get_ipython
+
+        shell = get_ipython()
+        if shell is None:
+            return False
+        return shell.__class__.__name__ == "ZMQInteractiveShell"
+    except ImportError:
+        return False
+
+
+class LiveStatsDisplay:
+    """Live-updating stats display that works in both notebooks and terminals.
+
+    In Jupyter notebooks, renders a grouped HTML table that updates in-place.
+    Stats are automatically organized into logical groups (Throughput, TTFT,
+    TTLT, Tokens, Errors) based on their key names.
+
+    In terminals, prints a compact grouped multi-line block using ANSI escape
+    codes to overwrite previous output.
+
+    Args:
+        disabled (bool): If ``True``, all display calls are no-ops.
+
+    Example::
+
+        display = LiveStatsDisplay()
+        display.update({"rpm": "185.9", "p50_ttft": "0.312s", "fail": "0"})
+        display.update({"rpm": "190.2", "p50_ttft": "0.305s", "fail": "1"})
+        display.close()
+    """
+
+    def __init__(self, disabled: bool = False):
+        self._disabled = disabled
+        self._is_notebook = _in_notebook()
+        self._handle = None
+        self._last_line_count = 0
+
+    def update(self, stats: dict[str, str], extra_prefix: str = "") -> None:
+        """Refresh the display with new stats.
+
+        Args:
+            stats (dict[str, str]): Mapping of label to formatted value.
+            extra_prefix (str): Optional prefix text shown before the table
+                (e.g. ``"reqs=127"`` for time-bound runs).
+        """
+        if self._disabled or not stats:
+            return
+
+        if self._is_notebook:
+            self._update_notebook(stats, extra_prefix)
+        else:
+            self._update_terminal(stats, extra_prefix)
+
+    def _update_notebook(self, stats: dict[str, str], extra_prefix: str) -> None:
+        """Render stats as a grouped HTML table in a Jupyter notebook.
+
+        Groups stats into columns (Throughput, TTFT, TTLT, Tokens, Errors) and
+        renders them as an HTML ``<table>`` that updates in-place via
+        ``IPython.display``.
+
+        Args:
+            stats (dict[str, str]): Mapping of label to formatted value.
+            extra_prefix (str): Optional text shown above the table.
+        """
+        from IPython.display import HTML, display
+
+        groups = _group_stats(stats)
+
+        # Build one column per group: header on top, key=value rows below
+        # All columns rendered side-by-side in a single table row
+        max_rows = max(len(items) for items in groups.values())
+
+        col_htmls = []
+        for group_name, items in groups.items():
+            col = (
+                f"<th style='padding:2px 10px;font-size:11px;color:#888;"
+                f"border-bottom:1px solid #ddd;text-align:left'>"
+                f"{group_name}</th>"
+            )
+            rows = []
+            for k, v in items:
+                rows.append(
+                    f"<td style='padding:1px 10px;font-size:12px'>"
+                    f"<span style='color:#666'>{k}</span>"
+                    f"&nbsp;&nbsp;"
+                    f"<span style='font-family:monospace'>{v}</span>"
+                    f"</td>"
+                )
+            # Pad shorter columns
+            for _ in range(max_rows - len(items)):
+                rows.append("<td></td>")
+            col_htmls.append((col, rows))
+
+        # Assemble: header row, then data rows
+        header_row = "<tr>" + "".join(c[0] for c in col_htmls) + "</tr>"
+        data_rows = ""
+        for i in range(max_rows):
+            data_rows += "<tr>" + "".join(c[1][i] for c in col_htmls) + "</tr>"
+
+        prefix_html = (
+            f"<span style='font-size:12px;font-family:monospace;color:#555'>"
+            f"{extra_prefix}</span><br>"
+            if extra_prefix
+            else ""
+        )
+        html = (
+            f"{prefix_html}"
+            f"<table style='border-collapse:collapse;margin:4px 0'>"
+            f"{header_row}{data_rows}</table>"
+        )
+
+        if self._handle is None:
+            self._handle = display(HTML(html), display_id=True)
+        else:
+            self._handle.update(HTML(html))
+
+    def _update_terminal(self, stats: dict[str, str], extra_prefix: str) -> None:
+        """Render stats as grouped text lines in a terminal.
+
+        Uses ANSI escape codes to erase the previous output and overwrite it
+        with the updated stats, one line per group.
+
+        Args:
+            stats (dict[str, str]): Mapping of label to formatted value.
+            extra_prefix (str): Optional text shown on the first line.
+        """
+        # Erase previous output
+        if self._last_line_count > 0:
+            sys.stderr.write(f"\033[{self._last_line_count}A\033[J")
+
+        groups = _group_stats(stats)
+        lines = []
+        if extra_prefix:
+            lines.append(f"  {extra_prefix}")
+        for group_name, items in groups.items():
+            values = "  ".join(f"{k}={v}" for k, v in items)
+            lines.append(f"  {group_name}: {values}")
+
+        output = "\n".join(lines)
+        sys.stderr.write(output + "\n")
+        sys.stderr.flush()
+        self._last_line_count = len(lines)
+
+    def close(self) -> None:
+        """Clean up the display.
+
+        In terminal mode, erases the stats block using ANSI escape codes.
+        In notebook mode, the HTML output remains visible.
+        """
+        if self._disabled:
+            return
+        # In terminal, erase the stats block
+        if not self._is_notebook and self._last_line_count > 0:
+            sys.stderr.write(f"\033[{self._last_line_count}A\033[J")
+            sys.stderr.flush()
+            self._last_line_count = 0

--- a/llmeter/live_display.py
+++ b/llmeter/live_display.py
@@ -15,60 +15,117 @@ from collections import OrderedDict
 
 logger = logging.getLogger(__name__)
 
-# Mapping from key substrings to (group_name, display_order).
-# Stats are grouped by the first matching pattern; unmatched keys go to "Other".
-_GROUP_PATTERNS: list[tuple[str, str]] = [
-    ("rpm", "Throughput"),
-    ("tps", "Throughput"),
-    ("ttft", "TTFT"),
-    ("ttlt", "TTLT"),
-    ("token", "Tokens"),
-    ("fail", "Errors"),
-]
+#: Default grouping of stat keys for display.  Each entry is
+#: ``(group_name, tuple_of_substrings)``; a stat key is assigned to the first
+#: group whose substring matches (case-insensitive).  Unmatched keys fall into
+#: ``"Other"``.  The tuple order defines the column order in the rendered table.
+DEFAULT_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("Throughput", ("rpm", "tps")),
+    ("TTFT", ("ttft",)),
+    ("TTLT", ("ttlt",)),
+    ("Tokens", ("token",)),
+    ("Errors", ("fail",)),
+    ("Other", ("",)),
+)
 
-_GROUP_ORDER = ["Throughput", "TTFT", "TTLT", "Tokens", "Errors", "Other"]
+#: Default stats to show on the progress bar during a run.
+#:
+#: Each entry maps a short display label to a *stat spec*:
+#:
+#: * A plain string — the canonical key in ``RunningStats.to_stats()``
+#:   (e.g. ``"failed_requests"``, ``"rpm"``, ``"time_to_first_token-p50"``).
+#: * A ``(stat_key, "inv")`` tuple — display the reciprocal of the value
+#:   (e.g. seconds-per-token → tokens-per-second).
+DEFAULT_DISPLAY_STATS: dict[str, str | tuple[str, str]] = {
+    "rpm": "rpm",
+    "output_tps": "output_tps",
+    "p50_ttft": "time_to_first_token-p50",
+    "p90_ttft": "time_to_first_token-p90",
+    "p50_ttlt": "time_to_last_token-p50",
+    "p90_ttlt": "time_to_last_token-p90",
+    "p50_tps": ("time_per_output_token-p50", "inv"),
+    "input_tokens": "num_tokens_input-sum",
+    "output_tokens": "num_tokens_output-sum",
+    "fail": "failed_requests",
+}
 
 
-def _classify(key: str) -> str:
+def _format_stat(key: str, value: float | int, *, invert: bool = False) -> str:
+    """Format a single stat value as a human-readable string.
+
+    Args:
+        key: The canonical stat key (used to infer units).
+        value: The raw numeric value.
+        invert: If ``True``, display ``1/value`` (e.g. time → rate).
+
+    Returns:
+        A formatted string like ``"0.312s"``, ``"28.3 tok/s"``, or ``"83"``.
+    """
+    if invert and value > 0:
+        return f"{1.0 / value:.1f} tok/s"
+    if "tps" in key or "output_tps" in key:
+        return f"{value:.1f} tok/s"
+    if "time" in key or "ttft" in key or "ttlt" in key:
+        return f"{value:.3f}s"
+    if "rpm" in key:
+        return f"{value:.1f}"
+    if isinstance(value, float) and value == int(value):
+        return str(int(value))
+    if isinstance(value, int):
+        return str(value)
+    return f"{value:.1f}"
+
+
+def _classify(
+    key: str,
+    groups: tuple[tuple[str, tuple[str, ...]], ...] = DEFAULT_GROUPS,
+) -> str:
     """Return the group name for a stat key based on substring matching.
 
-    Matches the key (case-insensitive) against ``_GROUP_PATTERNS``. The first
-    matching pattern determines the group. Unmatched keys are placed in
-    ``"Other"``.
+    Matches the key (case-insensitive) against *groups*. The first matching
+    pattern determines the group. Unmatched keys are placed in ``"Other"``.
 
     Args:
         key (str): The stat display label to classify (e.g. ``"p50_ttft"``).
+        groups: Group definitions to match against. Defaults to
+            :data:`DEFAULT_GROUPS`.
 
     Returns:
         str: The group name (e.g. ``"TTFT"``, ``"Throughput"``, ``"Other"``).
     """
     key_lower = key.lower()
-    for pattern, group in _GROUP_PATTERNS:
-        if pattern in key_lower:
-            return group
+    for group_name, patterns in groups:
+        for pattern in patterns:
+            if pattern and pattern in key_lower:
+                return group_name
     return "Other"
 
 
-def _group_stats(stats: dict[str, str]) -> OrderedDict[str, list[tuple[str, str]]]:
+def _group_stats(
+    stats: dict[str, str],
+    groups: tuple[tuple[str, tuple[str, ...]], ...] = DEFAULT_GROUPS,
+) -> OrderedDict[str, list[tuple[str, str]]]:
     """Organize stats into ordered groups for display.
 
     Each stat key is classified via :func:`_classify` and placed into the
     corresponding group. Groups are returned in the canonical order defined
-    by ``_GROUP_ORDER``, with empty groups omitted.
+    by *groups*, with empty groups omitted.
 
     Args:
         stats (dict[str, str]): Mapping of stat labels to formatted values.
+        groups: Group definitions controlling classification and order.
+            Defaults to :data:`DEFAULT_GROUPS`.
 
     Returns:
         OrderedDict[str, list[tuple[str, str]]]: Groups in display order, where
         each value is a list of ``(label, formatted_value)`` tuples.
     """
-    groups: dict[str, list[tuple[str, str]]] = {}
+    buckets: dict[str, list[tuple[str, str]]] = {}
     for k, v in stats.items():
-        group = _classify(k)
-        groups.setdefault(group, []).append((k, v))
-    # Return in canonical order, skipping empty groups
-    return OrderedDict((g, groups[g]) for g in _GROUP_ORDER if g in groups)
+        group = _classify(k, groups)
+        buckets.setdefault(group, []).append((k, v))
+    group_order = [name for name, _ in groups]
+    return OrderedDict((g, buckets[g]) for g in group_order if g in buckets)
 
 
 def _in_notebook() -> bool:
@@ -95,43 +152,114 @@ class LiveStatsDisplay:
 
     In Jupyter notebooks, renders a grouped HTML table that updates in-place.
     Stats are automatically organized into logical groups (Throughput, TTFT,
-    TTLT, Tokens, Errors) based on their key names.
+    TTLT, Tokens, Errors) based on their display label names.
 
     In terminals, prints a compact grouped multi-line block using ANSI escape
     codes to overwrite previous output.
 
+    The display owns all alias mapping and formatting.  Callers pass raw
+    numeric stats (e.g. from ``RunningStats.to_stats()``) and the display
+    selects, aliases, formats, and groups them for presentation.
+
     Args:
         disabled (bool): If ``True``, all display calls are no-ops.
+        groups: Group definitions controlling how display labels are classified
+            and ordered.  Defaults to :data:`DEFAULT_GROUPS`.
+        display_stats: Mapping of ``{display_label: stat_spec}`` controlling
+            which stats to show and how to label them.  Each *stat_spec* is
+            either a plain canonical key string (e.g. ``"time_to_first_token-p50"``)
+            or a ``(key, "inv")`` tuple for reciprocal display.
+            Defaults to :data:`DEFAULT_DISPLAY_STATS`.
 
     Example::
 
         display = LiveStatsDisplay()
-        display.update({"rpm": "185.9", "p50_ttft": "0.312s", "fail": "0"})
-        display.update({"rpm": "190.2", "p50_ttft": "0.305s", "fail": "1"})
+        raw = running_stats.to_stats()
+        display.update(raw)
         display.close()
     """
 
-    def __init__(self, disabled: bool = False):
+    def __init__(
+        self,
+        disabled: bool = False,
+        groups: tuple[tuple[str, tuple[str, ...]], ...] = DEFAULT_GROUPS,
+        display_stats: dict[str, str | tuple[str, str]] | None = None,
+    ):
         self._disabled = disabled
+        self._groups = groups
+        self._display_stats = (
+            display_stats if display_stats is not None else DEFAULT_DISPLAY_STATS
+        )
         self._is_notebook = _in_notebook()
         self._handle = None
         self._last_line_count = 0
 
-    def update(self, stats: dict[str, str], extra_prefix: str = "") -> None:
-        """Refresh the display with new stats.
+    def format_stats(
+        self,
+        raw: dict[str, object],
+    ) -> dict[str, str]:
+        """Select and format raw stats for display.
+
+        Picks the stats listed in ``self._display_stats`` from *raw*, applies
+        alias renaming and formatting, and returns an ordered dict of
+        ``{display_label: formatted_value}`` strings.
 
         Args:
-            stats (dict[str, str]): Mapping of label to formatted value.
+            raw: Flat dictionary of raw numeric stats, as returned by
+                ``RunningStats.to_stats()``.
+
+        Returns:
+            Ordered dict of ``{label: formatted_string}`` suitable for
+            rendering.
+        """
+        if not raw:
+            return {label: "—" for label in self._display_stats}
+
+        info: dict[str, str] = {}
+        for label, spec in self._display_stats.items():
+            if isinstance(spec, tuple):
+                key, modifier = spec[0], spec[1]
+                invert = modifier == "inv"
+            else:
+                key = spec
+                invert = False
+
+            val = raw.get(key)
+            if val is None:
+                info[label] = "—"
+                continue
+
+            try:
+                info[label] = _format_stat(key, float(val), invert=invert)
+            except (TypeError, ValueError):
+                info[label] = str(val)
+
+        return info
+
+    def update(
+        self,
+        raw_stats: dict[str, object],
+        extra_prefix: str = "",
+    ) -> None:
+        """Refresh the display with new raw stats.
+
+        Args:
+            raw_stats: Flat dictionary of raw numeric stats from
+                ``RunningStats.to_stats()``.
             extra_prefix (str): Optional prefix text shown before the table
                 (e.g. ``"reqs=127"`` for time-bound runs).
         """
-        if self._disabled or not stats:
+        if self._disabled:
+            return
+
+        formatted = self.format_stats(raw_stats)
+        if not formatted:
             return
 
         if self._is_notebook:
-            self._update_notebook(stats, extra_prefix)
+            self._update_notebook(formatted, extra_prefix)
         else:
-            self._update_terminal(stats, extra_prefix)
+            self._update_terminal(formatted, extra_prefix)
 
     def _update_notebook(self, stats: dict[str, str], extra_prefix: str) -> None:
         """Render stats as a grouped HTML table in a Jupyter notebook.
@@ -146,9 +274,7 @@ class LiveStatsDisplay:
         """
         from IPython.display import HTML, display
 
-        groups = _group_stats(stats)
-
-        # Build one column per group: header on top, key=value rows below
+        groups = _group_stats(stats, self._groups)
         # All columns rendered side-by-side in a single table row
         max_rows = max(len(items) for items in groups.values())
 
@@ -210,7 +336,7 @@ class LiveStatsDisplay:
         if self._last_line_count > 0:
             sys.stderr.write(f"\033[{self._last_line_count}A\033[J")
 
-        groups = _group_stats(stats)
+        groups = _group_stats(stats, self._groups)
         lines = []
         if extra_prefix:
             lines.append(f"  {extra_prefix}")

--- a/llmeter/live_display.py
+++ b/llmeter/live_display.py
@@ -33,19 +33,19 @@ DEFAULT_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
 #: Each entry maps a short display label to a *stat spec*:
 #:
 #: * A plain string — the canonical key in ``RunningStats.to_stats()``
-#:   (e.g. ``"failed_requests"``, ``"rpm"``, ``"time_to_first_token-p50"``).
+#:   (e.g. ``"failed_requests"``, ``"time_to_first_token-p50"``).
 #: * A ``(stat_key, "inv")`` tuple — display the reciprocal of the value
 #:   (e.g. seconds-per-token → tokens-per-second).
 DEFAULT_DISPLAY_STATS: dict[str, str | tuple[str, str]] = {
-    "rpm": "rpm",
+    "rpm": "requests_per_minute",
     "output_tps": "output_tps",
     "p50_ttft": "time_to_first_token-p50",
     "p90_ttft": "time_to_first_token-p90",
     "p50_ttlt": "time_to_last_token-p50",
     "p90_ttlt": "time_to_last_token-p90",
     "p50_tps": ("time_per_output_token-p50", "inv"),
-    "input_tokens": "num_tokens_input-sum",
-    "output_tokens": "num_tokens_output-sum",
+    "input_tokens": "total_input_tokens",
+    "output_tokens": "total_output_tokens",
     "fail": "failed_requests",
 }
 
@@ -67,10 +67,8 @@ def _format_stat(key: str, value: float | int, *, invert: bool = False) -> str:
         return f"{value:.1f} tok/s"
     if "time" in key or "ttft" in key or "ttlt" in key:
         return f"{value:.3f}s"
-    if "rpm" in key:
+    if "_per_minute" in key:
         return f"{value:.1f}"
-    if isinstance(value, float) and value == int(value):
-        return str(int(value))
     if isinstance(value, int):
         return str(value)
     return f"{value:.1f}"

--- a/llmeter/plotting/__init__.py
+++ b/llmeter/plotting/__init__.py
@@ -8,11 +8,11 @@ or via the `llmeter[plotting]` extra.
 
 from .plotting import (
     boxplot_by_dimension,
-    plot_heatmap,
-    scatter_histogram_2d,
-    plot_load_test_results,
-    histogram_by_dimension,
     color_sequences,
+    histogram_by_dimension,
+    plot_heatmap,
+    plot_load_test_results,
+    scatter_histogram_2d,
 )
 
 __all__ = [

--- a/llmeter/prompt_utils.py
+++ b/llmeter/prompt_utils.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Iterator
 from upath import UPath as Path
 from upath.types import ReadablePathLike, WritablePathLike
 
-from .json_utils import llmeter_default_serializer, llmeter_bytes_decoder
+from .json_utils import llmeter_bytes_decoder, llmeter_default_serializer
 from .tokenizers import DummyTokenizer, Tokenizer
 from .utils import DeferredError, ensure_path
 

--- a/llmeter/results.py
+++ b/llmeter/results.py
@@ -34,6 +34,8 @@ class Result:
     run_name: str | None = None
     run_description: str | None = None
     start_time: datetime | None = None
+    first_request_time: datetime | None = None
+    last_request_time: datetime | None = None
     end_time: datetime | None = None
 
     def __str__(self):
@@ -128,7 +130,12 @@ class Result:
         """Return the results as a dictionary with JSON-serializable values."""
         data = asdict(self)
         # Serialize datetime objects so stats dict is always JSON-safe
-        for key in ("start_time", "end_time"):
+        for key in (
+            "start_time",
+            "end_time",
+            "first_request_time",
+            "last_request_time",
+        ):
             if key in data and isinstance(data[key], datetime):
                 data[key] = llmeter_default_serializer(data[key])
         if include_responses:
@@ -204,7 +211,12 @@ class Result:
             summary = json.load(g)
 
         # Convert datetime strings back to datetime objects
-        for key in ["start_time", "end_time"]:
+        for key in [
+            "start_time",
+            "end_time",
+            "first_request_time",
+            "last_request_time",
+        ]:
             if key in summary and summary[key] and isinstance(summary[key], str):
                 try:
                     summary[key] = datetime.fromisoformat(summary[key])
@@ -241,7 +253,12 @@ class Result:
                 with stats_path.open("r") as s:
                     result._preloaded_stats = json.loads(s.read())
                     # Convert datetime strings in stats
-                    for key in ["start_time", "end_time"]:
+                    for key in [
+                        "start_time",
+                        "end_time",
+                        "first_request_time",
+                        "last_request_time",
+                    ]:
                         val = result._preloaded_stats.get(key)
                         if val and isinstance(val, str):
                             try:

--- a/llmeter/results.py
+++ b/llmeter/results.py
@@ -23,9 +23,9 @@ class Result:
     """Results of a test run."""
 
     responses: list[InvocationResponse]
-    total_requests: int
-    clients: int
-    n_requests: int
+    total_requests: int | None = None
+    clients: int = 1
+    n_requests: int | None = None
     total_test_time: float | None = None
     model_id: str | None = None
     output_path: WritablePathLike | None = None
@@ -253,8 +253,19 @@ class Result:
             else:
                 result._preloaded_stats = None
         else:
-            # Compute stats from the loaded responses
+            # Compute stats from the loaded responses, but also merge any
+            # contributed stats that were persisted in stats.json so they
+            # survive a save/load round-trip.
             result._preloaded_stats = cls._compute_stats(result)
+            stats_path = result_path / "stats.json"
+            if stats_path.exists():
+                with stats_path.open("r") as s:
+                    saved_stats = json.loads(s.read())
+                # Contributed stats are any keys in the saved file that are
+                # not produced by _compute_stats (i.e. they came from callbacks).
+                for key, value in saved_stats.items():
+                    if key not in result._preloaded_stats:
+                        result._preloaded_stats[key] = value
 
         return result
 
@@ -330,7 +341,9 @@ class Result:
             stats = self._preloaded_stats.copy()
         else:
             # Fallback: compute from responses (e.g. Result constructed manually)
-            stats = self._compute_stats(self)
+            # Cache so subsequent accesses don't recompute.
+            self._preloaded_stats = self._compute_stats(self)
+            stats = self._preloaded_stats.copy()
 
         if self._contributed_stats:
             stats.update(self._contributed_stats)

--- a/llmeter/results.py
+++ b/llmeter/results.py
@@ -281,6 +281,7 @@ class Result:
             "time_to_first_token",
             "num_tokens_output",
             "num_tokens_input",
+            "num_tokens_input_cached",
         ]
 
         results_stats = _get_stats_from_results(
@@ -442,6 +443,9 @@ def _get_run_stats(results: Result):
     )
     stats["total_output_tokens"] = sum(
         jmespath.search("[:].num_tokens_output", data=data)
+    )
+    stats["total_cached_input_tokens"] = sum(
+        v for v in jmespath.search("[:].num_tokens_input_cached", data=data) if v
     )
     stats["average_input_tokens_per_minute"] = (
         results.total_test_time

--- a/llmeter/results.py
+++ b/llmeter/results.py
@@ -5,7 +5,6 @@ import json
 import logging
 from dataclasses import asdict, dataclass
 from datetime import datetime
-from functools import cached_property
 from numbers import Number
 from typing import Any, Sequence
 
@@ -162,8 +161,8 @@ class Result:
                 InvocationResponse(**json.loads(line)) for line in f if line
             ]
         logger.info("Loaded %d responses from %s", len(self.responses), responses_path)
-        # Invalidate cached stats so they are recomputed with the loaded responses
-        self.__dict__.pop("_builtin_stats", None)
+        # Recompute stats from the freshly loaded responses
+        self._preloaded_stats = self._compute_stats(self)
         return self.responses
 
     @classmethod
@@ -234,9 +233,9 @@ class Result:
 
         result = cls(responses=responses, **summary)
 
-        # When skipping responses, load pre-computed stats from stats.json if available
-        # so that result.stats works without needing the responses
+        # Load or compute stats
         if not load_responses:
+            # Use pre-computed stats from disk when responses aren't loaded
             stats_path = result_path / "stats.json"
             if stats_path.exists():
                 with stats_path.open("r") as s:
@@ -253,29 +252,34 @@ class Result:
                                 pass
             else:
                 result._preloaded_stats = None
+        else:
+            # Compute stats from the loaded responses
+            result._preloaded_stats = cls._compute_stats(result)
 
         return result
 
-    @cached_property
-    def _builtin_stats(self) -> dict:
-        """
-        Default run metrics and aggregated statistics provided by LLMeter core
+    @classmethod
+    def _compute_stats(cls, result: "Result") -> dict:
+        """Compute stats from in-memory responses.
 
-        Users should generally refer to the `.stats` property instead, which combines this data
-        with any additional values contributed by callbacks or other extensions.
+        This is the fallback used when ``_preloaded_stats`` is not available — for
+        example when a ``Result`` is constructed manually or after
+        :meth:`load_responses` reloads data from disk.
 
-        This is a read-only and `@cached_property`, which means the result is computed once and
-        then cached for subsequent accesses - improving performance.
+        Args:
+            result: A ``Result`` instance whose ``responses`` list is populated.
 
         Returns:
-            stats: A dictionary containing all computed statistics. The keys are:
-                - All key-value pairs from the Result's dictionary representation
-                - Test-specific statistics
-                - Aggregated statistics with keys in the format "{stat_name}-{aggregation_type}"
-                  where stat_name is one of the four metrics listed above, and
-                  aggregation_type includes measures like mean, median, etc.
-        """
+            A flat dictionary matching the ``Result.stats`` schema, containing
+            run-level metrics (``failed_requests``, ``requests_per_minute``, …)
+            and per-metric aggregations (``time_to_first_token-p50``, …).
 
+        Example::
+
+            result = Result(responses=my_responses, total_requests=100, ...)
+            stats = Result._compute_stats(result)
+            stats["time_to_first_token-p90"]  # 0.485
+        """
         aggregation_metrics = [
             "time_to_last_token",
             "time_to_first_token",
@@ -283,49 +287,50 @@ class Result:
             "num_tokens_input",
             "num_tokens_input_cached",
         ]
-
-        results_stats = _get_stats_from_results(
-            self,
-            aggregation_metrics,
-        )
+        results_stats = _get_stats_from_results(result, aggregation_metrics)
         return {
-            **self.to_dict(),
-            **_get_run_stats(self),
+            **result.to_dict(),
+            **_get_run_stats(result),
             **{f"{k}-{j}": v for k, o in results_stats.items() for j, v in o.items()},
         }
 
     @property
     def stats(self) -> dict:
+        """Run metrics and aggregated statistics over the individual requests.
+
+        Returns a flat dictionary combining:
+
+        * Basic run information (from ``to_dict()``).
+        * Aggregated statistics (``average``, ``p50``, ``p90``, ``p99``) for
+          ``time_to_last_token``, ``time_to_first_token``, ``num_tokens_output``,
+          and ``num_tokens_input``.  Keys use the format
+          ``"{metric}-{aggregation}"``.
+        * Run-level throughput metrics (``requests_per_minute``,
+          ``total_input_tokens``, etc.).
+        * Any additional stats contributed by callbacks via
+          :meth:`_update_contributed_stats`.
+
+        During a live run, stats are computed incrementally by
+        :class:`~llmeter.utils.RunningStats` and stored in ``_preloaded_stats``.
+        When loading from disk with ``load_responses=False``, pre-computed stats
+        from ``stats.json`` are used.  As a fallback (e.g. manually constructed
+        ``Result``), stats are computed on the fly from ``self.responses``.
+
+        Returns:
+            A new shallow copy of the stats dictionary on each access.
+
+        Example::
+
+            result = await runner.run(payload=my_payload, clients=5)
+            result.stats["time_to_first_token-p50"]   # 0.312
+            result.stats["requests_per_minute"]        # 141.2
+            result.stats["failed_requests"]            # 0
         """
-        Run metrics and aggregated statistics over the individual requests
-
-        This combined view includes:
-        - Basic information about the run (from the Result's dictionary representation)
-        - Aggregated statistics ('average', 'p50', 'p90', 'p99') for:
-            - Time to last token
-            - Time to first token
-            - Number of tokens output
-            - Number of tokens input
-
-        Aggregated statistics are keyed in the format "{stat_name}-{aggregation_type}"
-
-        This property is read-only and returns a new shallow copy of the data on each access.
-        Default stats provided by LLMeter are calculated on first access and then cached. Callbacks
-        Callbacks or other mechanisms needing to augment stats should use the
-        `_update_contributed_stats()` method.
-
-        When the Result was loaded with ``load_responses=False``, pre-computed stats from
-        ``stats.json`` are returned if available. Call ``load_responses()`` to load the
-        individual responses and recompute stats from the raw data.
-        """
-        # Use preloaded stats when responses were not loaded
-        if not self.responses and self._preloaded_stats is not None:
+        if self._preloaded_stats is not None:
             stats = self._preloaded_stats.copy()
-            if self._contributed_stats:
-                stats.update(self._contributed_stats)
-            return stats
-
-        stats = self._builtin_stats.copy()
+        else:
+            # Fallback: compute from responses (e.g. Result constructed manually)
+            stats = self._compute_stats(self)
 
         if self._contributed_stats:
             stats.update(self._contributed_stats)

--- a/llmeter/runner.py
+++ b/llmeter/runner.py
@@ -12,7 +12,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from dataclasses import InitVar, asdict, dataclass, fields, replace
-from datetime import datetime
+from datetime import datetime, timedelta
 from itertools import cycle
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
@@ -59,14 +59,14 @@ class _RunConfig:
     tokenizer: Tokenizer | Any | None = None
     clients: int = 1
     n_requests: int | None = None
-    run_duration: int | float | None = None
+    run_duration: int | float | timedelta | None = None
     payload: dict | list[dict] | ReadablePathLike | None = None
     run_name: str | None = None
     run_description: str | None = None
     timeout: int | float = 60
     callbacks: list[Callback] | None = None
     low_memory: bool = False
-    progress_bar_stats: dict[str, tuple[str, ...] | str] | None = None
+    progress_bar_stats: dict[str, str | tuple[str, str]] | None = None
     disable_per_client_progress_bar: InitVar[bool] = True
     disable_clients_progress_bar: InitVar[bool] = True
 
@@ -75,10 +75,12 @@ class _RunConfig:
         self._disable_clients_progress_bar = disable_clients_progress_bar
         self._random_seed = 0
 
-        if self.n_requests is not None:
+        if self.n_requests is not None and self.run_duration is None:
             assert self.n_requests > 0, "Number of requests must be a positive integer"
 
         if self.run_duration is not None:
+            if isinstance(self.run_duration, timedelta):
+                self.run_duration = self.run_duration.total_seconds()
             assert self.run_duration > 0, "Run duration must be a positive number"
 
         assert self.clients > 0, "Number of clients must be a positive integer"
@@ -196,10 +198,10 @@ class _Run(_RunConfig):
 
         Normalizes the payload into a list of dicts, validates that ``n_requests``
         and ``run_duration`` are not both set, and sets ``_time_bound`` and
-        ``_n_requests`` accordingly.
+        ``n_requests`` accordingly.
 
-        For count-bound runs, ``_n_requests`` defaults to the number of payloads
-        when not explicitly provided. For time-bound runs, ``_n_requests`` is set
+        For count-bound runs, ``n_requests`` defaults to the number of payloads
+        when not explicitly provided. For time-bound runs, ``n_requests`` is set
         to 0 since the actual count is unknown upfront.
 
         Raises:
@@ -213,7 +215,11 @@ class _Run(_RunConfig):
         if isinstance(self.payload, dict):
             self.payload = [self.payload]
 
-        if self.run_duration is not None and self.n_requests is not None:
+        if (
+            self.run_duration is not None
+            and self.n_requests is not None
+            and self.n_requests != 0
+        ):
             raise ValueError(
                 "Cannot set both n_requests and run_duration. "
                 "Use n_requests for request-bound runs or run_duration for time-bound runs."
@@ -221,10 +227,11 @@ class _Run(_RunConfig):
 
         self._time_bound = self.run_duration is not None
         if self._time_bound:
-            # For time-bound runs, _n_requests is unknown upfront
-            self._n_requests = 0
+            # For time-bound runs, n_requests is unknown upfront; set to 0
+            # and update to the actual count after the run completes.
+            self.n_requests = 0
         else:
-            self._n_requests = self.n_requests or len(self.payload)
+            self.n_requests = self.n_requests or len(self.payload)
 
     @staticmethod
     async def _compute_time_per_output_token(response: InvocationResponse):
@@ -313,12 +320,12 @@ class _Run(_RunConfig):
                 self._progress_bar.update(1)
 
             if self._stats_display is not None:
-                snapshot = self._running_stats.snapshot(self.progress_bar_stats)
-                if snapshot:
+                raw = self._running_stats.to_stats()
+                if raw:
                     prefix = (
                         f"reqs={self._running_stats._count}" if self._time_bound else ""
                     )
-                    self._stats_display.update(snapshot, extra_prefix=prefix)
+                    self._stats_display.update(raw, extra_prefix=prefix)
 
             if output_path:
                 output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -331,18 +338,27 @@ class _Run(_RunConfig):
         self,
         payload: list[dict],
         n: int | None = None,
+        duration: float | None = None,
         shuffle_order=True,
     ) -> list[InvocationResponse]:
-        """Generate *n* invocations synchronously for a single client.
+        """Generate invocations synchronously for a single client.
 
-        Cycles through *payload* until *n* invocations are generated, sending
-        each request to the endpoint and pushing the response onto
-        ``self._queue`` for async token-counting and stats collection.
+        Terminates when either *n* requests have been sent or *duration* seconds
+        have elapsed, whichever is specified.  Exactly one of *n* or *duration*
+        must be provided.
+
+        Cycles through *payload*, sending each request to the endpoint and
+        pushing the response onto ``self._queue`` for async token-counting and
+        stats collection.
 
         Args:
             payload (list[dict]): The input payloads to cycle through.
             n (int | None, optional): The number of invocations to generate.
-                If not specified, every element in the payload is used once.
+                If not specified, every element in the payload is used once
+                (only when *duration* is also ``None``).
+            duration (float | None, optional): Maximum wall-clock seconds to
+                keep sending requests.  When set, requests are sent continuously
+                until the deadline.
             shuffle_order (bool, optional): Whether to shuffle the order of payloads
                 before generating invocations. Defaults to True.
 
@@ -357,25 +373,46 @@ class _Run(_RunConfig):
             random.seed(0)
             payload = random.sample(payload, k=len(payload))
 
-        responses = []
-        if n is None:
-            n = len(payload)
+        responses: list[InvocationResponse] = []
         if not payload:
             return responses
+
+        time_bound = duration is not None
+        if time_bound:
+            deadline = time.perf_counter() + duration
+        else:
+            if n is None:
+                n = len(payload)
+
         payload_iter = cycle(payload)
-        pbar = trange(
-            n,
-            leave=False,
-            desc="Requests",
-            disable=_disable_tqdm or self._disable_per_client_progress_bar,
+
+        # Count-bound runs get a trange progress bar; time-bound runs use a
+        # separate _tick_time_bar task so we skip the per-client bar here.
+        pbar = (
+            trange(
+                n,
+                leave=False,
+                desc="Requests",
+                disable=_disable_tqdm or self._disable_per_client_progress_bar,
+            )
+            if not time_bound
+            else None
         )
-        for _ in pbar:
+
+        sent = 0
+        while True:
+            if time_bound:
+                if time.perf_counter() >= deadline:
+                    break
+            else:
+                if sent >= n:
+                    break
+
             p = next(payload_iter)
             try:
                 p = asyncio.run(process_before_invoke_callbacks(self.callbacks, p))
                 self._running_stats.record_send()
                 response = self._endpoint.invoke(p)
-
             except Exception as e:
                 logger.exception(f"Error with invocation with payload {p}: {e}")
                 response = InvocationResponse.error_output(
@@ -388,74 +425,33 @@ class _Run(_RunConfig):
                 self._queue._loop.call_soon_threadsafe(  # type: ignore
                     self._queue.put_nowait, response
                 )
+            sent += 1
+            if pbar is not None:
+                pbar.update(1)
+
+        if pbar is not None:
+            pbar.close()
         return responses
 
-    def _invoke_for_duration(
-        self,
-        payload: list[dict],
-        duration: float,
-        shuffle_order=True,
-    ) -> list[InvocationResponse]:
-        """Generate invocations continuously until *duration* seconds have elapsed.
-
-        Cycles through *payload* indefinitely, stopping only when the wall-clock
-        time exceeds *duration*. Each completed request is pushed onto
-        ``self._queue`` for async token-counting and stats collection, mirroring
-        the behaviour of :meth:`_invoke_n_no_wait`.
-
-        Args:
-            payload (list[dict]): The input payloads to cycle through.
-            duration (float): Maximum wall-clock seconds to keep sending requests.
-            shuffle_order (bool, optional): Whether to shuffle the order of payloads
-                before generating invocations. Defaults to True.
-
-        Returns:
-            list[InvocationResponse]: All responses collected during the window.
-        """
-        if shuffle_order:
-            self._random_seed += random.randint(1, 1000)
-            random.seed(0)
-            payload = random.sample(payload, k=len(payload))
-
-        responses: list[InvocationResponse] = []
-        deadline = time.perf_counter() + duration
-        payload_iter = cycle(payload)
-
-        while time.perf_counter() < deadline:
-            p = next(payload_iter)
-            try:
-                p = asyncio.run(process_before_invoke_callbacks(self.callbacks, p))
-                self._running_stats.record_send()
-                response = self._endpoint.invoke(p)
-            except Exception as e:
-                logger.exception(f"Error with invocation with payload {p}: {e}")
-                response = InvocationResponse.error_output(
-                    id=uuid4().hex,
-                    error=str(e),
-                )
-            responses.append(response)
-            if self._queue:
-                self._queue._loop.call_soon_threadsafe(  # type: ignore
-                    self._queue.put_nowait, response
-                )
-        return responses
-
-    async def _invoke_n(
+    async def _invoke_client(
         self,
         payload: list[dict],
         n: int | None = None,
+        duration: float | None = None,
         add_start_jitter=True,
         shuffle_order=True,
     ) -> list[InvocationResponse]:
-        """Asynchronously generate *n* invocations for a single client.
+        """Asynchronously generate invocations for a single client.
 
-        Wraps :meth:`_invoke_n_no_wait` in a thread with an overall timeout
-        of ``self.timeout * n`` seconds.
+        Wraps :meth:`_invoke_n_no_wait` in a thread.  For count-bound runs an
+        overall timeout of ``self.timeout * n`` is applied; time-bound runs
+        have no extra timeout (the duration itself is the limit).
 
         Args:
             payload (list[dict]): The input payload(s) to generate invocations for.
             n (int | None, optional): The number of invocations to generate.
                 Defaults to None (one per payload element).
+            duration (float | None, optional): Maximum wall-clock seconds.
             add_start_jitter (bool, optional): Whether to add a random delay before
                 starting the invocations loop to avoid batch bunching when using
                 multiple clients. Defaults to True.
@@ -464,7 +460,7 @@ class _Run(_RunConfig):
 
         Returns:
             list[InvocationResponse]: A list of response objects. Returns an empty
-            list if the overall timeout is exceeded.
+            list if the overall timeout is exceeded (count-bound only).
         """
 
         if add_start_jitter:
@@ -473,70 +469,43 @@ class _Run(_RunConfig):
         if shuffle_order:
             self._random_seed = random.randint(0, 2**16 - 1)
 
+        coro = asyncio.to_thread(
+            self._invoke_n_no_wait, payload, n, duration, shuffle_order
+        )
+
+        if duration is not None:
+            # Time-bound: no extra timeout — the duration is the limit
+            return await coro
+
         try:
-            response = await asyncio.wait_for(
-                asyncio.to_thread(self._invoke_n_no_wait, payload, n, shuffle_order),
+            return await asyncio.wait_for(
+                coro,
                 timeout=self.timeout * (n or len(payload)),
             )
         except asyncio.TimeoutError:
             logger.error("client timeout!")
             return []
 
-        return response
-
-    async def _invoke_duration(
-        self,
-        payload: list[dict],
-        add_start_jitter=True,
-        shuffle_order=True,
-    ) -> list[InvocationResponse]:
-        """Asynchronously generate invocations for a single client until duration expires.
-
-        Wraps :meth:`_invoke_for_duration` in a thread. The client sends requests
-        continuously for ``self.run_duration`` seconds.
-
-        Args:
-            payload (list[dict]): The input payload(s) to cycle through.
-            add_start_jitter (bool, optional): Whether to add a random delay before
-                starting the invocations loop to avoid batch bunching when using
-                multiple clients. Defaults to True.
-            shuffle_order (bool, optional): Whether to shuffle the order of payloads
-                before generating invocations. Defaults to True.
-
-        Returns:
-            list[InvocationResponse]: All responses collected during the time window.
-        """
-
-        if add_start_jitter:
-            await asyncio.sleep(random.random() * 0.01)
-
-        if shuffle_order:
-            self._random_seed = random.randint(0, 2**16 - 1)
-
-        return await asyncio.to_thread(
-            self._invoke_for_duration,
-            payload,
-            self.run_duration,
-            shuffle_order,
-        )
-
-    async def _invoke_n_c(
+    async def _invoke_clients(
         self,
         payload: list[dict],
         n_requests: int | None = None,
+        duration: float | None = None,
         clients: int = 1,
     ) -> tuple[float, float, float]:
-        """Spawn *clients* concurrent count-bound invocation loops.
+        """Spawn *clients* concurrent invocation loops.
 
-        Each client generates *n_requests* invocations by delegating to
-        :meth:`_invoke_n`. All clients run concurrently and the method waits
-        for all of them to finish before signalling the token-counting queue
-        to stop.
+        Each client generates invocations by delegating to
+        :meth:`_invoke_client`.  All clients run concurrently and the method
+        waits for all of them to finish before signalling the token-counting
+        queue to stop.
 
         Args:
             payload (list[dict]): The input payloads to send.
             n_requests (int | None, optional): The number of invocations to
-                generate per client. Defaults to None.
+                generate per client (count-bound). Defaults to None.
+            duration (float | None, optional): Maximum wall-clock seconds per
+                client (time-bound). Defaults to None.
             clients (int, optional): The number of concurrent client connections.
                 Defaults to 1.
 
@@ -544,63 +513,35 @@ class _Run(_RunConfig):
             tuple[float, float, float]: A ``(total_test_time, start_t, end_t)``
             tuple of ``time.perf_counter`` values.
         """
-        logger.info(
-            f"Generating {clients} connections with {n_requests} invocations each"
-        )
+        if duration is not None:
+            logger.info(f"Generating {clients} connections for {duration}s each")
+        else:
+            logger.info(
+                f"Generating {clients} connections with {n_requests} invocations each"
+            )
         start_t = time.perf_counter()
         await tqdm.gather(
-            *[self._invoke_n(payload, n_requests) for _ in range(clients)],
+            *[
+                self._invoke_client(payload, n=n_requests, duration=duration)
+                for _ in range(clients)
+            ],
             leave=False,
             desc="Clients",
             disable=_disable_tqdm or self._disable_clients_progress_bar,
         )
         end_t = time.perf_counter()
         total_test_time = end_t - start_t
-        logger.info(
-            f"Completed {clients} clients x {n_requests} requests in "
-            f"{total_test_time * 1000:.2f}ms"
-        )
 
-        if self._queue:
-            await self._queue.put(None)
-            logger.debug("Signaling token counting task to exit")
-        return total_test_time, start_t, end_t
-
-    async def _invoke_duration_c(
-        self,
-        payload: list[dict],
-        clients: int = 1,
-    ) -> tuple[float, float, float]:
-        """Spawn *clients* concurrent time-bound invocation loops.
-
-        Each client sends requests continuously for ``self.run_duration`` seconds
-        by delegating to :meth:`_invoke_duration`. All clients run concurrently
-        and the method waits for all of them to finish before signalling the
-        token-counting queue to stop.
-
-        Args:
-            payload (list[dict]): The input payloads to cycle through.
-            clients (int, optional): The number of concurrent client connections.
-                Defaults to 1.
-
-        Returns:
-            tuple[float, float, float]: A ``(total_test_time, start_t, end_t)``
-            tuple of ``time.perf_counter`` values.
-        """
-        logger.info(f"Generating {clients} connections for {self.run_duration}s each")
-        start_t = time.perf_counter()
-        await tqdm.gather(
-            *[self._invoke_duration(payload) for _ in range(clients)],
-            leave=False,
-            desc="Clients",
-            disable=_disable_tqdm or self._disable_clients_progress_bar,
-        )
-        end_t = time.perf_counter()
-        total_test_time = end_t - start_t
-        logger.info(
-            f"Completed {clients} clients x {self.run_duration}s in "
-            f"{total_test_time * 1000:.2f}ms"
-        )
+        if duration is not None:
+            logger.info(
+                f"Completed {clients} clients x {duration}s in "
+                f"{total_test_time * 1000:.2f}ms"
+            )
+        else:
+            logger.info(
+                f"Completed {clients} clients x {n_requests} requests in "
+                f"{total_test_time * 1000:.2f}ms"
+            )
 
         if self._queue:
             await self._queue.put(None)
@@ -636,9 +577,9 @@ class _Run(_RunConfig):
         result = Result(
             responses=[],
             total_test_time=None,
-            total_requests=0 if self._time_bound else self._n_requests * self.clients,
+            total_requests=0 if self._time_bound else self.n_requests * self.clients,
             clients=self.clients,
-            n_requests=self._n_requests,
+            n_requests=self.n_requests,
             output_path=self.output_path,  # type: ignore
             model_id=self._endpoint.model_id,
             provider=self._endpoint.provider,
@@ -673,25 +614,28 @@ class _Run(_RunConfig):
         else:
             # Count-bound: progress bar shows completed requests
             self._progress_bar = tqdm(
-                total=self.clients * self._n_requests,
+                total=self.clients * self.n_requests,
                 leave=False,
                 desc="Total requests",
                 disable=_disable_tqdm,
             )
 
         # Live stats display — renders as an HTML table in notebooks, multi-line in terminals
-        self._stats_display = LiveStatsDisplay(disabled=_disable_tqdm)
+        self._stats_display = LiveStatsDisplay(
+            disabled=_disable_tqdm,
+            display_stats=self.progress_bar_stats,
+        )
 
         # Show the table layout immediately with placeholder values
-        initial_snapshot = self._running_stats.snapshot(self.progress_bar_stats)
         prefix = "reqs=0" if self._time_bound else ""
-        self._stats_display.update(initial_snapshot, extra_prefix=prefix)
+        self._stats_display.update({}, extra_prefix=prefix)
 
         try:
             run_start_time = now_utc()
             if self._time_bound:
-                invoke_coro = self._invoke_duration_c(
+                invoke_coro = self._invoke_clients(
                     payload=self.payload,  # type: ignore
+                    duration=self.run_duration,
                     clients=self.clients,
                 )
                 _, (total_test_time, start_time, end_time), _ = await asyncio.gather(
@@ -704,9 +648,9 @@ class _Run(_RunConfig):
                     self._tick_time_bar(),
                 )
             else:
-                invoke_coro = self._invoke_n_c(
+                invoke_coro = self._invoke_clients(
                     payload=self.payload,  # type: ignore
-                    n_requests=self._n_requests,
+                    n_requests=self.n_requests,
                     clients=self.clients,
                 )
                 _, (total_test_time, start_time, end_time) = await asyncio.gather(
@@ -739,7 +683,7 @@ class _Run(_RunConfig):
             total_requests=actual_total,
             n_requests=actual_total // max(self.clients, 1)
             if self._time_bound
-            else self._n_requests,
+            else self.n_requests,
             start_time=run_start_time,
             end_time=run_end_time,
         )
@@ -815,9 +759,10 @@ class Runner(_RunConfig):
         n_requests (int | None): The number of LLM invocations to generate *per client*. By
             default, each request in `payload` will be sent once by each client.  Mutually
             exclusive with ``run_duration``.
-        run_duration (int | float | None): Run each client for this many seconds instead of a
+        run_duration (int | float | timedelta | None): Run each client for this many seconds instead of a
             fixed request count.  Clients send requests continuously until the duration expires.
             Mutually exclusive with ``n_requests``.  Defaults to ``None`` (count-bound mode).
+            Accepts a number of seconds or a ``timedelta``.
         payload (dict | list[dict] | os.PathLike | str | None): The request data to send to the
             endpoint under test. You can provide a single JSON payload (dict), a list of payloads
             (list[dict]), or a path to one or more JSON/JSON-Lines files to be loaded by
@@ -840,8 +785,8 @@ class Runner(_RunConfig):
             ``result.load_responses()`` to load responses from disk after the run.  Defaults to
             ``False``.
         progress_bar_stats (dict | None): Controls which live stats appear on the progress bar.
-            Maps short display labels to field specs — see
-            :attr:`RunningStats.DEFAULT_SNAPSHOT_STATS` for the format and defaults.  Pass ``{}``
+            Maps short display labels to canonical stat keys — see
+            :data:`~llmeter.live_display.DEFAULT_DISPLAY_STATS` for the format and defaults.  Pass ``{}``
             to disable live stats entirely.  Defaults to ``None`` (use built-in defaults).
         disable_per_client_progress_bar (bool): Set `True` to disable per-client progress bars
             from showing during the run. Default `False` (each client's progress will be shown).
@@ -886,14 +831,14 @@ class Runner(_RunConfig):
         tokenizer: Tokenizer | Any | None = None,
         clients: int | None = None,
         n_requests: int | None = None,
-        run_duration: int | float | None = None,
+        run_duration: int | float | timedelta | None = None,
         payload: dict | list[dict] | ReadablePathLike | None = None,
         run_name: str | None = None,
         run_description: str | None = None,
         timeout: int | float | None = None,
         callbacks: list[Callback] | None = None,
         low_memory: bool | None = None,
-        progress_bar_stats: dict[str, tuple[str, ...] | str] | None = None,
+        progress_bar_stats: dict[str, str | tuple[str, str]] | None = None,
         disable_per_client_progress_bar: bool | None = None,
         disable_clients_progress_bar: bool | None = None,
     ) -> Result:
@@ -918,9 +863,10 @@ class Runner(_RunConfig):
             clients (int): The number of concurrent clients to use for sending requests.
             n_requests (int | None): The number of LLM invocations to generate *per client*.
                 Mutually exclusive with ``run_duration``.
-            run_duration (int | float | None): Run each client for this many seconds
+            run_duration (int | float | timedelta | None): Run each client for this many seconds
                 instead of a fixed request count.  Clients send requests continuously
                 until the duration expires.  Mutually exclusive with ``n_requests``.
+                Accepts a number of seconds or a ``timedelta``.
 
                 Example::
 
@@ -956,8 +902,8 @@ class Runner(_RunConfig):
                     result.load_responses()  # loads from disk
 
             progress_bar_stats (dict): Controls which live stats appear on the
-                progress bar.  Maps short display labels to field specs — see
-                :attr:`RunningStats.DEFAULT_SNAPSHOT_STATS` for the format and
+                progress bar.  Maps short display labels to canonical stat keys — see
+                :data:`~llmeter.live_display.DEFAULT_DISPLAY_STATS` for the format and
                 defaults.  Pass ``{}`` to disable live stats entirely.
 
                 Example::
@@ -965,9 +911,9 @@ class Runner(_RunConfig):
                     # Show only p99 latency and tokens per second:
                     result = await runner.run(
                         progress_bar_stats={
-                            "p99_ttlt": ("time_to_last_token", "p99"),
-                            "tps": ("time_per_output_token", "p50", "inv"),
-                            "fail": "failed",
+                            "p99_ttlt": "time_to_last_token-p99",
+                            "tps": ("time_per_output_token-p50", "inv"),
+                            "fail": "failed_requests",
                         },
                     )
             disable_per_client_progress_bar (bool): Set `True` to disable per-client progress bars

--- a/llmeter/runner.py
+++ b/llmeter/runner.py
@@ -21,6 +21,7 @@ from tqdm.auto import tqdm, trange
 from upath import UPath as Path
 from upath.types import ReadablePathLike, WritablePathLike
 
+from .live_display import LiveStatsDisplay
 from .utils import RunningStats, ensure_path, now_utc
 
 if TYPE_CHECKING:
@@ -58,6 +59,7 @@ class _RunConfig:
     tokenizer: Tokenizer | Any | None = None
     clients: int = 1
     n_requests: int | None = None
+    run_duration: int | float | None = None
     payload: dict | list[dict] | ReadablePathLike | None = None
     run_name: str | None = None
     run_description: str | None = None
@@ -75,6 +77,9 @@ class _RunConfig:
 
         if self.n_requests is not None:
             assert self.n_requests > 0, "Number of requests must be a positive integer"
+
+        if self.run_duration is not None:
+            assert self.run_duration > 0, "Run duration must be a positive number"
 
         assert self.clients > 0, "Number of clients must be a positive integer"
 
@@ -187,16 +192,39 @@ class _Run(_RunConfig):
         )
 
     def _validate_and_prepare_payload(self):
-        """Validate and prepare the payload for the test run and update n_requests
+        """Validate and prepare the payload for the test run.
 
-        This method ensures that the payload is valid and prepared for the test run.
+        Normalizes the payload into a list of dicts, validates that ``n_requests``
+        and ``run_duration`` are not both set, and sets ``_time_bound`` and
+        ``_n_requests`` accordingly.
+
+        For count-bound runs, ``_n_requests`` defaults to the number of payloads
+        when not explicitly provided. For time-bound runs, ``_n_requests`` is set
+        to 0 since the actual count is unknown upfront.
+
+        Raises:
+            AssertionError: If no payload is provided.
+            ValueError: If both ``n_requests`` and ``run_duration`` are set.
+            FileNotFoundError: If the payload path does not exist.
         """
         assert self.payload, "No payload provided"
         if isinstance(self.payload, (Path, str)):
             self.payload = list(load_payloads(self.payload))
         if isinstance(self.payload, dict):
             self.payload = [self.payload]
-        self._n_requests = self.n_requests or len(self.payload)
+
+        if self.run_duration is not None and self.n_requests is not None:
+            raise ValueError(
+                "Cannot set both n_requests and run_duration. "
+                "Use n_requests for request-bound runs or run_duration for time-bound runs."
+            )
+
+        self._time_bound = self.run_duration is not None
+        if self._time_bound:
+            # For time-bound runs, _n_requests is unknown upfront
+            self._n_requests = 0
+        else:
+            self._n_requests = self.n_requests or len(self.payload)
 
     @staticmethod
     async def _compute_time_per_output_token(response: InvocationResponse):
@@ -281,12 +309,16 @@ class _Run(_RunConfig):
                 self._responses.append(response)
                 self._running_stats.update(response.to_dict())
 
-            if self._progress_bar:
+            if self._progress_bar is not None and not self._time_bound:
                 self._progress_bar.update(1)
-                self._progress_bar.set_postfix(
-                    self._running_stats.snapshot(self.progress_bar_stats),
-                    refresh=False,
-                )
+
+            if self._stats_display is not None:
+                snapshot = self._running_stats.snapshot(self.progress_bar_stats)
+                if snapshot:
+                    prefix = (
+                        f"reqs={self._running_stats._count}" if self._time_bound else ""
+                    )
+                    self._stats_display.update(snapshot, extra_prefix=prefix)
 
             if output_path:
                 output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -301,23 +333,21 @@ class _Run(_RunConfig):
         n: int | None = None,
         shuffle_order=True,
     ) -> list[InvocationResponse]:
-        """
-        Generate multiple invocations for the given payload.
+        """Generate *n* invocations synchronously for a single client.
 
-        This method generates `n` invocations for the given payload(s) by sending
-        requests to the endpoint in a loop. If a sequence of payloads is provided,
-        the payloads are cycled through until `n` invocations are generated. If a
-        single payload is provided, it is used for all `n` invocations.
+        Cycles through *payload* until *n* invocations are generated, sending
+        each request to the endpoint and pushing the response onto
+        ``self._queue`` for async token-counting and stats collection.
 
         Args:
-            payload: The input payload to generate invocations for.
-            n (int|None, optional): The number of invocations to generate.
+            payload (list[dict]): The input payloads to cycle through.
+            n (int | None, optional): The number of invocations to generate.
                 If not specified, every element in the payload is used once.
             shuffle_order (bool, optional): Whether to shuffle the order of payloads
                 before generating invocations. Defaults to True.
 
         Returns:
-            List[EndpointResponse]: A list of response objects.
+            list[InvocationResponse]: A list of response objects.
         """
 
         # ToDo: replace with an async method to prepare payloads, including possible callbacks,
@@ -330,17 +360,20 @@ class _Run(_RunConfig):
         responses = []
         if n is None:
             n = len(payload)
-        for p, _ in zip(
-            cycle(payload),
-            trange(
-                n,
-                leave=False,
-                desc="Requests",
-                disable=_disable_tqdm or self._disable_per_client_progress_bar,
-            ),
-        ):
+        if not payload:
+            return responses
+        payload_iter = cycle(payload)
+        pbar = trange(
+            n,
+            leave=False,
+            desc="Requests",
+            disable=_disable_tqdm or self._disable_per_client_progress_bar,
+        )
+        for _ in pbar:
+            p = next(payload_iter)
             try:
                 p = asyncio.run(process_before_invoke_callbacks(self.callbacks, p))
+                self._running_stats.record_send()
                 response = self._endpoint.invoke(p)
 
             except Exception as e:
@@ -357,6 +390,56 @@ class _Run(_RunConfig):
                 )
         return responses
 
+    def _invoke_for_duration(
+        self,
+        payload: list[dict],
+        duration: float,
+        shuffle_order=True,
+    ) -> list[InvocationResponse]:
+        """Generate invocations continuously until *duration* seconds have elapsed.
+
+        Cycles through *payload* indefinitely, stopping only when the wall-clock
+        time exceeds *duration*. Each completed request is pushed onto
+        ``self._queue`` for async token-counting and stats collection, mirroring
+        the behaviour of :meth:`_invoke_n_no_wait`.
+
+        Args:
+            payload (list[dict]): The input payloads to cycle through.
+            duration (float): Maximum wall-clock seconds to keep sending requests.
+            shuffle_order (bool, optional): Whether to shuffle the order of payloads
+                before generating invocations. Defaults to True.
+
+        Returns:
+            list[InvocationResponse]: All responses collected during the window.
+        """
+        if shuffle_order:
+            self._random_seed += random.randint(1, 1000)
+            random.seed(0)
+            payload = random.sample(payload, k=len(payload))
+
+        responses: list[InvocationResponse] = []
+        deadline = time.perf_counter() + duration
+        payload_iter = cycle(payload)
+
+        while time.perf_counter() < deadline:
+            p = next(payload_iter)
+            try:
+                p = asyncio.run(process_before_invoke_callbacks(self.callbacks, p))
+                self._running_stats.record_send()
+                response = self._endpoint.invoke(p)
+            except Exception as e:
+                logger.exception(f"Error with invocation with payload {p}: {e}")
+                response = InvocationResponse.error_output(
+                    id=uuid4().hex,
+                    error=str(e),
+                )
+            responses.append(response)
+            if self._queue:
+                self._queue._loop.call_soon_threadsafe(  # type: ignore
+                    self._queue.put_nowait, response
+                )
+        return responses
+
     async def _invoke_n(
         self,
         payload: list[dict],
@@ -364,17 +447,15 @@ class _Run(_RunConfig):
         add_start_jitter=True,
         shuffle_order=True,
     ) -> list[InvocationResponse]:
-        """
-        Asynchronously generate multiple invocations for the given payload.
+        """Asynchronously generate *n* invocations for a single client.
 
-        This method generates `n` invocations for the given payload(s) by sending
-        requests to the endpoint asynchronously. If a sequence of payloads is provided,
-        the payloads are cycled through until `n` invocations are generated. If a
-        single payload is provided, it is used for all `n` invocations.
+        Wraps :meth:`_invoke_n_no_wait` in a thread with an overall timeout
+        of ``self.timeout * n`` seconds.
 
         Args:
-            payload (Dict[str, str] | Sequence[Dict[str, str]]): The input payload(s) to generate invocations for.
-            n (int | None, optional): The number of invocations to generate. Defaults to None.
+            payload (list[dict]): The input payload(s) to generate invocations for.
+            n (int | None, optional): The number of invocations to generate.
+                Defaults to None (one per payload element).
             add_start_jitter (bool, optional): Whether to add a random delay before
                 starting the invocations loop to avoid batch bunching when using
                 multiple clients. Defaults to True.
@@ -382,7 +463,8 @@ class _Run(_RunConfig):
                 before generating invocations. Defaults to True.
 
         Returns:
-            List[EndpointResponse]: A list of response objects.
+            list[InvocationResponse]: A list of response objects. Returns an empty
+            list if the overall timeout is exceeded.
         """
 
         if add_start_jitter:
@@ -402,26 +484,65 @@ class _Run(_RunConfig):
 
         return response
 
+    async def _invoke_duration(
+        self,
+        payload: list[dict],
+        add_start_jitter=True,
+        shuffle_order=True,
+    ) -> list[InvocationResponse]:
+        """Asynchronously generate invocations for a single client until duration expires.
+
+        Wraps :meth:`_invoke_for_duration` in a thread. The client sends requests
+        continuously for ``self.run_duration`` seconds.
+
+        Args:
+            payload (list[dict]): The input payload(s) to cycle through.
+            add_start_jitter (bool, optional): Whether to add a random delay before
+                starting the invocations loop to avoid batch bunching when using
+                multiple clients. Defaults to True.
+            shuffle_order (bool, optional): Whether to shuffle the order of payloads
+                before generating invocations. Defaults to True.
+
+        Returns:
+            list[InvocationResponse]: All responses collected during the time window.
+        """
+
+        if add_start_jitter:
+            await asyncio.sleep(random.random() * 0.01)
+
+        if shuffle_order:
+            self._random_seed = random.randint(0, 2**16 - 1)
+
+        return await asyncio.to_thread(
+            self._invoke_for_duration,
+            payload,
+            self.run_duration,
+            shuffle_order,
+        )
+
     async def _invoke_n_c(
         self,
         payload: list[dict],
         n_requests: int | None = None,
         clients: int = 1,
     ) -> tuple[float, float, float]:
-        """
-        Asynchronously generates multiple invocations for a given payload.
+        """Spawn *clients* concurrent count-bound invocation loops.
+
+        Each client generates *n_requests* invocations by delegating to
+        :meth:`_invoke_n`. All clients run concurrently and the method waits
+        for all of them to finish before signalling the token-counting queue
+        to stop.
 
         Args:
-            payload (dict): The input data for generating invocations.
-            queue (asyncio.Queue): The queue to store the generated responses.
-            n_requests (int | None, optional): The number of invocations to generate per connection. Defaults to None.
-            clients (int, optional): The number of concurrent connections to generate invocations. Defaults to 1.
+            payload (list[dict]): The input payloads to send.
+            n_requests (int | None, optional): The number of invocations to
+                generate per client. Defaults to None.
+            clients (int, optional): The number of concurrent client connections.
+                Defaults to 1.
 
         Returns:
-            None
-
-        Raises:
-            None
+            tuple[float, float, float]: A ``(total_test_time, start_t, end_t)``
+            tuple of ``time.perf_counter`` values.
         """
         logger.info(
             f"Generating {clients} connections with {n_requests} invocations each"
@@ -436,14 +557,74 @@ class _Run(_RunConfig):
         end_t = time.perf_counter()
         total_test_time = end_t - start_t
         logger.info(
-            f"Generated {clients} connections with {n_requests} invocations each in {total_test_time * 1000:.2f} seconds"
+            f"Completed {clients} clients x {n_requests} requests in "
+            f"{total_test_time * 1000:.2f}ms"
         )
 
-        # Signal the token counting task to exit
         if self._queue:
             await self._queue.put(None)
             logger.debug("Signaling token counting task to exit")
         return total_test_time, start_t, end_t
+
+    async def _invoke_duration_c(
+        self,
+        payload: list[dict],
+        clients: int = 1,
+    ) -> tuple[float, float, float]:
+        """Spawn *clients* concurrent time-bound invocation loops.
+
+        Each client sends requests continuously for ``self.run_duration`` seconds
+        by delegating to :meth:`_invoke_duration`. All clients run concurrently
+        and the method waits for all of them to finish before signalling the
+        token-counting queue to stop.
+
+        Args:
+            payload (list[dict]): The input payloads to cycle through.
+            clients (int, optional): The number of concurrent client connections.
+                Defaults to 1.
+
+        Returns:
+            tuple[float, float, float]: A ``(total_test_time, start_t, end_t)``
+            tuple of ``time.perf_counter`` values.
+        """
+        logger.info(f"Generating {clients} connections for {self.run_duration}s each")
+        start_t = time.perf_counter()
+        await tqdm.gather(
+            *[self._invoke_duration(payload) for _ in range(clients)],
+            leave=False,
+            desc="Clients",
+            disable=_disable_tqdm or self._disable_clients_progress_bar,
+        )
+        end_t = time.perf_counter()
+        total_test_time = end_t - start_t
+        logger.info(
+            f"Completed {clients} clients x {self.run_duration}s in "
+            f"{total_test_time * 1000:.2f}ms"
+        )
+
+        if self._queue:
+            await self._queue.put(None)
+            logger.debug("Signaling token counting task to exit")
+        return total_test_time, start_t, end_t
+
+    async def _tick_time_bar(self):
+        """Advance ``_progress_bar`` every 0.5 s until ``run_duration`` is reached.
+
+        Designed to run as a concurrent task alongside the invocation loops so
+        the user sees a smooth time-based progress bar.
+        """
+        start = time.perf_counter()
+        duration = self.run_duration
+        prev = 0
+        while True:
+            await asyncio.sleep(0.5)
+            elapsed = time.perf_counter() - start
+            tick = min(int(elapsed), int(duration)) - prev
+            if tick > 0 and self._progress_bar is not None:
+                self._progress_bar.update(tick)
+                prev += tick
+            if elapsed >= duration:
+                break
 
     async def _run(self):
         """Run the test with the given configuration
@@ -451,10 +632,11 @@ class _Run(_RunConfig):
         This method is expected to be called *exactly once* after the _Run object is created.
         Attempting to re-use a _Run object may result in undefined behavior.
         """
+        # For time-bound runs, total_requests is unknown upfront
         result = Result(
             responses=[],
             total_test_time=None,
-            total_requests=self._n_requests * self.clients,
+            total_requests=0 if self._time_bound else self._n_requests * self.clients,
             clients=self.clients,
             n_requests=self._n_requests,
             output_path=self.output_path,  # type: ignore
@@ -477,27 +659,64 @@ class _Run(_RunConfig):
         loop.set_default_executor(ThreadPoolExecutor(max_workers=self.clients + 5))
         logger.info("Starting test")
         self._queue = asyncio.Queue()
-        self._progress_bar = tqdm(
-            total=self.clients * self._n_requests,
-            leave=False,
-            desc="Total requests",
-            disable=_disable_tqdm,
-        )
+
+        if self._time_bound:
+            # Time-bound: progress bar shows elapsed seconds
+            self._progress_bar = tqdm(
+                total=int(self.run_duration),
+                leave=False,
+                desc="Elapsed",
+                unit="s",
+                bar_format="{desc}: {bar}| {n:.0f}/{total:.0f}s [{elapsed}]",
+                disable=_disable_tqdm,
+            )
+        else:
+            # Count-bound: progress bar shows completed requests
+            self._progress_bar = tqdm(
+                total=self.clients * self._n_requests,
+                leave=False,
+                desc="Total requests",
+                disable=_disable_tqdm,
+            )
+
+        # Live stats display — renders as an HTML table in notebooks, multi-line in terminals
+        self._stats_display = LiveStatsDisplay(disabled=_disable_tqdm)
+
+        # Show the table layout immediately with placeholder values
+        initial_snapshot = self._running_stats.snapshot(self.progress_bar_stats)
+        prefix = "reqs=0" if self._time_bound else ""
+        self._stats_display.update(initial_snapshot, extra_prefix=prefix)
 
         try:
             run_start_time = now_utc()
-            _, (total_test_time, start_time, end_time) = await asyncio.gather(
-                self._process_results_from_q(
-                    output_path=ensure_path(self.output_path) / "responses.jsonl"
-                    if self.output_path
-                    else None,
-                ),
-                self._invoke_n_c(
+            if self._time_bound:
+                invoke_coro = self._invoke_duration_c(
+                    payload=self.payload,  # type: ignore
+                    clients=self.clients,
+                )
+                _, (total_test_time, start_time, end_time), _ = await asyncio.gather(
+                    self._process_results_from_q(
+                        output_path=ensure_path(self.output_path) / "responses.jsonl"
+                        if self.output_path
+                        else None,
+                    ),
+                    invoke_coro,
+                    self._tick_time_bar(),
+                )
+            else:
+                invoke_coro = self._invoke_n_c(
                     payload=self.payload,  # type: ignore
                     n_requests=self._n_requests,
                     clients=self.clients,
-                ),
-            )
+                )
+                _, (total_test_time, start_time, end_time) = await asyncio.gather(
+                    self._process_results_from_q(
+                        output_path=Path(self.output_path) / "responses.jsonl"
+                        if self.output_path
+                        else None,
+                    ),
+                    invoke_coro,
+                )
             run_end_time = now_utc()
 
         except asyncio.CancelledError:
@@ -507,12 +726,20 @@ class _Run(_RunConfig):
             return result
 
         self._progress_bar.close()
+        if self._stats_display is not None:
+            self._stats_display.close()
         logger.info(f"Test completed in {total_test_time * 1000:.2f} seconds.")
+
+        actual_total = self._running_stats._count
 
         result = replace(
             result,
             responses=self._responses,
             total_test_time=total_test_time,
+            total_requests=actual_total,
+            n_requests=actual_total // max(self.clients, 1)
+            if self._time_bound
+            else self._n_requests,
             start_time=run_start_time,
             end_time=run_end_time,
         )
@@ -586,7 +813,11 @@ class Runner(_RunConfig):
             `DummyTokenizer` will be used if needed.
         clients (int): The number of concurrent clients to use for sending requests. Defaults to 1.
         n_requests (int | None): The number of LLM invocations to generate *per client*. By
-            default, each request in `payload` will be sent once by each client.
+            default, each request in `payload` will be sent once by each client.  Mutually
+            exclusive with ``run_duration``.
+        run_duration (int | float | None): Run each client for this many seconds instead of a
+            fixed request count.  Clients send requests continuously until the duration expires.
+            Mutually exclusive with ``n_requests``.  Defaults to ``None`` (count-bound mode).
         payload (dict | list[dict] | os.PathLike | str | None): The request data to send to the
             endpoint under test. You can provide a single JSON payload (dict), a list of payloads
             (list[dict]), or a path to one or more JSON/JSON-Lines files to be loaded by
@@ -655,6 +886,7 @@ class Runner(_RunConfig):
         tokenizer: Tokenizer | Any | None = None,
         clients: int | None = None,
         n_requests: int | None = None,
+        run_duration: int | float | None = None,
         payload: dict | list[dict] | ReadablePathLike | None = None,
         run_name: str | None = None,
         run_description: str | None = None,
@@ -685,6 +917,17 @@ class Runner(_RunConfig):
                 output token counts for endpoints that don't report exact information.
             clients (int): The number of concurrent clients to use for sending requests.
             n_requests (int | None): The number of LLM invocations to generate *per client*.
+                Mutually exclusive with ``run_duration``.
+            run_duration (int | float | None): Run each client for this many seconds
+                instead of a fixed request count.  Clients send requests continuously
+                until the duration expires.  Mutually exclusive with ``n_requests``.
+
+                Example::
+
+                    # Run for 60 seconds with 5 concurrent clients:
+                    result = await runner.run(run_duration=60, clients=5)
+                    result.total_requests  # actual count completed
+
             payload (dict | list[dict] | ReadablePathLike | None): The request data to send to the
                 endpoint under test. You can provide a single JSON payload (dict), a list of
                 payloads (list[dict]), or a path to one or more JSON/JSON-Lines files to be loaded
@@ -754,6 +997,7 @@ class Runner(_RunConfig):
             tokenizer=tokenizer,
             clients=clients,
             n_requests=n_requests,
+            run_duration=run_duration,
             payload=payload,
             run_name=run_name,
             run_description=run_description,

--- a/llmeter/runner.py
+++ b/llmeter/runner.py
@@ -21,7 +21,7 @@ from tqdm.auto import tqdm, trange
 from upath import UPath as Path
 from upath.types import ReadablePathLike, WritablePathLike
 
-from .utils import ensure_path, now_utc
+from .utils import RunningStats, ensure_path, now_utc
 
 if TYPE_CHECKING:
     # Avoid circular import: We only need typing for Callback
@@ -63,6 +63,8 @@ class _RunConfig:
     run_description: str | None = None
     timeout: int | float = 60
     callbacks: list[Callback] | None = None
+    low_memory: bool = False
+    progress_bar_stats: dict[str, tuple[str, ...] | str] | None = None
     disable_per_client_progress_bar: InitVar[bool] = True
     disable_clients_progress_bar: InitVar[bool] = True
 
@@ -168,6 +170,22 @@ class _Run(_RunConfig):
         self._validate_and_prepare_payload()
         self._responses = []
 
+        if self.low_memory:
+            assert self.output_path is not None, (
+                "output_path is required when low_memory=True "
+                "(responses must be written to disk)"
+            )
+
+        self._running_stats = RunningStats(
+            metrics=[
+                "time_to_last_token",
+                "time_to_first_token",
+                "time_per_output_token",
+                "num_tokens_output",
+                "num_tokens_input",
+            ]
+        )
+
     def _validate_and_prepare_payload(self):
         """Validate and prepare the payload for the test run and update n_requests
 
@@ -257,9 +275,18 @@ class _Run(_RunConfig):
             if self.callbacks is not None:
                 [await cb.after_invoke(response) for cb in self.callbacks]
 
-            self._responses.append(response)
+            if self.low_memory and self._running_stats is not None:
+                self._running_stats.update(response.to_dict())
+            else:
+                self._responses.append(response)
+                self._running_stats.update(response.to_dict())
+
             if self._progress_bar:
                 self._progress_bar.update(1)
+                self._progress_bar.set_postfix(
+                    self._running_stats.snapshot(self.progress_bar_stats),
+                    refresh=False,
+                )
 
             if output_path:
                 output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -490,6 +517,22 @@ class _Run(_RunConfig):
             end_time=run_end_time,
         )
 
+        # Compute stats from the running accumulators
+        result._preloaded_stats = self._running_stats.to_stats(
+            total_requests=result.total_requests,
+            total_test_time=total_test_time,
+            result_dict=result.to_dict(),
+        )
+        result._preloaded_stats["start_time"] = run_start_time
+        result._preloaded_stats["end_time"] = run_end_time
+        result._preloaded_stats["total_test_time"] = total_test_time
+
+        if self.low_memory:
+            logger.info(
+                "Low-memory mode: responses not stored in memory. "
+                "Use result.load_responses() to load from disk."
+            )
+
         if self.callbacks is not None:
             [await cb.after_run(result) for cb in self.callbacks]
 
@@ -560,6 +603,15 @@ class Runner(_RunConfig):
             endpoint. Defaults to 60 seconds.
         callbacks (list[Callback] | None): Optional callbacks to enable during the test Run. See
             `llmeter.callbacks` for more information.
+        low_memory (bool): When ``True``, responses are written to disk but not kept in memory
+            during the run.  Stats are computed incrementally via
+            :class:`~llmeter.utils.RunningStats`.  Requires ``output_path`` to be set.  Use
+            ``result.load_responses()`` to load responses from disk after the run.  Defaults to
+            ``False``.
+        progress_bar_stats (dict | None): Controls which live stats appear on the progress bar.
+            Maps short display labels to field specs — see
+            :attr:`RunningStats.DEFAULT_SNAPSHOT_STATS` for the format and defaults.  Pass ``{}``
+            to disable live stats entirely.  Defaults to ``None`` (use built-in defaults).
         disable_per_client_progress_bar (bool): Set `True` to disable per-client progress bars
             from showing during the run. Default `False` (each client's progress will be shown).
         disable_clients_progress_bar (bool): Set `True` to disable overall progress bar from
@@ -608,6 +660,8 @@ class Runner(_RunConfig):
         run_description: str | None = None,
         timeout: int | float | None = None,
         callbacks: list[Callback] | None = None,
+        low_memory: bool | None = None,
+        progress_bar_stats: dict[str, tuple[str, ...] | str] | None = None,
         disable_per_client_progress_bar: bool | None = None,
         disable_clients_progress_bar: bool | None = None,
     ) -> Result:
@@ -643,6 +697,36 @@ class Runner(_RunConfig):
                 endpoint.
             callbacks (list[Callback] | None): Optional callbacks to enable during the test Run. See
                 `llmeter.callbacks` for more information.
+            low_memory (bool): When ``True``, responses are written to disk but not
+                kept in memory.  Stats are computed incrementally via
+                :class:`~llmeter.utils.RunningStats`.  Requires ``output_path``.
+                Use ``result.load_responses()`` to access responses after the run.
+
+                Example::
+
+                    result = await runner.run(
+                        output_path="/tmp/my_run",
+                        low_memory=True,
+                    )
+                    result.stats          # works (computed incrementally)
+                    result.responses      # [] (empty)
+                    result.load_responses()  # loads from disk
+
+            progress_bar_stats (dict): Controls which live stats appear on the
+                progress bar.  Maps short display labels to field specs — see
+                :attr:`RunningStats.DEFAULT_SNAPSHOT_STATS` for the format and
+                defaults.  Pass ``{}`` to disable live stats entirely.
+
+                Example::
+
+                    # Show only p99 latency and tokens per second:
+                    result = await runner.run(
+                        progress_bar_stats={
+                            "p99_ttlt": ("time_to_last_token", "p99"),
+                            "tps": ("time_per_output_token", "p50", "inv"),
+                            "fail": "failed",
+                        },
+                    )
             disable_per_client_progress_bar (bool): Set `True` to disable per-client progress bars
                 from showing during the run.
             disable_clients_progress_bar (bool): Set `True` to disable overall progress bar from
@@ -675,6 +759,8 @@ class Runner(_RunConfig):
             run_description=run_description,
             timeout=timeout,
             callbacks=callbacks,
+            low_memory=low_memory,
+            progress_bar_stats=progress_bar_stats,
             disable_per_client_progress_bar=disable_per_client_progress_bar,
             disable_clients_progress_bar=disable_clients_progress_bar,
         )

--- a/llmeter/runner.py
+++ b/llmeter/runner.py
@@ -320,7 +320,7 @@ class _Run(_RunConfig):
                 self._progress_bar.update(1)
 
             if self._stats_display is not None:
-                raw = self._running_stats.to_stats()
+                raw = self._running_stats.to_stats(end_time=now_utc())
                 if raw:
                     prefix = (
                         f"reqs={self._running_stats._count}" if self._time_bound else ""
@@ -411,7 +411,6 @@ class _Run(_RunConfig):
             p = next(payload_iter)
             try:
                 p = asyncio.run(process_before_invoke_callbacks(self.callbacks, p))
-                self._running_stats.record_send()
                 response = self._endpoint.invoke(p)
             except Exception as e:
                 logger.exception(f"Error with invocation with payload {p}: {e}")
@@ -685,13 +684,14 @@ class _Run(_RunConfig):
             if self._time_bound
             else self.n_requests,
             start_time=run_start_time,
+            first_request_time=self._running_stats._first_send_time,
+            last_request_time=self._running_stats._last_send_time,
             end_time=run_end_time,
         )
 
         # Compute stats from the running accumulators
         result._preloaded_stats = self._running_stats.to_stats(
-            total_requests=result.total_requests,
-            total_test_time=total_test_time,
+            end_time=run_end_time,
             result_dict=result.to_dict(),
         )
         result._preloaded_stats["start_time"] = run_start_time

--- a/llmeter/tokenizers.py
+++ b/llmeter/tokenizers.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
+
+import json
 from abc import ABC, abstractmethod
 from typing import Any
 
 from upath import UPath
 from upath.types import ReadablePathLike, WritablePathLike
-import json
 
 from .utils import ensure_path
 

--- a/llmeter/utils.py
+++ b/llmeter/utils.py
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 import bisect
-import time
 from datetime import datetime, timezone
 from itertools import filterfalse
 from math import isnan
@@ -113,28 +112,10 @@ class RunningStats:
         self._metrics = list(metrics)
         self._count = 0
         self._failed = 0
-        self._sends = 0
-        self._first_send_time: float | None = None
-        self._last_send_time: float | None = None
+        self._first_send_time: datetime | None = None
+        self._last_send_time: datetime | None = None
         self._sums: dict[str, float] = {m: 0.0 for m in metrics}
         self._values: dict[str, list[float]] = {m: [] for m in metrics}
-
-    def record_send(self) -> None:
-        """Record that a request was dispatched to the endpoint.
-
-        Call this from the invocation loop each time a request is sent, *before*
-        waiting for the response. This tracks the send-side time window used for
-        accurate RPM and throughput calculations.
-
-        The send window (``_first_send_time`` to ``_last_send_time``) excludes
-        the tail latency of the final response, giving a more accurate picture
-        of the request dispatch rate.
-        """
-        now = time.perf_counter()
-        self._sends += 1
-        if self._first_send_time is None:
-            self._first_send_time = now
-        self._last_send_time = now
 
     def update(self, response_dict: dict[str, Any]) -> None:
         """Record one response's metric values.
@@ -158,61 +139,39 @@ class RunningStats:
         self._count += 1
         if response_dict.get("error") is not None:
             self._failed += 1
+        request_time = response_dict.get("request_time")
+        if request_time is not None:
+            if self._first_send_time is None or request_time < self._first_send_time:
+                self._first_send_time = request_time
+            if self._last_send_time is None or request_time > self._last_send_time:
+                self._last_send_time = request_time
         for m in self._metrics:
             val = response_dict.get(m)
-            if val is not None and not (isinstance(val, float) and isnan(val)):
+            if val is not None and not (isinstance(val, (float, int)) and isnan(val)):
                 self._sums[m] += val
                 bisect.insort(self._values[m], val)
 
     def to_stats(
         self,
-        total_requests: int | None = None,
-        total_test_time: float | None = None,
+        end_time: datetime | None = None,
         result_dict: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Compute all accumulated statistics as raw numeric values.
 
         This is the single source of truth for stats computation.  It is called
-        once at the end of a run (with all three optional arguments) to produce
-        the full ``Result.stats`` dict, and also called internally by
-        :meth:`snapshot` (without arguments) for mid-run progress display.
+        once at the end of a run (with all arguments) to produce the full
+        ``Result.stats`` dict, and also called internally by :meth:`snapshot`
+        (without arguments) for mid-run progress display.
 
         Args:
-            total_requests: Total number of requests across all clients.  When
-                provided, enables ``failed_requests_rate`` and
-                ``requests_per_minute`` computation.
-            total_test_time: Wall-clock duration of the run in seconds.  When
-                provided, enables throughput metrics (requests/min, tokens/min).
+            end_time: Wall-clock end time of the run.  Used together with
+                ``_first_send_time`` to compute output-rate metrics.
             result_dict: Base key-value pairs to include in the output (typically
                 from ``Result.to_dict()``).  When ``None``, only metric
                 aggregations and failure counts are returned.
 
         Returns:
-            A flat dictionary of statistics.  Keys include:
-
-            * ``failed_requests``, ``failed_requests_rate``, ``requests_per_minute``
-            * ``total_input_tokens``, ``total_output_tokens``
-            * ``average_input_tokens_per_minute``, ``average_output_tokens_per_minute``
-            * ``{metric}-{agg}`` for each tracked metric and each aggregation
-              (``average``, ``p50``, ``p90``, ``p99``).
-
-        Example::
-
-            rs = RunningStats(metrics=["time_to_first_token", "num_tokens_output"])
-            for resp in responses:
-                rs.update(resp.to_dict())
-
-            # Mid-run (no run-level context):
-            partial = rs.to_stats()
-            partial["time_to_first_token-p50"]  # 0.312
-
-            # End of run (full Result.stats schema):
-            full = rs.to_stats(
-                total_requests=100,
-                total_test_time=42.5,
-                result_dict=result.to_dict(),
-            )
-            full["requests_per_minute"]  # 141.2
+            A flat dictionary of statistics.
         """
         stats: dict[str, Any] = {}
         if result_dict is not None:
@@ -220,20 +179,9 @@ class RunningStats:
 
         # Run-level stats
         stats["failed_requests"] = self._failed
-        stats["failed_requests_rate"] = total_requests and self._failed / total_requests
-        stats["requests_per_minute"] = (
-            total_test_time and total_requests / total_test_time * 60
-            if total_requests
-            else None
-        )
+        stats["failed_requests_rate"] = self._count and self._failed / self._count
         stats["total_input_tokens"] = self._sums.get("num_tokens_input", 0)
         stats["total_output_tokens"] = self._sums.get("num_tokens_output", 0)
-        stats["average_input_tokens_per_minute"] = (
-            total_test_time and stats["total_input_tokens"] / total_test_time * 60
-        )
-        stats["average_output_tokens_per_minute"] = (
-            total_test_time and stats["total_output_tokens"] / total_test_time * 60
-        )
 
         # Per-metric aggregations
         for m in self._metrics:
@@ -241,28 +189,40 @@ class RunningStats:
             for j, v in agg.items():
                 stats[f"{m}-{j}"] = v
 
-        # Send-window throughput (live RPM and output tokens/s).
-        # These use the dispatch timestamps rather than response timestamps,
-        # giving a more accurate picture of the request rate.
+        # Input rate metrics use the dispatch timestamps (request_time on
+        # responses) rather than response timestamps, giving a more accurate
+        # picture of the request rate.
         send_window = self._send_window()
         if send_window and send_window > 0:
-            stats["rpm"] = self._count / send_window * 60
+            stats["requests_per_minute"] = self._count * 60 / send_window
+            stats["average_input_tokens_per_minute"] = (
+                stats["total_input_tokens"] * 60 / send_window
+            )
+
+        # Output rate metrics use overall test end time (or now, when ongoing).
+        if (
+            self._first_send_time is not None
+            and end_time is not None
+            and end_time > self._first_send_time
+        ):
+            run_window = (end_time - self._first_send_time).total_seconds()
             total_out = self._sums.get("num_tokens_output", 0)
-            stats["output_tps"] = total_out / send_window
+            stats["average_output_tokens_per_minute"] = total_out * 60 / run_window
+            stats["output_tps"] = total_out / run_window
 
         return stats
 
     def _send_window(self) -> float | None:
-        """Return the elapsed seconds between first and last ``record_send`` call.
+        """Return the elapsed seconds between first and last request timestamp.
 
-        Returns ``None`` when fewer than two sends have been recorded.
+        Returns ``None`` when fewer than two requests have been recorded.
         """
         if (
             self._first_send_time is not None
             and self._last_send_time is not None
             and self._last_send_time > self._first_send_time
         ):
-            return self._last_send_time - self._first_send_time
+            return (self._last_send_time - self._first_send_time).total_seconds()
         return None
 
 

--- a/llmeter/utils.py
+++ b/llmeter/utils.py
@@ -109,31 +109,6 @@ class RunningStats:
         # {'failed_requests': 0, ..., 'time_to_first_token-p50': 0.4, ...}
     """
 
-    #: Default stats shown on the progress bar during a run.
-    #: Each entry maps a short display label to a spec:
-    #:
-    #: * ``(metric_name, aggregation)`` — aggregation can be ``"p50"``, ``"p90"``,
-    #:   ``"p99"``, ``"average"``, or ``"sum"``.
-    #: * ``(metric_name, aggregation, "inv")`` — same as above but displays the
-    #:   reciprocal (e.g. seconds-per-token → tokens-per-second).
-    #: * The literal string ``"failed"`` for the running failure count.
-    #: * The literal string ``"rpm"`` for live requests-per-minute based on the
-    #:   send window (first request sent to last request sent).
-    #: * The literal string ``"output_tps"`` for aggregate output tokens per second
-    #:   across all clients, based on the send window.
-    DEFAULT_SNAPSHOT_STATS: dict[str, tuple[str, ...] | str] = {
-        "rpm": "rpm",
-        "output_tps": "output_tps",
-        "p50_ttft": ("time_to_first_token", "p50"),
-        "p90_ttft": ("time_to_first_token", "p90"),
-        "p50_ttlt": ("time_to_last_token", "p50"),
-        "p90_ttlt": ("time_to_last_token", "p90"),
-        "p50_tps": ("time_per_output_token", "p50", "inv"),
-        "input_tokens": ("num_tokens_input", "sum"),
-        "output_tokens": ("num_tokens_output", "sum"),
-        "fail": "failed",
-    }
-
     def __init__(self, metrics: Sequence[str]):
         self._metrics = list(metrics)
         self._count = 0
@@ -266,114 +241,29 @@ class RunningStats:
             for j, v in agg.items():
                 stats[f"{m}-{j}"] = v
 
+        # Send-window throughput (live RPM and output tokens/s).
+        # These use the dispatch timestamps rather than response timestamps,
+        # giving a more accurate picture of the request rate.
+        send_window = self._send_window()
+        if send_window and send_window > 0:
+            stats["rpm"] = self._count / send_window * 60
+            total_out = self._sums.get("num_tokens_output", 0)
+            stats["output_tps"] = total_out / send_window
+
         return stats
 
-    def snapshot(
-        self,
-        fields: dict[str, tuple[str, ...] | str] | None = None,
-    ) -> dict[str, str]:
-        """Format a subset of :meth:`to_stats` for progress-bar display.
+    def _send_window(self) -> float | None:
+        """Return the elapsed seconds between first and last ``record_send`` call.
 
-        Calls :meth:`to_stats` internally and picks only the requested fields,
-        formatting each value as a human-readable string.
-
-        Args:
-            fields: Mapping of ``{display_label: spec}``.  Each *spec* is one of:
-
-                * ``(metric, aggregation)`` — a 2-tuple where *metric* is a tracked
-                  metric name and *aggregation* is ``"p50"``, ``"p90"``, ``"p99"``,
-                  ``"average"``, or ``"sum"``.
-                * ``(metric, aggregation, "inv")`` — a 3-tuple; same as above but
-                  the value is inverted before display (e.g. seconds-per-token →
-                  tokens-per-second).
-                * ``"failed"`` — the literal string; shows the running failure count.
-                * ``"rpm"`` — the literal string; shows live requests-per-minute
-                  estimate based on the send window (first to last request sent).
-                * ``"output_tps"`` — the literal string; shows aggregate output
-                  tokens per second across all clients, based on the send window.
-
-                Defaults to :attr:`DEFAULT_SNAPSHOT_STATS` when ``None``.
-
-        Returns:
-            An ordered dict of ``{label: formatted_value}`` strings suitable for
-            ``tqdm.set_postfix()``.
-
-        Example::
-
-            # Use defaults:
-            rs.snapshot()
-            # {'p50_ttft': '0.312s', 'p90_ttlt': '1.203s', ..., 'fail': '0'}
-
-            # Custom selection — only p99 latency and failures:
-            rs.snapshot({
-                "p99_ttlt": ("time_to_last_token", "p99"),
-                "fail": "failed",
-            })
-            # {'p99_ttlt': '2.105s', 'fail': '1'}
-
-            # Inverted metric — tokens per second from time_per_output_token:
-            rs.snapshot({
-                "tps": ("time_per_output_token", "p50", "inv"),
-            })
-            # {'tps': '28.3 tok/s'}
+        Returns ``None`` when fewer than two sends have been recorded.
         """
-        if self._count == 0:
-            if fields is None:
-                fields = self.DEFAULT_SNAPSHOT_STATS
-            return {label: "—" for label in fields}
-
-        if fields is None:
-            fields = self.DEFAULT_SNAPSHOT_STATS
-
-        raw = self.to_stats()
-
-        info: dict[str, str] = {}
-        for label, spec in fields.items():
-            if spec == "failed":
-                info[label] = str(self._failed)
-                continue
-
-            if spec == "rpm":
-                if (
-                    self._first_send_time is not None
-                    and self._last_send_time is not None
-                    and self._last_send_time > self._first_send_time
-                ):
-                    send_window = self._last_send_time - self._first_send_time
-                    info[label] = f"{self._count / send_window * 60:.1f}"
-                continue
-
-            if spec == "output_tps":
-                if (
-                    self._first_send_time is not None
-                    and self._last_send_time is not None
-                    and self._last_send_time > self._first_send_time
-                ):
-                    send_window = self._last_send_time - self._first_send_time
-                    total_out = self._sums.get("num_tokens_output", 0)
-                    info[label] = f"{total_out / send_window:.1f} tok/s"
-                continue
-
-            metric = spec[0]
-            agg = spec[1]
-            invert = len(spec) > 2 and spec[2] == "inv"
-
-            if agg == "sum":
-                info[label] = f"{self._sums.get(metric, 0):.0f}"
-                continue
-
-            val = raw.get(f"{metric}-{agg}")
-            if val is None:
-                continue
-
-            if invert and val > 0:
-                info[label] = f"{1.0 / val:.1f} tok/s"
-            elif "time" in metric:
-                info[label] = f"{val:.3f}s"
-            else:
-                info[label] = f"{val:.1f}"
-
-        return info
+        if (
+            self._first_send_time is not None
+            and self._last_send_time is not None
+            and self._last_send_time > self._first_send_time
+        ):
+            return self._last_send_time - self._first_send_time
+        return None
 
 
 def now_utc() -> datetime:

--- a/llmeter/utils.py
+++ b/llmeter/utils.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 import bisect
+import time
 from datetime import datetime, timezone
 from itertools import filterfalse
 from math import isnan
@@ -116,7 +117,13 @@ class RunningStats:
     #: * ``(metric_name, aggregation, "inv")`` — same as above but displays the
     #:   reciprocal (e.g. seconds-per-token → tokens-per-second).
     #: * The literal string ``"failed"`` for the running failure count.
+    #: * The literal string ``"rpm"`` for live requests-per-minute based on the
+    #:   send window (first request sent to last request sent).
+    #: * The literal string ``"output_tps"`` for aggregate output tokens per second
+    #:   across all clients, based on the send window.
     DEFAULT_SNAPSHOT_STATS: dict[str, tuple[str, ...] | str] = {
+        "rpm": "rpm",
+        "output_tps": "output_tps",
         "p50_ttft": ("time_to_first_token", "p50"),
         "p90_ttft": ("time_to_first_token", "p90"),
         "p50_ttlt": ("time_to_last_token", "p50"),
@@ -131,8 +138,28 @@ class RunningStats:
         self._metrics = list(metrics)
         self._count = 0
         self._failed = 0
+        self._sends = 0
+        self._first_send_time: float | None = None
+        self._last_send_time: float | None = None
         self._sums: dict[str, float] = {m: 0.0 for m in metrics}
         self._values: dict[str, list[float]] = {m: [] for m in metrics}
+
+    def record_send(self) -> None:
+        """Record that a request was dispatched to the endpoint.
+
+        Call this from the invocation loop each time a request is sent, *before*
+        waiting for the response. This tracks the send-side time window used for
+        accurate RPM and throughput calculations.
+
+        The send window (``_first_send_time`` to ``_last_send_time``) excludes
+        the tail latency of the final response, giving a more accurate picture
+        of the request dispatch rate.
+        """
+        now = time.perf_counter()
+        self._sends += 1
+        if self._first_send_time is None:
+            self._first_send_time = now
+        self._last_send_time = now
 
     def update(self, response_dict: dict[str, Any]) -> None:
         """Record one response's metric values.
@@ -260,6 +287,10 @@ class RunningStats:
                   the value is inverted before display (e.g. seconds-per-token →
                   tokens-per-second).
                 * ``"failed"`` — the literal string; shows the running failure count.
+                * ``"rpm"`` — the literal string; shows live requests-per-minute
+                  estimate based on the send window (first to last request sent).
+                * ``"output_tps"`` — the literal string; shows aggregate output
+                  tokens per second across all clients, based on the send window.
 
                 Defaults to :attr:`DEFAULT_SNAPSHOT_STATS` when ``None``.
 
@@ -287,7 +318,9 @@ class RunningStats:
             # {'tps': '28.3 tok/s'}
         """
         if self._count == 0:
-            return {}
+            if fields is None:
+                fields = self.DEFAULT_SNAPSHOT_STATS
+            return {label: "—" for label in fields}
 
         if fields is None:
             fields = self.DEFAULT_SNAPSHOT_STATS
@@ -298,6 +331,27 @@ class RunningStats:
         for label, spec in fields.items():
             if spec == "failed":
                 info[label] = str(self._failed)
+                continue
+
+            if spec == "rpm":
+                if (
+                    self._first_send_time is not None
+                    and self._last_send_time is not None
+                    and self._last_send_time > self._first_send_time
+                ):
+                    send_window = self._last_send_time - self._first_send_time
+                    info[label] = f"{self._count / send_window * 60:.1f}"
+                continue
+
+            if spec == "output_tps":
+                if (
+                    self._first_send_time is not None
+                    and self._last_send_time is not None
+                    and self._last_send_time > self._first_send_time
+                ):
+                    send_window = self._last_send_time - self._first_send_time
+                    total_out = self._sums.get("num_tokens_output", 0)
+                    info[label] = f"{total_out / send_window:.1f} tok/s"
                 continue
 
             metric = spec[0]

--- a/llmeter/utils.py
+++ b/llmeter/utils.py
@@ -1,5 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+import bisect
 from datetime import datetime, timezone
 from itertools import filterfalse
 from math import isnan
@@ -84,6 +85,241 @@ def summary_stats_from_list(
 
     except StatisticsError:
         return {}
+
+
+class RunningStats:
+    """Accumulate summary statistics incrementally from individual responses.
+
+    Maintains sorted value lists per metric so that percentiles (p50, p90, p99),
+    averages, and sums can be computed at any point — both mid-run (for live
+    progress-bar display via :meth:`snapshot`) and at the end of a run (for the
+    final :class:`~llmeter.results.Result` stats via :meth:`to_stats`).
+
+    Args:
+        metrics: Names of numeric response fields to track (e.g.
+            ``"time_to_first_token"``, ``"num_tokens_output"``).
+
+    Example::
+
+        rs = RunningStats(metrics=["time_to_first_token", "time_to_last_token"])
+        rs.update({"time_to_first_token": 0.3, "time_to_last_token": 0.8})
+        rs.update({"time_to_first_token": 0.5, "time_to_last_token": 1.2, "error": None})
+        rs.to_stats()
+        # {'failed_requests': 0, ..., 'time_to_first_token-p50': 0.4, ...}
+    """
+
+    #: Default stats shown on the progress bar during a run.
+    #: Each entry maps a short display label to a spec:
+    #:
+    #: * ``(metric_name, aggregation)`` — aggregation can be ``"p50"``, ``"p90"``,
+    #:   ``"p99"``, ``"average"``, or ``"sum"``.
+    #: * ``(metric_name, aggregation, "inv")`` — same as above but displays the
+    #:   reciprocal (e.g. seconds-per-token → tokens-per-second).
+    #: * The literal string ``"failed"`` for the running failure count.
+    DEFAULT_SNAPSHOT_STATS: dict[str, tuple[str, ...] | str] = {
+        "p50_ttft": ("time_to_first_token", "p50"),
+        "p90_ttft": ("time_to_first_token", "p90"),
+        "p50_ttlt": ("time_to_last_token", "p50"),
+        "p90_ttlt": ("time_to_last_token", "p90"),
+        "p50_tps": ("time_per_output_token", "p50", "inv"),
+        "input_tokens": ("num_tokens_input", "sum"),
+        "output_tokens": ("num_tokens_output", "sum"),
+        "fail": "failed",
+    }
+
+    def __init__(self, metrics: Sequence[str]):
+        self._metrics = list(metrics)
+        self._count = 0
+        self._failed = 0
+        self._sums: dict[str, float] = {m: 0.0 for m in metrics}
+        self._values: dict[str, list[float]] = {m: [] for m in metrics}
+
+    def update(self, response_dict: dict[str, Any]) -> None:
+        """Record one response's metric values.
+
+        Call this once per :class:`~llmeter.endpoints.base.InvocationResponse`
+        (typically via ``response.to_dict()``).  The method extracts each tracked
+        metric from *response_dict*, skipping ``None`` and ``NaN`` values, and
+        increments the failure counter when an ``"error"`` key is present.
+
+        Args:
+            response_dict: A flat dictionary of response fields, as returned by
+                ``InvocationResponse.to_dict()``.
+
+        Example::
+
+            rs = RunningStats(metrics=["time_to_first_token"])
+            rs.update({"time_to_first_token": 0.42, "error": None})
+            rs.update({"time_to_first_token": None, "error": "timeout"})
+            assert rs._failed == 1
+        """
+        self._count += 1
+        if response_dict.get("error") is not None:
+            self._failed += 1
+        for m in self._metrics:
+            val = response_dict.get(m)
+            if val is not None and not (isinstance(val, float) and isnan(val)):
+                self._sums[m] += val
+                bisect.insort(self._values[m], val)
+
+    def to_stats(
+        self,
+        total_requests: int | None = None,
+        total_test_time: float | None = None,
+        result_dict: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Compute all accumulated statistics as raw numeric values.
+
+        This is the single source of truth for stats computation.  It is called
+        once at the end of a run (with all three optional arguments) to produce
+        the full ``Result.stats`` dict, and also called internally by
+        :meth:`snapshot` (without arguments) for mid-run progress display.
+
+        Args:
+            total_requests: Total number of requests across all clients.  When
+                provided, enables ``failed_requests_rate`` and
+                ``requests_per_minute`` computation.
+            total_test_time: Wall-clock duration of the run in seconds.  When
+                provided, enables throughput metrics (requests/min, tokens/min).
+            result_dict: Base key-value pairs to include in the output (typically
+                from ``Result.to_dict()``).  When ``None``, only metric
+                aggregations and failure counts are returned.
+
+        Returns:
+            A flat dictionary of statistics.  Keys include:
+
+            * ``failed_requests``, ``failed_requests_rate``, ``requests_per_minute``
+            * ``total_input_tokens``, ``total_output_tokens``
+            * ``average_input_tokens_per_minute``, ``average_output_tokens_per_minute``
+            * ``{metric}-{agg}`` for each tracked metric and each aggregation
+              (``average``, ``p50``, ``p90``, ``p99``).
+
+        Example::
+
+            rs = RunningStats(metrics=["time_to_first_token", "num_tokens_output"])
+            for resp in responses:
+                rs.update(resp.to_dict())
+
+            # Mid-run (no run-level context):
+            partial = rs.to_stats()
+            partial["time_to_first_token-p50"]  # 0.312
+
+            # End of run (full Result.stats schema):
+            full = rs.to_stats(
+                total_requests=100,
+                total_test_time=42.5,
+                result_dict=result.to_dict(),
+            )
+            full["requests_per_minute"]  # 141.2
+        """
+        stats: dict[str, Any] = {}
+        if result_dict is not None:
+            stats.update(result_dict)
+
+        # Run-level stats
+        stats["failed_requests"] = self._failed
+        stats["failed_requests_rate"] = total_requests and self._failed / total_requests
+        stats["requests_per_minute"] = (
+            total_test_time and total_requests / total_test_time * 60
+            if total_requests
+            else None
+        )
+        stats["total_input_tokens"] = self._sums.get("num_tokens_input", 0)
+        stats["total_output_tokens"] = self._sums.get("num_tokens_output", 0)
+        stats["average_input_tokens_per_minute"] = (
+            total_test_time and stats["total_input_tokens"] / total_test_time * 60
+        )
+        stats["average_output_tokens_per_minute"] = (
+            total_test_time and stats["total_output_tokens"] / total_test_time * 60
+        )
+
+        # Per-metric aggregations
+        for m in self._metrics:
+            agg = summary_stats_from_list(self._values.get(m, []))
+            for j, v in agg.items():
+                stats[f"{m}-{j}"] = v
+
+        return stats
+
+    def snapshot(
+        self,
+        fields: dict[str, tuple[str, ...] | str] | None = None,
+    ) -> dict[str, str]:
+        """Format a subset of :meth:`to_stats` for progress-bar display.
+
+        Calls :meth:`to_stats` internally and picks only the requested fields,
+        formatting each value as a human-readable string.
+
+        Args:
+            fields: Mapping of ``{display_label: spec}``.  Each *spec* is one of:
+
+                * ``(metric, aggregation)`` — a 2-tuple where *metric* is a tracked
+                  metric name and *aggregation* is ``"p50"``, ``"p90"``, ``"p99"``,
+                  ``"average"``, or ``"sum"``.
+                * ``(metric, aggregation, "inv")`` — a 3-tuple; same as above but
+                  the value is inverted before display (e.g. seconds-per-token →
+                  tokens-per-second).
+                * ``"failed"`` — the literal string; shows the running failure count.
+
+                Defaults to :attr:`DEFAULT_SNAPSHOT_STATS` when ``None``.
+
+        Returns:
+            An ordered dict of ``{label: formatted_value}`` strings suitable for
+            ``tqdm.set_postfix()``.
+
+        Example::
+
+            # Use defaults:
+            rs.snapshot()
+            # {'p50_ttft': '0.312s', 'p90_ttlt': '1.203s', ..., 'fail': '0'}
+
+            # Custom selection — only p99 latency and failures:
+            rs.snapshot({
+                "p99_ttlt": ("time_to_last_token", "p99"),
+                "fail": "failed",
+            })
+            # {'p99_ttlt': '2.105s', 'fail': '1'}
+
+            # Inverted metric — tokens per second from time_per_output_token:
+            rs.snapshot({
+                "tps": ("time_per_output_token", "p50", "inv"),
+            })
+            # {'tps': '28.3 tok/s'}
+        """
+        if self._count == 0:
+            return {}
+
+        if fields is None:
+            fields = self.DEFAULT_SNAPSHOT_STATS
+
+        raw = self.to_stats()
+
+        info: dict[str, str] = {}
+        for label, spec in fields.items():
+            if spec == "failed":
+                info[label] = str(self._failed)
+                continue
+
+            metric = spec[0]
+            agg = spec[1]
+            invert = len(spec) > 2 and spec[2] == "inv"
+
+            if agg == "sum":
+                info[label] = f"{self._sums.get(metric, 0):.0f}"
+                continue
+
+            val = raw.get(f"{metric}-{agg}")
+            if val is None:
+                continue
+
+            if invert and val > 0:
+                info[label] = f"{1.0 / val:.1f} tok/s"
+            elif "time" in metric:
+                info[label] = f"{val:.3f}s"
+            else:
+                info[label] = f"{val:.1f}"
+
+        return info
 
 
 def now_utc() -> datetime:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
-    "boto3-stubs[bedrock,bedrock-runtime,essential,sagemaker]>=1.35.24",
+    "boto3-stubs[bedrock,bedrock-runtime,essential,sagemaker,sagemaker-runtime]>=1.35.24",
     "ipykernel>=6.29.0",
     "ipywidgets>=8.1.3",
     "transformers>=4.40.2",

--- a/tests/integ/conftest.py
+++ b/tests/integ/conftest.py
@@ -148,6 +148,7 @@ def test_image_bytes():
         tuple: (image1_bytes, image2_bytes) - Two JPEG images as bytes
     """
     import io
+
     from PIL import Image
 
     # 32x32 red square JPEG - binary format

--- a/tests/integ/test_bedrock_converse.py
+++ b/tests/integ/test_bedrock_converse.py
@@ -84,8 +84,11 @@ def test_bedrock_converse_non_streaming(
         f"Response should not contain errors: {response.error}"
     )
 
-    # Verify response has an ID
+    # Verify response has an ID from the Bedrock API (AWS RequestId format)
     assert response.id is not None, "Response should have an ID"
+    assert "-" in response.id, (
+        f"Response ID should be an AWS RequestId (UUID with hyphens), got: {response.id}"
+    )
 
 
 @pytest.mark.integ
@@ -161,8 +164,11 @@ def test_bedrock_converse_streaming(
         f"Response should not contain errors: {response.error}"
     )
 
-    # Verify response has an ID
+    # Verify response has an ID from the Bedrock API (AWS RequestId format)
     assert response.id is not None, "Response should have an ID"
+    assert "-" in response.id, (
+        f"Response ID should be an AWS RequestId (UUID with hyphens), got: {response.id}"
+    )
 
 
 @pytest.mark.integ
@@ -235,8 +241,11 @@ def test_bedrock_converse_with_image(
         f"Response should not contain errors: {response.error}"
     )
 
-    # Verify response has an ID
+    # Verify response has an ID from the Bedrock API (AWS RequestId format)
     assert response.id is not None, "Response should have an ID"
+    assert "-" in response.id, (
+        f"Response ID should be an AWS RequestId (UUID with hyphens), got: {response.id}"
+    )
 
 
 @pytest.mark.integ
@@ -286,6 +295,12 @@ def test_bedrock_converse_streaming_with_image(
         f"Response should not contain errors: {response.error}"
     )
 
+    # Verify response has an ID from the Bedrock API (AWS RequestId format)
+    assert response.id is not None, "Response should have an ID"
+    assert "-" in response.id, (
+        f"Response ID should be an AWS RequestId (UUID with hyphens), got: {response.id}"
+    )
+
 
 def test_save_load_payload_with_image(test_payload_with_image, tmp_path):
     """
@@ -303,7 +318,7 @@ def test_save_load_payload_with_image(test_payload_with_image, tmp_path):
         test_payload_with_image: Test payload with image content (from fixture).
         tmp_path: Temporary directory for test files (from pytest).
     """
-    from llmeter.prompt_utils import save_payloads, load_payloads
+    from llmeter.prompt_utils import load_payloads, save_payloads
 
     # Save payload with image
     output_file = save_payloads(test_payload_with_image, tmp_path, "test_image.jsonl")
@@ -346,7 +361,7 @@ def test_save_load_payload_with_video(tmp_path):
     Args:
         tmp_path: Temporary directory for test files (from pytest).
     """
-    from llmeter.prompt_utils import save_payloads, load_payloads
+    from llmeter.prompt_utils import load_payloads, save_payloads
 
     # Create a test payload with video content (simulated video bytes)
     video_payload = {
@@ -408,7 +423,7 @@ def test_save_load_multiple_images(tmp_path):
     Args:
         tmp_path: Temporary directory for test files (from pytest).
     """
-    from llmeter.prompt_utils import save_payloads, load_payloads
+    from llmeter.prompt_utils import load_payloads, save_payloads
 
     # Create a test payload with multiple images
     multi_image_payload = {
@@ -500,8 +515,8 @@ def test_round_trip_bedrock_converse_structure(
         aws_credentials: Boto3 session with valid AWS credentials (from fixture).
         aws_region: AWS region for testing (from fixture).
     """
-    from llmeter.prompt_utils import save_payloads, load_payloads
     from llmeter.endpoints.bedrock import BedrockConverse
+    from llmeter.prompt_utils import load_payloads, save_payloads
 
     # Create a complete Bedrock Converse payload with all typical fields
     complete_payload = {

--- a/tests/integ/test_bedrock_converse.py
+++ b/tests/integ/test_bedrock_converse.py
@@ -23,6 +23,8 @@ Estimated Cost:
     - ~$0.0006 total for all tests in this module
 """
 
+from datetime import datetime
+
 import pytest
 
 from llmeter.endpoints.bedrock import BedrockConverse
@@ -88,6 +90,11 @@ def test_bedrock_converse_non_streaming(
     assert response.id is not None, "Response should have an ID"
     assert "-" in response.id, (
         f"Response ID should be an AWS RequestId (UUID with hyphens), got: {response.id}"
+    )
+
+    # Verify request_time is always set
+    assert isinstance(response.request_time, datetime), (
+        "request_time should be a datetime"
     )
 
 
@@ -170,6 +177,11 @@ def test_bedrock_converse_streaming(
         f"Response ID should be an AWS RequestId (UUID with hyphens), got: {response.id}"
     )
 
+    # Verify request_time is always set
+    assert isinstance(response.request_time, datetime), (
+        "request_time should be a datetime"
+    )
+
 
 @pytest.mark.integ
 def test_bedrock_converse_with_image(
@@ -245,6 +257,11 @@ def test_bedrock_converse_with_image(
     assert response.id is not None, "Response should have an ID"
     assert "-" in response.id, (
         f"Response ID should be an AWS RequestId (UUID with hyphens), got: {response.id}"
+    )
+
+    # Verify request_time is always set
+    assert isinstance(response.request_time, datetime), (
+        "request_time should be a datetime"
     )
 
 

--- a/tests/integ/test_bedrock_converse.py
+++ b/tests/integ/test_bedrock_converse.py
@@ -302,6 +302,101 @@ def test_bedrock_converse_streaming_with_image(
     )
 
 
+@pytest.mark.integ
+def test_bedrock_converse_streaming_prompt_caching(
+    aws_credentials, aws_region, bedrock_test_model
+):
+    """Test that BedrockConverseStream captures prompt caching metrics.
+
+    This test validates that:
+    - A request with a cachePoint in the system prompt succeeds
+    - ``num_tokens_input_cached`` is populated on the response
+    - A second request with the same prefix reads from cache
+
+    Prompt caching requires a minimum of 1024 tokens in the cached prefix
+    for Nova models. We use a long system prompt to meet this threshold.
+
+    Args:
+        aws_credentials: Boto3 session with valid AWS credentials.
+        aws_region: AWS region for testing.
+        bedrock_test_model: Model ID for testing.
+
+    AWS Permissions Required:
+        - bedrock:InvokeModelWithResponseStream
+
+    Estimated Cost:
+        ~$0.0003 per test run (two streaming calls with ~2K cached input tokens)
+    """
+    import time
+    from uuid import uuid4
+
+    from llmeter.endpoints.bedrock import BedrockConverseStream
+
+    endpoint = BedrockConverseStream(model_id=bedrock_test_model, region=aws_region)
+
+    # Unique prefix per test run to avoid accidental cache hits from previous runs.
+    run_id = uuid4().hex
+
+    # Build a system prompt long enough to meet the 1024-token minimum for
+    # Nova prompt caching.  Each "rule" line is ~25 tokens, so 80 lines ≈ 2000.
+    long_system_text = (
+        f"You are a helpful assistant (session {run_id}). Follow these rules:\n"
+        + "\n".join(
+            f"Rule {i}: Always be concise, accurate, and helpful in your responses. "
+            "This is an important guideline that must be followed at all times."
+            for i in range(1, 81)
+        )
+    )
+
+    payload = {
+        "system": [
+            {"text": long_system_text},
+            {"cachePoint": {"type": "default"}},
+        ],
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"text": "Say hello in one word."}],
+            }
+        ],
+        "inferenceConfig": {"maxTokens": 10},
+    }
+
+    # First call: writes the system prompt to cache
+    response1 = endpoint.invoke(payload)
+    assert response1.error is None, f"First call should not error: {response1.error}"
+    assert response1.response_text, "First call should return text"
+
+    # num_tokens_input_cached should be present (may be 0 on cache write)
+    assert response1.num_tokens_input_cached is not None, (
+        "Response should include num_tokens_input_cached field"
+    )
+
+    # Brief pause to allow cache propagation
+    time.sleep(1)
+
+    # Second call with same system prefix: should read from cache
+    payload_2 = {
+        **payload,
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"text": "Say goodbye in one word."}],
+            }
+        ],
+    }
+    response2 = endpoint.invoke(payload_2)
+    assert response2.error is None, f"Second call should not error: {response2.error}"
+    assert response2.response_text, "Second call should return text"
+
+    assert response2.num_tokens_input_cached is not None, (
+        "Second call should report num_tokens_input_cached"
+    )
+    assert response2.num_tokens_input_cached > 0, (
+        f"Expected cached tokens > 0 on cache hit, got {response2.num_tokens_input_cached}"
+    )
+
+
 def test_save_load_payload_with_image(test_payload_with_image, tmp_path):
     """
     Test saving and loading payload with image content using serialization.

--- a/tests/integ/test_bedrock_error_handling.py
+++ b/tests/integ/test_bedrock_error_handling.py
@@ -21,6 +21,8 @@ Estimated Cost:
     - ~$0.0002 total for all tests in this module
 """
 
+from datetime import datetime
+
 import pytest
 
 from llmeter.endpoints.bedrock import BedrockConverse
@@ -97,6 +99,11 @@ def test_invalid_model_error(aws_credentials, aws_region):
     if response.num_tokens_output is not None:
         assert response.num_tokens_output == 0, "Output tokens should be 0 on error"
 
+    # Verify request_time is set even on error
+    assert isinstance(response.request_time, datetime), (
+        "request_time should be a datetime even on error"
+    )
+
 
 @pytest.mark.integ
 def test_invalid_payload_error(aws_credentials, aws_region, bedrock_test_model):
@@ -167,6 +174,11 @@ def test_invalid_payload_error(aws_credentials, aws_region, bedrock_test_model):
         assert response.num_tokens_input == 0, "Input tokens should be 0 on error"
     if response.num_tokens_output is not None:
         assert response.num_tokens_output == 0, "Output tokens should be 0 on error"
+
+    # Verify request_time is set even on error
+    assert isinstance(response.request_time, datetime), (
+        "request_time should be a datetime even on error"
+    )
 
 
 @pytest.mark.integ
@@ -259,6 +271,11 @@ def test_error_response_structure(aws_credentials, aws_region, bedrock_test_mode
         )
         assert hasattr(response, "time_to_first_token"), (
             f"Error response {i}: should have time_to_first_token field"
+        )
+
+        # Verify request_time is set even on error
+        assert isinstance(response.request_time, datetime), (
+            f"Error response {i}: request_time should be a datetime even on error"
         )
 
     # Verify that different error types produce different error messages

--- a/tests/integ/test_bedrock_invoke.py
+++ b/tests/integ/test_bedrock_invoke.py
@@ -22,6 +22,8 @@ Estimated Cost:
     - ~$0.0002 total for all tests in this module
 """
 
+from datetime import datetime
+
 import pytest
 
 from llmeter.endpoints.bedrock_invoke import BedrockInvoke
@@ -115,6 +117,11 @@ def test_bedrock_invoke_non_streaming(aws_credentials, aws_region, bedrock_test_
         f"Response ID should be an AWS RequestId (UUID with hyphens), got: {response.id}"
     )
 
+    # Verify request_time is always set
+    assert isinstance(response.request_time, datetime), (
+        "request_time should be a datetime"
+    )
+
 
 @pytest.mark.integ
 def test_bedrock_invoke_with_image(aws_credentials, aws_region, bedrock_test_model):
@@ -204,6 +211,11 @@ def test_bedrock_invoke_with_image(aws_credentials, aws_region, bedrock_test_mod
     assert response.id is not None, "Response should have an ID"
     assert "-" in response.id, (
         f"Response ID should be an AWS RequestId (UUID with hyphens), got: {response.id}"
+    )
+
+    # Verify request_time is always set
+    assert isinstance(response.request_time, datetime), (
+        "request_time should be a datetime"
     )
 
 
@@ -312,6 +324,11 @@ def test_bedrock_invoke_streaming(aws_credentials, aws_region, bedrock_test_mode
     assert response.id is not None, "Response should have an ID"
     assert "-" in response.id, (
         f"Response ID should be an AWS RequestId (UUID with hyphens), got: {response.id}"
+    )
+
+    # Verify request_time is always set
+    assert isinstance(response.request_time, datetime), (
+        "request_time should be a datetime"
     )
 
 

--- a/tests/integ/test_bedrock_invoke.py
+++ b/tests/integ/test_bedrock_invoke.py
@@ -109,8 +109,11 @@ def test_bedrock_invoke_non_streaming(aws_credentials, aws_region, bedrock_test_
         f"Response should not contain errors: {response.error}"
     )
 
-    # Verify response has an ID
+    # Verify response has an ID from the Bedrock API
     assert response.id is not None, "Response should have an ID"
+    assert "-" in response.id, (
+        f"Response ID should be an AWS RequestId (UUID with hyphens), got: {response.id}"
+    )
 
 
 @pytest.mark.integ
@@ -195,6 +198,12 @@ def test_bedrock_invoke_with_image(aws_credentials, aws_region, bedrock_test_mod
     assert "red" in response_lower or "blue" in response_lower, (
         "Model should identify at least one color (red/blue) from the split image, got: "
         f"{response.response_text[:200]}"
+    )
+
+    # Verify response has an ID from the Bedrock API
+    assert response.id is not None, "Response should have an ID"
+    assert "-" in response.id, (
+        f"Response ID should be an AWS RequestId (UUID with hyphens), got: {response.id}"
     )
 
 
@@ -299,8 +308,11 @@ def test_bedrock_invoke_streaming(aws_credentials, aws_region, bedrock_test_mode
         f"Response should not contain errors: {response.error}"
     )
 
-    # Verify response has an ID
+    # Verify response has an ID from the Bedrock API
     assert response.id is not None, "Response should have an ID"
+    assert "-" in response.id, (
+        f"Response ID should be an AWS RequestId (UUID with hyphens), got: {response.id}"
+    )
 
 
 def test_save_load_invoke_payload_with_image(tmp_path):
@@ -319,9 +331,11 @@ def test_save_load_invoke_payload_with_image(tmp_path):
     Args:
         tmp_path: Temporary directory for test files (from pytest).
     """
-    from llmeter.prompt_utils import save_payloads, load_payloads
     import io
+
     from PIL import Image
+
+    from llmeter.prompt_utils import load_payloads, save_payloads
 
     # Create a simple test image
     img = Image.new("RGB", (50, 50), color="blue")
@@ -403,7 +417,7 @@ def test_round_trip_invoke_structure(
         aws_region: AWS region for testing (from fixture).
         bedrock_test_model: Model ID for testing (from fixture).
     """
-    from llmeter.prompt_utils import save_payloads, load_payloads
+    from llmeter.prompt_utils import load_payloads, save_payloads
 
     # Create a complete Bedrock Invoke payload with provider-specific structure
     # This mimics the actual Anthropic Claude Messages API format used by InvokeModel

--- a/tests/integ/test_openai_bedrock.py
+++ b/tests/integ/test_openai_bedrock.py
@@ -248,8 +248,9 @@ def test_save_load_openai_payload_with_image_url(tmp_path):
     Args:
         tmp_path: Temporary directory for test files (from pytest).
     """
-    from llmeter.prompt_utils import save_payloads, load_payloads
     import base64
+
+    from llmeter.prompt_utils import load_payloads, save_payloads
 
     # Create a small test image (1x1 red pixel PNG)
     test_image_bytes = base64.b64decode(
@@ -335,8 +336,9 @@ def test_save_load_openai_complete_structure(
     Estimated Cost:
         ~$0.0002 per test run (using Qwen3-VL with minimal tokens)
     """
-    from llmeter.prompt_utils import save_payloads, load_payloads
     import base64
+
+    from llmeter.prompt_utils import load_payloads, save_payloads
 
     # Get test images as binary data
     image1_binary, image2_binary = test_image_bytes

--- a/tests/integ/test_openai_response_bedrock.py
+++ b/tests/integ/test_openai_response_bedrock.py
@@ -170,9 +170,9 @@ def test_response_bedrock_streaming(
     )
     assert response.time_to_last_token > 0, "Time to last token should be positive"
 
-    # Verify TTLT > TTFT
-    assert response.time_to_last_token > response.time_to_first_token, (
-        "Time to last token should be greater than time to first token"
+    # Verify TTLT >= TTFT
+    assert response.time_to_last_token >= response.time_to_first_token, (
+        "Time to last token should be gte time to first token"
     )
 
     # Verify response ID

--- a/tests/unit/endpoints/test_bedrock.py
+++ b/tests/unit/endpoints/test_bedrock.py
@@ -46,7 +46,7 @@ class TestBedrock:
 
         # Call the method under test
         start_time = time.perf_counter()
-        result = bedrock_stream._parse_conversation_stream(client_response, start_time)
+        result = bedrock_stream.parse_response(client_response, start_time)
 
         # Assert the result is an InvocationResponse object
         assert isinstance(result, InvocationResponse)
@@ -93,9 +93,7 @@ class TestBedrock:
             mock_perf_counter.side_effect = [start_t + 0.1, start_t + 0.2]
 
             bedrock_stream = BedrockConverseStream(model_id="test_model")
-            result = bedrock_stream._parse_conversation_stream(
-                mock_client_response, start_t
-            )
+            result = bedrock_stream.parse_response(mock_client_response, start_t)
 
         assert isinstance(result, InvocationResponse)
         assert result.response_text == "Hello world!"
@@ -131,11 +129,11 @@ class TestBedrock:
         }
 
         # Call the method
-        result = bedrock_stream._parse_conversation_stream(client_response, start_t)
+        result = bedrock_stream.parse_response(client_response, start_t)
 
         # Assertions
         assert isinstance(result, InvocationResponse)
-        assert result.id
+        # id is back-filled by the invoke wrapper, not by parse_response
         assert result.response_text == ""
         assert result.time_to_last_token is not None
         assert result.time_to_first_token is None
@@ -169,7 +167,7 @@ class TestBedrock:
         start_t = time.perf_counter()
 
         # Call the method
-        response = bedrock_stream._parse_conversation_stream(client_response, start_t)
+        response = bedrock_stream.parse_response(client_response, start_t)
 
         # Assertions
         assert isinstance(response, InvocationResponse)
@@ -216,7 +214,7 @@ class TestBedrock:
         start_t = time.perf_counter()
 
         # Call the method under test
-        result = bedrock_stream._parse_conversation_stream(mock_response, start_t)
+        result = bedrock_stream.parse_response(mock_response, start_t)
 
         # Assertions
         assert isinstance(result, InvocationResponse)
@@ -253,13 +251,13 @@ class TestBedrock:
         start_t = time.perf_counter()
 
         # Call the method under test
-        response = bedrock_stream._parse_conversation_stream(client_response, start_t)
+        response = bedrock_stream.parse_response(client_response, start_t)
 
         # Assert the response is an InvocationResponse
         assert isinstance(response, InvocationResponse)
 
         # Assert the response contains expected values
-        assert response.id is not None
+        # id is back-filled by the invoke wrapper, not by parse_response
         assert response.response_text == "Hello"
         assert response.time_to_last_token is not None
         assert response.time_to_first_token is not None
@@ -276,7 +274,7 @@ class TestBedrock:
         empty_response = {"stream": [], "ResponseMetadata": {"RetryAttempts": 0}}
         start_t = 0.0
 
-        result = bedrock._parse_conversation_stream(empty_response, start_t)
+        result = bedrock.parse_response(empty_response, start_t)
 
         assert isinstance(result, InvocationResponse)
         assert result.response_text == ""
@@ -286,17 +284,15 @@ class TestBedrock:
     def test__parse_conversation_stream_incorrect_type(self):
         """
         Test _parse_conversation_stream with incorrect input type.
+        Parsing methods are internal — they raise on bad input, and the
+        base invoke wrapper converts the exception to an error response.
         """
         bedrock = BedrockConverseStream(model_id="test_model")
         incorrect_type_response = "Not a dictionary"
         start_t = 0.0
 
-        result = bedrock._parse_conversation_stream(incorrect_type_response, start_t)
-
-        assert isinstance(result, InvocationResponse)
-        assert result.response_text is None
-        assert result.time_to_first_token is None
-        assert result.time_to_last_token is None
+        with pytest.raises(TypeError):
+            bedrock.parse_response(incorrect_type_response, start_t)
 
     def test__parse_conversation_stream_invalid_input(self):
         """
@@ -309,12 +305,8 @@ class TestBedrock:
         }
         start_t = 0.0
 
-        result = bedrock._parse_conversation_stream(invalid_response, start_t)
-
-        assert isinstance(result, InvocationResponse)
-        assert result.response_text is None
-        assert result.time_to_first_token is None
-        assert result.time_to_last_token is None
+        with pytest.raises(KeyError):
+            bedrock.parse_response(invalid_response, start_t)
 
     def test__parse_conversation_stream_missing_metadata(self):
         """
@@ -330,7 +322,7 @@ class TestBedrock:
         }
         start_t = 0.0
 
-        result = bedrock._parse_conversation_stream(response_without_metadata, start_t)
+        result = bedrock.parse_response(response_without_metadata, start_t)
 
         assert isinstance(result, InvocationResponse)
         assert result.response_text == "Hello"
@@ -340,17 +332,16 @@ class TestBedrock:
     def test__parse_converse_response_invalid_output_structure(self):
         """
         Test _parse_converse_response with an invalid 'output' structure.
-        This should return an InvocationResponse with error details.
+        Parsing methods raise on bad input; the base invoke wrapper converts
+        exceptions to error responses.
         """
         bedrock_converse = BedrockConverse(model_id="test_model")
         invalid_response = {
             "output": {"invalid_key": "value"},
             "ResponseMetadata": {"RetryAttempts": 0},
         }
-        result = bedrock_converse._parse_converse_response(invalid_response)
-        assert isinstance(result, InvocationResponse)
-        assert result.error is not None
-        assert "missing required field" in str(result.error).lower()
+        with pytest.raises(KeyError):
+            bedrock_converse.parse_response(invalid_response, 0.0)
 
     def test__parse_converse_response_invalid_usage_type(self):
         """
@@ -363,7 +354,7 @@ class TestBedrock:
             "usage": "invalid_usage",
             "ResponseMetadata": {"RetryAttempts": 0},
         }
-        result = bedrock_converse._parse_converse_response(response)
+        result = bedrock_converse.parse_response(response, 0.0)
         assert isinstance(result, InvocationResponse)
         assert result.num_tokens_input is None
         assert result.num_tokens_output is None
@@ -371,28 +362,22 @@ class TestBedrock:
     def test__parse_converse_response_missing_output(self):
         """
         Test _parse_converse_response with a dictionary missing the 'output' key.
-        This should return an InvocationResponse with an error.
         """
         bedrock_converse = BedrockConverse(model_id="test_model")
         invalid_response = {"ResponseMetadata": {"RetryAttempts": 0}}
-        result = bedrock_converse._parse_converse_response(invalid_response)
-        assert isinstance(result, InvocationResponse)
-        assert result.error is not None
-        assert "output" in str(result.error).lower()
+        with pytest.raises(KeyError):
+            bedrock_converse.parse_response(invalid_response, 0.0)
 
     def test__parse_converse_response_missing_response_metadata(self):
         """
         Test _parse_converse_response with a dictionary missing the 'ResponseMetadata' key.
-        This should return an InvocationResponse with an error.
         """
         bedrock_converse = BedrockConverse(model_id="test_model")
         invalid_response = {
             "output": {"message": {"content": [{"text": "Test output"}]}}
         }
-        result = bedrock_converse._parse_converse_response(invalid_response)
-        assert isinstance(result, InvocationResponse)
-        assert result.error is not None
-        assert "responsemetadata" in str(result.error).lower()
+        with pytest.raises(KeyError):
+            bedrock_converse.parse_response(invalid_response, 0.0)
 
     def test__parse_payload_1(self):
         """
@@ -685,14 +670,10 @@ class TestBedrock:
         payload = {"messages": [{"role": "user", "content": [{"text": "Hello"}]}]}
 
         # Act
-        with patch(
-            "llmeter.endpoints.bedrock.uuid4", return_value=Mock(hex="mock_uuid")
-        ):
-            result = bedrock_converse.invoke(payload)
+        result = bedrock_converse.invoke(payload)
 
         # Assert
         assert isinstance(result, InvocationResponse)
-        assert result.id == "mock_uuid"
         assert result.error == "API error"
         assert result.input_payload == {
             "messages": [{"role": "user", "content": [{"text": "Hello"}]}],
@@ -801,7 +782,6 @@ class TestBedrock:
         # Assert the response is an error InvocationResponse
         assert isinstance(response, InvocationResponse)
         assert response.error == "API Error"
-        # assert response.id == "mock_uuid"
         assert response.input_payload == {
             "messages": [{"role": "user", "content": "Hello"}],
             "inferenceConfig": {},
@@ -830,7 +810,7 @@ class TestBedrock:
 
         # Act
         with patch("uuid.uuid4", return_value=Mock(hex="mock_uuid")):
-            result = bedrock_converse._parse_converse_response(mock_response)
+            result = bedrock_converse.parse_response(mock_response, 0.0)
 
         # Assert
         assert isinstance(result, InvocationResponse)

--- a/tests/unit/endpoints/test_bedrock.py
+++ b/tests/unit/endpoints/test_bedrock.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import time
-import uuid
 from unittest.mock import Mock, patch
 
 import pytest
@@ -20,17 +19,9 @@ from llmeter.endpoints.bedrock import (
 class TestBedrock:
     def test__parse_conversation_stream_1(self):
         """
-        Test the _parse_conversation_stream method with a complete stream containing
+        Test process_raw_response with a complete stream containing
         contentBlockDelta, contentBlockStop, and metadata.
-
-        This test verifies that the method correctly parses the conversation stream,
-        extracts the output text, calculates timing information, and processes metadata
-        to create an accurate InvocationResponse object.
         """
-        # Mock the UUID generation to ensure consistent test results
-        uuid.uuid4 = Mock(return_value=Mock(hex="test_uuid"))
-
-        # Create a mock client response
         client_response = {
             "stream": [
                 {"contentBlockDelta": {"delta": {"text": "Hello"}}},
@@ -41,42 +32,33 @@ class TestBedrock:
             "ResponseMetadata": {"RetryAttempts": 0},
         }
 
-        # Create an instance of BedrockConverseStream
         bedrock_stream = BedrockConverseStream(model_id="test_model")
 
-        # Call the method under test
         start_time = time.perf_counter()
-        result = bedrock_stream.parse_response(client_response, start_time)
+        result = InvocationResponse(id=None, response_text=None)
+        bedrock_stream.process_raw_response(client_response, start_time, result)
 
-        # Assert the result is an InvocationResponse object
         assert isinstance(result, InvocationResponse)
 
-        # Check the parsed values
-        # assert result.id == "test_uuid"
         assert result.response_text == "Hello world!"
         assert result.num_tokens_input == 10
         assert result.num_tokens_output == 20
         assert result.retries == 0
 
-        # Check that timing information is set
         assert result.time_to_first_token is not None
         assert result.time_to_last_token is not None
-        # time_per_output_token is computed by the runner, not the endpoint
         assert result.time_per_output_token is None
-        # Verify that time calculations are logical
         assert 0 < result.time_to_first_token < result.time_to_last_token
 
     def test__parse_conversation_stream_2(self):
         """
-        Test the _parse_conversation_stream method when:
+        Test process_raw_response when:
+
         - "contentBlockDelta" is in chunk, but time_flag is False
         - "contentBlockStop" is in chunk
-        - "metadata" is in chunk
-        - metadata is present
+        - "metadata" is in present in chunk
+        - "ResponseMetadata" is also present, including a request ID
         - num_tokens_output, time_to_last_token, and time_to_first_token are all truthy
-
-        This test verifies that the method correctly processes the stream,
-        calculates timings, and sets all relevant fields in the InvocationResponse.
         """
         mock_client_response = {
             "stream": [
@@ -85,41 +67,39 @@ class TestBedrock:
                 {"contentBlockStop": {}},
                 {"metadata": {"usage": {"inputTokens": 10, "outputTokens": 20}}},
             ],
-            "ResponseMetadata": {"RetryAttempts": 0},
+            "ResponseMetadata": {"RequestId": "override-2", "RetryAttempts": 0},
         }
         start_t = time.perf_counter()
 
         with patch("time.perf_counter") as mock_perf_counter:
-            mock_perf_counter.side_effect = [start_t + 0.1, start_t + 0.2]
+            mock_perf_counter.side_effect = [
+                start_t + 0.1,
+                start_t + 0.2,
+                start_t + 0.3,
+                start_t + 0.4,
+            ]
 
             bedrock_stream = BedrockConverseStream(model_id="test_model")
-            result = bedrock_stream.parse_response(mock_client_response, start_t)
+            result = InvocationResponse(id=None, response_text=None)
+            bedrock_stream.process_raw_response(mock_client_response, start_t, result)
 
         assert isinstance(result, InvocationResponse)
+        assert result.id == "override-2"
         assert result.response_text == "Hello world!"
         assert result.num_tokens_input == 10
         assert result.num_tokens_output == 20
         assert abs(result.time_to_first_token - 0.1) < 1e-5
-        assert abs(result.time_to_last_token - 0.2) < 1e-5
+        # TTLT Stops at contentBlockStop block:
+        assert abs(result.time_to_last_token - 0.3) < 1e-5
 
     def test__parse_conversation_stream_3(self):
         """
-        Test the _parse_conversation_stream method when:
-        - There's no 'contentBlockDelta' in any chunk
-        - There's a 'contentBlockStop' in a chunk
-        - There's 'metadata' in a chunk
-        - The metadata contains valid usage information
-        - All necessary timing information is available
-
-        This test verifies that the method correctly processes the stream,
-        calculates timing information, and sets all relevant fields in the
-        InvocationResponse object when these conditions are met.
+        Test process_raw_response when there's no contentBlockDelta but
+        contentBlockStop and metadata are present.
         """
-        # Setup
         bedrock_stream = BedrockConverseStream(model_id="test_model")
         start_t = time.perf_counter()
 
-        # Mock client response
         client_response = {
             "stream": [
                 {"contentBlockStop": {}},
@@ -128,13 +108,12 @@ class TestBedrock:
             "ResponseMetadata": {"RetryAttempts": 0},
         }
 
-        # Call the method
-        result = bedrock_stream.parse_response(client_response, start_t)
+        result = InvocationResponse(id=None, response_text=None)
+        bedrock_stream.process_raw_response(client_response, start_t, result)
 
-        # Assertions
         assert isinstance(result, InvocationResponse)
         # id is back-filled by the invoke wrapper, not by parse_response
-        assert result.response_text == ""
+        assert result.response_text is None
         assert result.time_to_last_token is not None
         assert result.time_to_first_token is None
         assert result.num_tokens_input == 10
@@ -144,16 +123,11 @@ class TestBedrock:
 
     def test__parse_conversation_stream_4(self):
         """
-        Test the _parse_conversation_stream method when the response contains
-        contentBlockDelta, metadata, and has valid token output and timing information.
-
-        This test verifies that the method correctly processes a stream response
-        containing a content block delta, metadata.
+        Test process_raw_response with contentBlockDelta, contentBlockStop,
+        and metadata with valid token counts.
         """
-        # Create an instance of BedrockConverseStream
         bedrock_stream = BedrockConverseStream(model_id="test_model")
 
-        # Mock client response
         client_response = {
             "stream": [
                 {"contentBlockDelta": {"delta": {"text": "Hello"}}},
@@ -163,44 +137,26 @@ class TestBedrock:
             "ResponseMetadata": {"RetryAttempts": 0},
         }
 
-        # Set start time
         start_t = time.perf_counter()
+        response = InvocationResponse(id=None, response_text=None)
+        bedrock_stream.process_raw_response(client_response, start_t, response)
 
-        # Call the method
-        response = bedrock_stream.parse_response(client_response, start_t)
-
-        # Assertions
         assert isinstance(response, InvocationResponse)
         assert response.response_text == "Hello"
         assert response.num_tokens_input == 10
         assert response.num_tokens_output == 5
         assert response.time_to_first_token is not None
         assert response.time_to_last_token is not None
-        # time_per_output_token is computed by the runner, not the endpoint
         assert response.time_per_output_token is None
         assert response.retries == 0
 
     def test__parse_conversation_stream_6(self):
         """
-        Test the _parse_conversation_stream method when:
-        - The stream contains a contentBlockDelta
-        - The time_flag is initially True
-        - The stream contains a contentBlockStop
-        - The stream contains metadata
-        - The metadata is present
-        - The conditions for calculating time_per_output_token are not met
-
-        Expected behavior:
-        - The method should return an InvocationResponse object
-        - The response should contain the correct output text
-        - The response should have time_to_first_token and time_to_last_token set
-        - The response should have num_tokens_input and num_tokens_output set from metadata
-        - The response should not have time_per_output_token set
+        Test process_raw_response with contentBlockDelta, contentBlockStop, and
+        metadata. Verifies time_per_output_token is not set (computed by runner).
         """
-        # Create a mock BedrockConverseStream instance
         bedrock_stream = BedrockConverseStream(model_id="test_model")
 
-        # Create a mock client response
         mock_response = {
             "stream": [
                 {"contentBlockDelta": {"delta": {"text": "Hello"}}},
@@ -210,13 +166,10 @@ class TestBedrock:
             "ResponseMetadata": {"RetryAttempts": 0},
         }
 
-        # Set up the start time
         start_t = time.perf_counter()
+        result = InvocationResponse(id=None, response_text=None)
+        bedrock_stream.process_raw_response(mock_response, start_t, result)
 
-        # Call the method under test
-        result = bedrock_stream.parse_response(mock_response, start_t)
-
-        # Assertions
         assert isinstance(result, InvocationResponse)
         assert result.response_text == "Hello"
         assert result.time_to_first_token is not None
@@ -229,15 +182,10 @@ class TestBedrock:
 
     def test__parse_conversation_stream_7(self):
         """
-        Test the _parse_conversation_stream method when the response contains
-        contentBlockDelta, contentBlockStop, and metadata, but metadata is empty.
-        This test verifies that the method correctly processes the stream chunks
-        and returns an InvocationResponse with expected values.
+        Test process_raw_response when metadata chunk is empty (no usage info).
         """
-        # Create an instance of BedrockConverseStream
         bedrock_stream = BedrockConverseStream(model_id="test_model")
 
-        # Mock client response
         client_response = {
             "stream": [
                 {"contentBlockDelta": {"delta": {"text": "Hello"}}},
@@ -247,17 +195,13 @@ class TestBedrock:
             "ResponseMetadata": {"RetryAttempts": 0},
         }
 
-        # Set start time
         start_t = time.perf_counter()
+        response = InvocationResponse(id=None, response_text=None)
+        bedrock_stream.process_raw_response(client_response, start_t, response)
 
-        # Call the method under test
-        response = bedrock_stream.parse_response(client_response, start_t)
-
-        # Assert the response is an InvocationResponse
         assert isinstance(response, InvocationResponse)
-
-        # Assert the response contains expected values
         # id is back-filled by the invoke wrapper, not by parse_response
+        assert response.id is None
         assert response.response_text == "Hello"
         assert response.time_to_last_token is not None
         assert response.time_to_first_token is not None
@@ -268,22 +212,23 @@ class TestBedrock:
 
     def test__parse_conversation_stream_empty_input(self):
         """
-        Test _parse_conversation_stream with an empty input.
+        Test process_raw_response with an empty stream.
         """
         bedrock = BedrockConverseStream(model_id="test_model")
         empty_response = {"stream": [], "ResponseMetadata": {"RetryAttempts": 0}}
         start_t = 0.0
 
-        result = bedrock.parse_response(empty_response, start_t)
+        result = InvocationResponse(id=None, response_text=None)
+        bedrock.process_raw_response(empty_response, start_t, result)
 
         assert isinstance(result, InvocationResponse)
-        assert result.response_text == ""
+        assert result.response_text is None
         assert result.time_to_first_token is None
         assert result.time_to_last_token is None
 
     def test__parse_conversation_stream_incorrect_type(self):
         """
-        Test _parse_conversation_stream with incorrect input type.
+        Test process_raw_response with incorrect input type.
         Parsing methods are internal — they raise on bad input, and the
         base invoke wrapper converts the exception to an error response.
         """
@@ -291,12 +236,13 @@ class TestBedrock:
         incorrect_type_response = "Not a dictionary"
         start_t = 0.0
 
+        result = InvocationResponse(id=None, response_text=None)
         with pytest.raises(TypeError):
-            bedrock.parse_response(incorrect_type_response, start_t)
+            bedrock.process_raw_response(incorrect_type_response, start_t, result)
 
     def test__parse_conversation_stream_invalid_input(self):
         """
-        Test _parse_conversation_stream with invalid input structure.
+        Test process_raw_response with invalid input structure.
         """
         bedrock = BedrockConverseStream(model_id="test_model")
         invalid_response = {
@@ -305,12 +251,13 @@ class TestBedrock:
         }
         start_t = 0.0
 
+        result = InvocationResponse(id=None, response_text=None)
         with pytest.raises(KeyError):
-            bedrock.parse_response(invalid_response, start_t)
+            bedrock.process_raw_response(invalid_response, start_t, result)
 
     def test__parse_conversation_stream_missing_metadata(self):
         """
-        Test _parse_conversation_stream with missing metadata.
+        Test process_raw_response with missing metadata chunk.
         """
         bedrock = BedrockConverseStream(model_id="test_model")
         response_without_metadata = {
@@ -322,7 +269,8 @@ class TestBedrock:
         }
         start_t = 0.0
 
-        result = bedrock.parse_response(response_without_metadata, start_t)
+        result = InvocationResponse(id=None, response_text=None)
+        bedrock.process_raw_response(response_without_metadata, start_t, result)
 
         assert isinstance(result, InvocationResponse)
         assert result.response_text == "Hello"
@@ -331,7 +279,7 @@ class TestBedrock:
 
     def test__parse_converse_response_invalid_output_structure(self):
         """
-        Test _parse_converse_response with an invalid 'output' structure.
+        Test process_raw_response with an invalid 'output' structure.
         Parsing methods raise on bad input; the base invoke wrapper converts
         exceptions to error responses.
         """
@@ -340,13 +288,14 @@ class TestBedrock:
             "output": {"invalid_key": "value"},
             "ResponseMetadata": {"RetryAttempts": 0},
         }
+        result = InvocationResponse(id=None, response_text=None)
         with pytest.raises(KeyError):
-            bedrock_converse.parse_response(invalid_response, 0.0)
+            bedrock_converse.process_raw_response(invalid_response, 0.0, result)
 
     def test__parse_converse_response_invalid_usage_type(self):
         """
-        Test _parse_converse_response with 'usage' as a non-dictionary type.
-        This should not raise an exception but return None for token counts.
+        Test process_raw_response with 'usage' as a non-dictionary type.
+        This should raise an exception but still capture output text and retries
         """
         bedrock_converse = BedrockConverse(model_id="test_model")
         response = {
@@ -354,30 +303,39 @@ class TestBedrock:
             "usage": "invalid_usage",
             "ResponseMetadata": {"RetryAttempts": 0},
         }
-        result = bedrock_converse.parse_response(response, 0.0)
+        result = InvocationResponse(id=None, response_text=None)
+        with pytest.raises(AttributeError):
+            bedrock_converse.process_raw_response(response, 0.0, result)
         assert isinstance(result, InvocationResponse)
         assert result.num_tokens_input is None
         assert result.num_tokens_output is None
+        assert result.response_text == "Test output"
+        assert result.retries == 0
 
     def test__parse_converse_response_missing_output(self):
         """
-        Test _parse_converse_response with a dictionary missing the 'output' key.
+        Test process_raw_response with a dictionary missing the 'output' key.
         """
         bedrock_converse = BedrockConverse(model_id="test_model")
         invalid_response = {"ResponseMetadata": {"RetryAttempts": 0}}
+        result = InvocationResponse(id=None, response_text=None)
         with pytest.raises(KeyError):
-            bedrock_converse.parse_response(invalid_response, 0.0)
+            bedrock_converse.process_raw_response(invalid_response, 0.0, result)
 
     def test__parse_converse_response_missing_response_metadata(self):
         """
-        Test _parse_converse_response with a dictionary missing the 'ResponseMetadata' key.
+        Test process_raw_response with a dictionary missing the 'ResponseMetadata' key.
         """
         bedrock_converse = BedrockConverse(model_id="test_model")
         invalid_response = {
             "output": {"message": {"content": [{"text": "Test output"}]}}
         }
-        with pytest.raises(KeyError):
-            bedrock_converse.parse_response(invalid_response, 0.0)
+        result = InvocationResponse(id=None, response_text=None)
+        # Should not raise:
+        bedrock_converse.process_raw_response(invalid_response, 0.0, result)
+
+        # Should manage to parse text:
+        assert result.response_text == "Test output"
 
     def test__parse_payload_1(self):
         """
@@ -603,8 +561,8 @@ class TestBedrock:
         """
         bedrock_stream = BedrockConverseStream(model_id="test_model")
         bedrock_stream._bedrock_client = Mock()
-        bedrock_stream._bedrock_client.converse_stream.side_effect = Exception(
-            "Unexpected error"
+        bedrock_stream._bedrock_client.converse_stream = Mock(
+            side_effect=Exception("Unexpected error")
         )
 
         response = bedrock_stream.invoke(
@@ -622,10 +580,11 @@ class TestBedrock:
         """
         bedrock = BedrockConverse(model_id="test_model")
         bedrock._bedrock_client = MagicMock()
+        bedrock._bedrock_client.converse = Mock(return_value={})
         response = bedrock.invoke({})
         assert isinstance(response, InvocationResponse)
         assert response.error is not None
-        assert "expected string for output text" in str(response.error).lower()
+        assert "output" in str(response.error).lower()
 
     # def test_invoke_empty_payload_2(self): #TODO: fix mocking of boto3 client
     #     """
@@ -646,7 +605,9 @@ class TestBedrock:
         """
         bedrock_stream = BedrockConverseStream(model_id="test_model")
         bedrock_stream._bedrock_client = Mock()
-        bedrock_stream._bedrock_client.converse_stream.return_value = {"stream": []}
+        bedrock_stream._bedrock_client.converse_stream = Mock(
+            return_value={"stream": []}
+        )
 
         response = bedrock_stream.invoke(
             {"messages": [{"role": "user", "content": [{"text": "Hello"}]}]}
@@ -665,7 +626,9 @@ class TestBedrock:
         # Arrange
         bedrock_converse = BedrockConverse(model_id="test_model")
         bedrock_converse._bedrock_client = Mock()
-        bedrock_converse._bedrock_client.converse.side_effect = Exception("API error")
+        bedrock_converse._bedrock_client.converse = Mock(
+            side_effect=Exception("API error")
+        )
 
         payload = {"messages": [{"role": "user", "content": [{"text": "Hello"}]}]}
 
@@ -797,10 +760,8 @@ class TestBedrock:
 
     def test_parse_converse_response_success(self):
         """
-        Test that _parse_converse_response correctly parses a successful response
-        and returns an InvocationResponse object with the expected attributes.
+        Test that process_raw_response correctly parses a successful response.
         """
-        # Arrange
         bedrock_converse = BedrockConverse(model_id="test_model")
         mock_response = {
             "output": {"message": {"content": [{"text": "Test output"}]}},
@@ -808,13 +769,12 @@ class TestBedrock:
             "ResponseMetadata": {"RetryAttempts": 1},
         }
 
-        # Act
-        with patch("uuid.uuid4", return_value=Mock(hex="mock_uuid")):
-            result = bedrock_converse.parse_response(mock_response, 0.0)
+        result = InvocationResponse(id="test_id", response_text=None)
+        bedrock_converse.process_raw_response(mock_response, 0.0, result)
 
-        # Assert
         assert isinstance(result, InvocationResponse)
-        # assert result.id == "mock_uuid"  #TODO: fix uuid patching
+        # It's OK to clear the placeholder ID, because the invoke wrapper will put it back:
+        assert result.id is None
         assert result.response_text == "Test output"
         assert result.num_tokens_input == 10
         assert result.num_tokens_output == 20
@@ -831,10 +791,12 @@ class TestBedrock:
             yield {"contentBlockDelta": {"delta": {"text": "Hello"}}}
             raise TimeoutError("Connection timed out during streaming")
 
-        bedrock_stream._bedrock_client.converse_stream.return_value = {
-            "stream": exploding_stream(),
-            "ResponseMetadata": {"RetryAttempts": 0, "RequestId": "req-123"},
-        }
+        bedrock_stream._bedrock_client.converse_stream = Mock(
+            return_value={
+                "stream": exploding_stream(),
+                "ResponseMetadata": {"RetryAttempts": 0, "RequestId": "req-123"},
+            }
+        )
 
         response = bedrock_stream.invoke(
             {"messages": [{"role": "user", "content": [{"text": "Hi"}]}]}
@@ -856,10 +818,12 @@ class TestBedrock:
             yield {"contentBlockDelta": {"delta": {"text": " data"}}}
             raise ConnectionError("Connection reset by peer")
 
-        bedrock_stream._bedrock_client.converse_stream.return_value = {
-            "stream": dropping_stream(),
-            "ResponseMetadata": {"RetryAttempts": 0, "RequestId": "req-456"},
-        }
+        bedrock_stream._bedrock_client.converse_stream = Mock(
+            return_value={
+                "stream": dropping_stream(),
+                "ResponseMetadata": {"RetryAttempts": 0, "RequestId": "req-456"},
+            }
+        )
 
         response = bedrock_stream.invoke(
             {"messages": [{"role": "user", "content": [{"text": "Hi"}]}]}

--- a/tests/unit/endpoints/test_bedrock.py
+++ b/tests/unit/endpoints/test_bedrock.py
@@ -819,3 +819,53 @@ class TestBedrock:
         assert result.num_tokens_input == 10
         assert result.num_tokens_output == 20
         assert result.retries == 1
+
+    def test_invoke_stream_mid_stream_timeout(self):
+        """Verify that a timeout during stream consumption is caught by the
+        invoke wrapper and returned as an error InvocationResponse — not raised."""
+        bedrock_stream = BedrockConverseStream(model_id="test_model")
+        bedrock_stream._bedrock_client = Mock()
+
+        # converse_stream returns immediately, but iterating the stream raises
+        def exploding_stream():
+            yield {"contentBlockDelta": {"delta": {"text": "Hello"}}}
+            raise TimeoutError("Connection timed out during streaming")
+
+        bedrock_stream._bedrock_client.converse_stream.return_value = {
+            "stream": exploding_stream(),
+            "ResponseMetadata": {"RetryAttempts": 0, "RequestId": "req-123"},
+        }
+
+        response = bedrock_stream.invoke(
+            {"messages": [{"role": "user", "content": [{"text": "Hi"}]}]}
+        )
+
+        assert isinstance(response, InvocationResponse)
+        assert response.error is not None
+        assert "timed out" in response.error.lower()
+        assert response.input_payload is not None
+
+    def test_invoke_stream_connection_drop(self):
+        """Verify that a connection error mid-stream is caught and returns
+        partial data where possible."""
+        bedrock_stream = BedrockConverseStream(model_id="test_model")
+        bedrock_stream._bedrock_client = Mock()
+
+        def dropping_stream():
+            yield {"contentBlockDelta": {"delta": {"text": "Partial"}}}
+            yield {"contentBlockDelta": {"delta": {"text": " data"}}}
+            raise ConnectionError("Connection reset by peer")
+
+        bedrock_stream._bedrock_client.converse_stream.return_value = {
+            "stream": dropping_stream(),
+            "ResponseMetadata": {"RetryAttempts": 0, "RequestId": "req-456"},
+        }
+
+        response = bedrock_stream.invoke(
+            {"messages": [{"role": "user", "content": [{"text": "Hi"}]}]}
+        )
+
+        assert isinstance(response, InvocationResponse)
+        assert response.error is not None
+        assert "connection" in response.error.lower()
+        assert response.input_payload is not None

--- a/tests/unit/endpoints/test_bedrock_invoke.py
+++ b/tests/unit/endpoints/test_bedrock_invoke.py
@@ -605,3 +605,62 @@ class TestBedrockInvokeStream:
         assert isinstance(response, InvocationResponse)
         assert response.error is not None
         assert "test error" in str(response.error).lower()
+
+    def test_invoke_stream_mid_stream_timeout(self):
+        """Verify that a timeout during stream body iteration is caught by
+        the invoke wrapper and returned as an error InvocationResponse."""
+        endpoint = BedrockInvokeStream(model_id="test_model")
+        endpoint._bedrock_client = MagicMock()
+
+        def exploding_body():
+            yield {
+                "chunk": {
+                    "bytes": json.dumps(
+                        {"choices": [{"delta": {"content": "Hello"}}]}
+                    ).encode()
+                }
+            }
+            raise TimeoutError("Read timed out during streaming")
+
+        endpoint._bedrock_client.invoke_model_with_response_stream.return_value = {
+            "body": exploding_body(),
+            "ResponseMetadata": {"RetryAttempts": 0, "RequestId": "req-789"},
+        }
+
+        response = endpoint.invoke(
+            {"messages": [{"role": "user", "content": [{"text": "Hi"}]}]}
+        )
+
+        assert isinstance(response, InvocationResponse)
+        assert response.error is not None
+        assert "timed out" in response.error.lower()
+        assert response.input_payload is not None
+
+    def test_invoke_stream_connection_drop(self):
+        """Verify that a connection error mid-stream is caught by the wrapper."""
+        endpoint = BedrockInvokeStream(model_id="test_model")
+        endpoint._bedrock_client = MagicMock()
+
+        def dropping_body():
+            yield {
+                "chunk": {
+                    "bytes": json.dumps(
+                        {"choices": [{"delta": {"content": "Partial"}}]}
+                    ).encode()
+                }
+            }
+            raise ConnectionError("Connection reset by peer")
+
+        endpoint._bedrock_client.invoke_model_with_response_stream.return_value = {
+            "body": dropping_body(),
+            "ResponseMetadata": {"RetryAttempts": 0, "RequestId": "req-abc"},
+        }
+
+        response = endpoint.invoke(
+            {"messages": [{"role": "user", "content": [{"text": "Hi"}]}]}
+        )
+
+        assert isinstance(response, InvocationResponse)
+        assert response.error is not None
+        assert "connection" in response.error.lower()
+        assert response.input_payload is not None

--- a/tests/unit/endpoints/test_bedrock_invoke.py
+++ b/tests/unit/endpoints/test_bedrock_invoke.py
@@ -1,11 +1,11 @@
-from contextlib import contextmanager
-from io import BytesIO
 import json
 import time
+from contextlib import contextmanager
+from io import BytesIO
 
+import pytest
 from botocore.exceptions import ClientError
 from mock import MagicMock
-import pytest
 
 from llmeter.endpoints.bedrock_invoke import (
     BedrockInvoke,
@@ -125,7 +125,7 @@ class TestBedrockInvoke:
             retries=1,
         ) as mock_response:
             # Act
-            result = endpoint._parse_response(mock_response)
+            result = endpoint.parse_response(mock_response, 0.0)
 
         # Assert
         assert isinstance(result, InvocationResponse)
@@ -141,10 +141,10 @@ class TestBedrockInvoke:
         """
         endpoint = BedrockInvoke(model_id="test_model")
         with _mock_invoke_model_response({"wrong_key": "wrong_value"}) as mock_resp:
-            result = endpoint._parse_response(mock_resp)
+            result = endpoint.parse_response(mock_resp, 0.0)
         assert isinstance(result, InvocationResponse)
         assert result.error is None
-        assert isinstance(result.id, str)
+        # id is back-filled by the invoke wrapper, not by parse_response
         assert result.input_prompt is None
         assert result.num_tokens_input is None
         assert result.num_tokens_output is None
@@ -152,15 +152,13 @@ class TestBedrockInvoke:
 
     def test__parse_response_invalid_json(self):
         """
-        If response is invalid JSON, result is an error:
+        If response is invalid JSON, _parse_response raises JSONDecodeError.
+        The base invoke wrapper converts this to an error response.
         """
         endpoint = BedrockInvoke(model_id="test_model")
         with BytesIO('{"Oops": '.encode("utf-8")) as invalid_body:
-            result = endpoint._parse_response({"body": invalid_body})
-        assert isinstance(result, InvocationResponse)
-        assert result.error is not None
-        assert "json" in str(result.error).lower()
-        assert isinstance(result.id, str)
+            with pytest.raises(json.JSONDecodeError):
+                endpoint.parse_response({"body": invalid_body}, 0.0)
 
     def test__parse_response_custom_jmespaths(self):
         """
@@ -185,7 +183,7 @@ class TestBedrockInvoke:
             },
         ) as mock_response:
             # Act
-            result = endpoint._parse_response(mock_response)
+            result = endpoint.parse_response(mock_response, 0.0)
 
         # Assert
         assert isinstance(result, InvocationResponse)
@@ -278,7 +276,8 @@ class TestBedrockInvoke:
 
     def test_invoke_payload_no_text(self):
         """
-        When text cannot be extracted from the input payload, an error should be returned
+        When text cannot be extracted from the input payload, the invocation
+        should still succeed — _parse_payload failure is not an invocation error.
         """
         endpoint = BedrockInvoke(model_id="test_model")
         endpoint._bedrock_client = MagicMock()
@@ -288,8 +287,9 @@ class TestBedrockInvoke:
             )
             response = endpoint.invoke({})
         assert isinstance(response, InvocationResponse)
-        assert response.error is not None
-        assert "failed to extract input text" in str(response.error).lower()
+        assert response.error is None
+        # input_prompt falls back to None when _parse_payload can't extract text
+        assert response.input_prompt is None
 
     def test_invoke_generic_exception(self):
         """
@@ -407,7 +407,7 @@ class TestBedrockInvokeStream:
 
         # Call the method under test
         start_time = time.perf_counter()
-        result = endpoint._parse_response_stream(client_response, start_time)
+        result = endpoint.parse_response(client_response, start_time)
 
         # Assert the result is an InvocationResponse object
         assert isinstance(result, InvocationResponse)
@@ -462,7 +462,7 @@ class TestBedrockInvokeStream:
 
         # Call the method under test
         start_time = time.perf_counter()
-        result = endpoint._parse_response_stream(client_response, start_time)
+        result = endpoint.parse_response(client_response, start_time)
 
         # Assert the result is an InvocationResponse object
         assert isinstance(result, InvocationResponse)
@@ -478,51 +478,98 @@ class TestBedrockInvokeStream:
 
     def test__parse_response_stream_known_error(self):
         """
-        Test _parse_response_stream detects and returns known errors in the stream
+        Test parse_response records known Bedrock stream errors and returns partial data.
         """
         endpoint = BedrockInvokeStream(model_id="test_model")
         client_response = {
             "body": [
                 {"throttlingException": {"message": "Test error"}},
-                MagicMock(
-                    side_effect=RuntimeError("Shouldn't try to access this chunk")
-                ),
             ],
             "ResponseMetadata": {"RetryAttempts": 0},
         }
 
-        # Call the method under test
         start_time = time.perf_counter()
-        result = endpoint._parse_response_stream(client_response, start_time)
+        result = endpoint.parse_response(client_response, start_time)
 
-        # Check result:
         assert isinstance(result, InvocationResponse)
         assert result.error is not None
-        assert "test error" in str(result.error).lower()
+        assert "test error" in result.error.lower()
 
-    def test__parse_response_stream_unknown_error(self):
+    def test__parse_response_stream_known_error_with_partial_data(self):
         """
-        Test _parse_response_stream detects and returns unknown errors in the stream
+        Test that partial data collected before a stream error is preserved.
         """
-        endpoint = BedrockInvokeStream(model_id="test_model")
+        endpoint = BedrockInvokeStream(
+            model_id="test_model",
+            generated_text_jmespath="choices[0].delta.content",
+        )
         client_response = {
             "body": [
-                {"myUnexpectedChunkType": {"hello": "world"}},
-                MagicMock(
-                    side_effect=RuntimeError("Shouldn't try to access this chunk")
-                ),
+                {
+                    "chunk": {
+                        "bytes": json.dumps(
+                            {"choices": [{"delta": {"content": "Hello"}}]}
+                        ).encode()
+                    }
+                },
+                {
+                    "chunk": {
+                        "bytes": json.dumps(
+                            {"choices": [{"delta": {"content": " world"}}]}
+                        ).encode()
+                    }
+                },
+                {"throttlingException": {"message": "Rate exceeded"}},
             ],
             "ResponseMetadata": {"RetryAttempts": 0},
         }
 
-        # Call the method under test
         start_time = time.perf_counter()
-        result = endpoint._parse_response_stream(client_response, start_time)
+        result = endpoint.parse_response(client_response, start_time)
 
-        # Check result:
         assert isinstance(result, InvocationResponse)
         assert result.error is not None
-        assert "unknown event" in str(result.error).lower()
+        assert "rate exceeded" in result.error.lower()
+        # Partial data is preserved
+        assert result.response_text == "Hello world"
+        assert result.time_to_first_token is not None
+
+    def test__parse_response_stream_unknown_event(self):
+        """
+        Test parse_response skips unknown event types without aborting.
+        """
+        endpoint = BedrockInvokeStream(
+            model_id="test_model",
+            generated_text_jmespath="choices[0].delta.content",
+        )
+        client_response = {
+            "body": [
+                {
+                    "chunk": {
+                        "bytes": json.dumps(
+                            {"choices": [{"delta": {"content": "Hi"}}]}
+                        ).encode()
+                    }
+                },
+                {"myUnexpectedChunkType": {"hello": "world"}},
+                {
+                    "chunk": {
+                        "bytes": json.dumps(
+                            {"choices": [{"delta": {"content": "!"}}]}
+                        ).encode()
+                    }
+                },
+            ],
+            "ResponseMetadata": {"RetryAttempts": 0},
+        }
+
+        start_time = time.perf_counter()
+        result = endpoint.parse_response(client_response, start_time)
+
+        assert isinstance(result, InvocationResponse)
+        # Unknown events are skipped, not errors
+        assert result.error is None
+        assert result.response_text == "Hi!"
 
     def test__parse_response_stream_empty_input(self):
         """
@@ -531,7 +578,7 @@ class TestBedrockInvokeStream:
         endpoint = BedrockInvokeStream(model_id="test_model")
         empty_response = {"body": [], "ResponseMetadata": {"RetryAttempts": 0}}
         start_time = time.perf_counter()
-        result = endpoint._parse_response_stream(empty_response, start_time)
+        result = endpoint.parse_response(empty_response, start_time)
 
         assert isinstance(result, InvocationResponse)
         assert result.response_text == ""

--- a/tests/unit/endpoints/test_bedrock_invoke.py
+++ b/tests/unit/endpoints/test_bedrock_invoke.py
@@ -5,7 +5,7 @@ from io import BytesIO
 
 import pytest
 from botocore.exceptions import ClientError
-from mock import MagicMock
+from mock import MagicMock, Mock
 
 from llmeter.endpoints.bedrock_invoke import (
     BedrockInvoke,
@@ -97,10 +97,8 @@ class TestBedrockInvoke:
 
     def test_parse_response_success(self):
         """
-        Test that _parse_response correctly parses a successful ChatCompletions response
-        and returns an InvocationResponse object with the expected attributes.
+        Test that process_raw_response correctly parses a successful ChatCompletions response.
         """
-        # Arrange
         endpoint = BedrockInvoke(model_id="test_model")
         with _mock_invoke_model_response(
             {
@@ -124,10 +122,9 @@ class TestBedrockInvoke:
             },
             retries=1,
         ) as mock_response:
-            # Act
-            result = endpoint.parse_response(mock_response, 0.0)
+            result = InvocationResponse(id=None, response_text=None)
+            endpoint.process_raw_response(mock_response, 0.0, result)
 
-        # Assert
         assert isinstance(result, InvocationResponse)
         assert result.id == "test_response_id"
         assert result.response_text == "Test output"
@@ -141,10 +138,10 @@ class TestBedrockInvoke:
         """
         endpoint = BedrockInvoke(model_id="test_model")
         with _mock_invoke_model_response({"wrong_key": "wrong_value"}) as mock_resp:
-            result = endpoint.parse_response(mock_resp, 0.0)
+            result = InvocationResponse(id=None, response_text=None)
+            endpoint.process_raw_response(mock_resp, 0.0, result)
         assert isinstance(result, InvocationResponse)
         assert result.error is None
-        # id is back-filled by the invoke wrapper, not by parse_response
         assert result.input_prompt is None
         assert result.num_tokens_input is None
         assert result.num_tokens_output is None
@@ -152,19 +149,19 @@ class TestBedrockInvoke:
 
     def test__parse_response_invalid_json(self):
         """
-        If response is invalid JSON, _parse_response raises JSONDecodeError.
+        If response is invalid JSON, process_raw_response raises JSONDecodeError.
         The base invoke wrapper converts this to an error response.
         """
         endpoint = BedrockInvoke(model_id="test_model")
+        result = InvocationResponse(id=None, response_text=None)
         with BytesIO('{"Oops": '.encode("utf-8")) as invalid_body:
             with pytest.raises(json.JSONDecodeError):
-                endpoint.parse_response({"body": invalid_body}, 0.0)
+                endpoint.process_raw_response({"body": invalid_body}, 0.0, result)
 
     def test__parse_response_custom_jmespaths(self):
         """
-        Test that _parse_response correctly parses with custom JMESPath configs
+        Test that process_raw_response correctly parses with custom JMESPath configs
         """
-        # Arrange
         endpoint = BedrockInvoke(
             model_id="test_model",
             generated_text_jmespath="my.cool.nested.output",
@@ -182,10 +179,9 @@ class TestBedrockInvoke:
                 }
             },
         ) as mock_response:
-            # Act
-            result = endpoint.parse_response(mock_response, 0.0)
+            result = InvocationResponse(id=None, response_text=None)
+            endpoint.process_raw_response(mock_response, 0.0, result)
 
-        # Assert
         assert isinstance(result, InvocationResponse)
         assert result.response_text == "Hi there"
         assert result.num_tokens_input == 24
@@ -263,9 +259,10 @@ class TestBedrockInvoke:
         """
         endpoint = BedrockInvoke(model_id="test_model")
         endpoint._bedrock_client = MagicMock()
-        endpoint._bedrock_client.invoke_model = MagicMock()
-        endpoint._bedrock_client.invoke_model.side_effect = ClientError(
-            {"Error": {"Message": "Test error"}}, "invoke_model"
+        endpoint._bedrock_client.invoke_model = Mock(
+            side_effect=ClientError(
+                {"Error": {"Message": "Test error"}}, "invoke_model"
+            )
         )
         response = endpoint.invoke(
             {"messages": [{"role": "user", "content": [{"text": "Hello"}]}]}
@@ -282,9 +279,7 @@ class TestBedrockInvoke:
         endpoint = BedrockInvoke(model_id="test_model")
         endpoint._bedrock_client = MagicMock()
         with _mock_invoke_model_response({}) as mock_resp:
-            endpoint._bedrock_client.invoke_model = MagicMock(
-                return_value=mock_resp,
-            )
+            endpoint._bedrock_client.invoke_model = Mock(return_value=mock_resp)
             response = endpoint.invoke({})
         assert isinstance(response, InvocationResponse)
         assert response.error is None
@@ -298,7 +293,7 @@ class TestBedrockInvoke:
         """
         endpoint = BedrockInvoke(model_id="test_model")
         endpoint._bedrock_client = MagicMock()
-        endpoint._bedrock_client.invoke_model = MagicMock(
+        endpoint._bedrock_client.invoke_model = Mock(
             side_effect=Exception("Generic error")
         )
         response = endpoint.invoke(
@@ -332,9 +327,7 @@ class TestBedrockInvoke:
         with _mock_invoke_model_response(
             body={"output": {"message": {"content": [{"text": "Hi"}]}}},
         ) as mock_response:
-            endpoint._bedrock_client.invoke_model = MagicMock(
-                return_value=mock_response
-            )
+            endpoint._bedrock_client.invoke_model = Mock(return_value=mock_response)
 
             payload = {
                 "messages": [{"role": "user", "content": [{"text": "Hello"}]}],
@@ -353,7 +346,7 @@ class TestBedrockInvoke:
 class TestBedrockInvokeStream:
     def test__parse_response_stream_standard(self):
         """
-        Test the default _parse_response_stream method with ChatCompletions format events.
+        Test the default process_raw_response method with ChatCompletions format events.
         """
         endpoint = BedrockInvokeStream(model_id="test_model")
         client_response = {
@@ -405,31 +398,27 @@ class TestBedrockInvokeStream:
             "ResponseMetadata": {"RetryAttempts": 0},
         }
 
-        # Call the method under test
         start_time = time.perf_counter()
-        result = endpoint.parse_response(client_response, start_time)
+        result = InvocationResponse(id=None, response_text=None)
+        endpoint.process_raw_response(client_response, start_time, result)
 
-        # Assert the result is an InvocationResponse object
         assert isinstance(result, InvocationResponse)
 
-        # Check the parsed values
         assert result.id == "test_id"
         assert result.response_text == "Hi there fella"
         assert result.num_tokens_input == 6
         assert result.num_tokens_output == 7
         assert result.retries == 0
 
-        # Check that timing information is set
         assert result.time_to_first_token is not None
         assert result.time_to_first_token < 100000
         assert result.time_to_last_token is not None
         assert result.time_to_last_token < 100000
-        # Verify that time calculations are logical
         assert 0 < result.time_to_first_token < result.time_to_last_token
 
     def test__parse_response_stream_no_content(self):
         """
-        Test the default _parse_response_stream method when there's no content returned
+        Test the default process_raw_response method when there's no content returned
         """
         endpoint = BedrockInvokeStream(model_id="test_model")
         client_response = {
@@ -460,25 +449,22 @@ class TestBedrockInvokeStream:
             "ResponseMetadata": {"RetryAttempts": 0},
         }
 
-        # Call the method under test
         start_time = time.perf_counter()
-        result = endpoint.parse_response(client_response, start_time)
+        result = InvocationResponse(id=None, response_text=None)
+        endpoint.process_raw_response(client_response, start_time, result)
 
-        # Assert the result is an InvocationResponse object
         assert isinstance(result, InvocationResponse)
 
-        # Check the parsed values
-        assert result.response_text == ""
+        assert result.response_text is None
         assert result.num_tokens_input == 6
         assert result.num_tokens_output == 7
 
-        # Check that timing information is set
         assert result.time_to_first_token is None
         assert result.time_to_last_token is None
 
     def test__parse_response_stream_known_error(self):
         """
-        Test parse_response records known Bedrock stream errors and returns partial data.
+        Test process_raw_response records known Bedrock stream errors and returns partial data.
         """
         endpoint = BedrockInvokeStream(model_id="test_model")
         client_response = {
@@ -489,7 +475,8 @@ class TestBedrockInvokeStream:
         }
 
         start_time = time.perf_counter()
-        result = endpoint.parse_response(client_response, start_time)
+        result = InvocationResponse(id=None, response_text=None)
+        endpoint.process_raw_response(client_response, start_time, result)
 
         assert isinstance(result, InvocationResponse)
         assert result.error is not None
@@ -525,18 +512,18 @@ class TestBedrockInvokeStream:
         }
 
         start_time = time.perf_counter()
-        result = endpoint.parse_response(client_response, start_time)
+        result = InvocationResponse(id=None, response_text=None)
+        endpoint.process_raw_response(client_response, start_time, result)
 
         assert isinstance(result, InvocationResponse)
         assert result.error is not None
         assert "rate exceeded" in result.error.lower()
-        # Partial data is preserved
         assert result.response_text == "Hello world"
         assert result.time_to_first_token is not None
 
     def test__parse_response_stream_unknown_event(self):
         """
-        Test parse_response skips unknown event types without aborting.
+        Test process_raw_response skips unknown event types without aborting.
         """
         endpoint = BedrockInvokeStream(
             model_id="test_model",
@@ -564,24 +551,25 @@ class TestBedrockInvokeStream:
         }
 
         start_time = time.perf_counter()
-        result = endpoint.parse_response(client_response, start_time)
+        result = InvocationResponse(id=None, response_text=None)
+        endpoint.process_raw_response(client_response, start_time, result)
 
         assert isinstance(result, InvocationResponse)
-        # Unknown events are skipped, not errors
         assert result.error is None
         assert result.response_text == "Hi!"
 
     def test__parse_response_stream_empty_input(self):
         """
-        Test _parse_response_stream with an empty input.
+        Test process_raw_response with an empty input.
         """
         endpoint = BedrockInvokeStream(model_id="test_model")
         empty_response = {"body": [], "ResponseMetadata": {"RetryAttempts": 0}}
         start_time = time.perf_counter()
-        result = endpoint.parse_response(empty_response, start_time)
+        result = InvocationResponse(id=None, response_text=None)
+        endpoint.process_raw_response(empty_response, start_time, result)
 
         assert isinstance(result, InvocationResponse)
-        assert result.response_text == ""
+        assert result.response_text is None
         assert result.time_to_first_token is None
         assert result.time_to_last_token is None
 
@@ -592,9 +580,8 @@ class TestBedrockInvokeStream:
         """
         endpoint = BedrockInvokeStream(model_id="test_model")
         endpoint._bedrock_client = MagicMock()
-        endpoint._bedrock_client.invoke_model_with_response_stream = MagicMock()
-        endpoint._bedrock_client.invoke_model_with_response_stream.side_effect = (
-            ClientError(
+        endpoint._bedrock_client.invoke_model_with_response_stream = Mock(
+            side_effect=ClientError(
                 {"Error": {"Message": "Test error"}},
                 "invoke_model_with_response_stream",
             )
@@ -622,10 +609,12 @@ class TestBedrockInvokeStream:
             }
             raise TimeoutError("Read timed out during streaming")
 
-        endpoint._bedrock_client.invoke_model_with_response_stream.return_value = {
-            "body": exploding_body(),
-            "ResponseMetadata": {"RetryAttempts": 0, "RequestId": "req-789"},
-        }
+        endpoint._bedrock_client.invoke_model_with_response_stream = Mock(
+            return_value={
+                "body": exploding_body(),
+                "ResponseMetadata": {"RetryAttempts": 0, "RequestId": "req-789"},
+            }
+        )
 
         response = endpoint.invoke(
             {"messages": [{"role": "user", "content": [{"text": "Hi"}]}]}
@@ -651,10 +640,12 @@ class TestBedrockInvokeStream:
             }
             raise ConnectionError("Connection reset by peer")
 
-        endpoint._bedrock_client.invoke_model_with_response_stream.return_value = {
-            "body": dropping_body(),
-            "ResponseMetadata": {"RetryAttempts": 0, "RequestId": "req-abc"},
-        }
+        endpoint._bedrock_client.invoke_model_with_response_stream = Mock(
+            return_value={
+                "body": dropping_body(),
+                "ResponseMetadata": {"RetryAttempts": 0, "RequestId": "req-abc"},
+            }
+        )
 
         response = endpoint.invoke(
             {"messages": [{"role": "user", "content": [{"text": "Hi"}]}]}

--- a/tests/unit/endpoints/test_bedrock_multimodal.py
+++ b/tests/unit/endpoints/test_bedrock_multimodal.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from llmeter.endpoints.bedrock import BedrockBase
-from llmeter.prompt_utils import ImageContent, DocumentContent
+from llmeter.prompt_utils import DocumentContent, ImageContent
 
 
 class TestBedrockMultiModal:

--- a/tests/unit/endpoints/test_endpoints.py
+++ b/tests/unit/endpoints/test_endpoints.py
@@ -5,7 +5,7 @@ import pytest
 
 import llmeter
 import llmeter.endpoints
-from llmeter.endpoints.base import Endpoint, InvocationResponse, llmeter_invoke
+from llmeter.endpoints.base import Endpoint, InvocationResponse
 
 # Tests for InvocationResponse
 
@@ -67,22 +67,22 @@ def test_invocation_response_repr_and_str():
 # Tests for BaseEndpoint
 
 
-class ConcreteEndpoint(Endpoint):
+class ConcreteEndpoint(Endpoint[dict]):
     def __init__(self, endpoint_name: str, model_id: str, provider: str):
         super().__init__(
             endpoint_name=endpoint_name, model_id=model_id, provider=provider
         )
 
-    @llmeter_invoke
-    def invoke(self, payload: dict) -> InvocationResponse:
+    @Endpoint.llmeter_invoke
+    def invoke(self, payload: dict) -> dict:
         return payload
 
-    def parse_response(self, raw_response, start_t: float) -> InvocationResponse:
-        return InvocationResponse(
-            id="test_id",
-            response_text=f"Invoked with payload: {raw_response}",
-            input_prompt=raw_response.get("prompt", ""),
-        )
+    def process_raw_response(
+        self, raw_response: dict, start_t: float, response: InvocationResponse
+    ) -> None:
+        response.id = "test_id"
+        response.response_text = f"Invoked with payload: {raw_response}"
+        response.input_prompt = raw_response.get("prompt", "")
 
     @classmethod
     def create_payload(cls, prompt: str):
@@ -130,7 +130,9 @@ def test_invoke_error_sets_request_time(concrete_endpoint):
 
     # Make parse_response raise to trigger the error path
     with patch.object(
-        type(concrete_endpoint), "parse_response", side_effect=RuntimeError("boom")
+        type(concrete_endpoint),
+        "process_raw_response",
+        side_effect=RuntimeError("boom"),
     ):
         before = datetime.now(timezone.utc)
         response = concrete_endpoint.invoke({"prompt": "Hello"})

--- a/tests/unit/endpoints/test_endpoints.py
+++ b/tests/unit/endpoints/test_endpoints.py
@@ -5,7 +5,7 @@ import pytest
 
 import llmeter
 import llmeter.endpoints
-from llmeter.endpoints.base import Endpoint, InvocationResponse
+from llmeter.endpoints.base import Endpoint, InvocationResponse, llmeter_invoke
 
 # Tests for InvocationResponse
 
@@ -73,6 +73,7 @@ class ConcreteEndpoint(Endpoint):
             endpoint_name=endpoint_name, model_id=model_id, provider=provider
         )
 
+    @llmeter_invoke
     def invoke(self, payload: dict) -> InvocationResponse:
         return self.parse_response(payload, 0.0)
 

--- a/tests/unit/endpoints/test_endpoints.py
+++ b/tests/unit/endpoints/test_endpoints.py
@@ -110,6 +110,36 @@ def test_base_endpoint_invoke(concrete_endpoint):
     assert response.input_prompt == "Hello"
 
 
+def test_invoke_sets_request_time(concrete_endpoint):
+    """The invoke wrapper should always set request_time on the response."""
+    from datetime import datetime, timezone
+
+    before = datetime.now(timezone.utc)
+    response = concrete_endpoint.invoke({"prompt": "Hello"})
+    after = datetime.now(timezone.utc)
+
+    assert response.request_time is not None
+    assert before <= response.request_time <= after
+
+
+def test_invoke_error_sets_request_time(concrete_endpoint):
+    """request_time should be set even when invoke raises an exception."""
+    from datetime import datetime, timezone
+    from unittest.mock import patch
+
+    # Make parse_response raise to trigger the error path
+    with patch.object(
+        type(concrete_endpoint), "parse_response", side_effect=RuntimeError("boom")
+    ):
+        before = datetime.now(timezone.utc)
+        response = concrete_endpoint.invoke({"prompt": "Hello"})
+        after = datetime.now(timezone.utc)
+
+    assert response.error is not None
+    assert response.request_time is not None
+    assert before <= response.request_time <= after
+
+
 def test_base_endpoint_create_payload():
     payload = ConcreteEndpoint.create_payload("Test prompt")
     assert payload == {"prompt": "Test prompt"}

--- a/tests/unit/endpoints/test_endpoints.py
+++ b/tests/unit/endpoints/test_endpoints.py
@@ -74,10 +74,13 @@ class ConcreteEndpoint(Endpoint):
         )
 
     def invoke(self, payload: dict) -> InvocationResponse:
+        return self.parse_response(payload, 0.0)
+
+    def parse_response(self, raw_response, start_t: float) -> InvocationResponse:
         return InvocationResponse(
             id="test_id",
-            response_text=f"Invoked with payload: {payload}",
-            input_prompt=payload.get("prompt", ""),
+            response_text=f"Invoked with payload: {raw_response}",
+            input_prompt=raw_response.get("prompt", ""),
         )
 
     @classmethod

--- a/tests/unit/endpoints/test_endpoints.py
+++ b/tests/unit/endpoints/test_endpoints.py
@@ -75,7 +75,7 @@ class ConcreteEndpoint(Endpoint):
 
     @llmeter_invoke
     def invoke(self, payload: dict) -> InvocationResponse:
-        return self.parse_response(payload, 0.0)
+        return payload
 
     def parse_response(self, raw_response, start_t: float) -> InvocationResponse:
         return InvocationResponse(

--- a/tests/unit/endpoints/test_litellm.py
+++ b/tests/unit/endpoints/test_litellm.py
@@ -242,7 +242,7 @@ class TestLiteLLM:
         usage_mock.completion_tokens = 8
         mock_response.usage = usage_mock
 
-        result = self.endpoint._parse_converse_response(mock_response)
+        result = self.endpoint.parse_response(mock_response, 0.0)
 
         assert isinstance(result, InvocationResponse)
         assert result.id == "response-id"
@@ -259,7 +259,7 @@ class TestLiteLLM:
         # Remove usage attribute to simulate AttributeError
         del mock_response.usage
 
-        result = self.endpoint._parse_converse_response(mock_response)
+        result = self.endpoint.parse_response(mock_response, 0.0)
 
         assert isinstance(result, InvocationResponse)
         assert result.id == "response-id"
@@ -412,7 +412,7 @@ class TestLiteLLMStreaming:
         mock_stream = MagicMock()
         mock_stream.__iter__ = lambda self: iter([chunk1, chunk2])
 
-        result = self.endpoint._parse_stream(mock_stream, start_t)  # type: ignore
+        result = self.endpoint.parse_response(mock_stream, start_t)  # type: ignore
 
         assert isinstance(result, InvocationResponse)
         assert result.id == "test-id"
@@ -440,7 +440,7 @@ class TestLiteLLMStreaming:
         mock_stream = MagicMock()
         mock_stream.__iter__ = lambda self: iter([chunk])
 
-        result = self.endpoint._parse_stream(mock_stream, start_t)  # type: ignore
+        result = self.endpoint.parse_response(mock_stream, start_t)  # type: ignore
 
         assert result.num_tokens_input is None
         assert result.num_tokens_output is None
@@ -468,7 +468,7 @@ class TestLiteLLMStreaming:
         mock_stream = MagicMock()
         mock_stream.__iter__ = lambda self: iter([chunk1, chunk2])
 
-        result = self.endpoint._parse_stream(mock_stream, start_t)  # type: ignore
+        result = self.endpoint.parse_response(mock_stream, start_t)  # type: ignore
 
         assert result.response_text == "Real content"
 
@@ -489,7 +489,7 @@ class TestLiteLLMStreaming:
         mock_stream = MagicMock()
         mock_stream.__iter__ = lambda self: iter([chunk])
 
-        result = self.endpoint._parse_stream(mock_stream, start_t)  # type: ignore
+        result = self.endpoint.parse_response(mock_stream, start_t)  # type: ignore
 
         # With 1 token, (num_tokens_output - 1) = 0, so time_per_output_token should be None
         assert result.time_per_output_token is None

--- a/tests/unit/endpoints/test_litellm.py
+++ b/tests/unit/endpoints/test_litellm.py
@@ -136,13 +136,11 @@ class TestLiteLLM:
     @patch("llmeter.endpoints.litellm.completion")
     def test_invoke_success(self, mock_completion):
         """Test successful invoke."""
-        # Mock the response
         mock_response = MagicMock()
         mock_response.id = "test-id"
         mock_response.choices = [MagicMock()]
         mock_response.choices[0].message.content = "Hello there!"
 
-        # Create usage mock separately and assign it
         usage_mock = MagicMock()
         usage_mock.prompt_tokens = 10
         usage_mock.completion_tokens = 5
@@ -150,20 +148,19 @@ class TestLiteLLM:
 
         mock_completion.return_value = mock_response
 
-        # Patch isinstance to make the type check pass
-        with patch("llmeter.endpoints.litellm.isinstance") as mock_isinstance:
-            mock_isinstance.return_value = True
+        payload = {"messages": [{"role": "user", "content": "Hello"}]}
+        result = self.endpoint.invoke(payload)
 
-            payload = {"messages": [{"role": "user", "content": "Hello"}]}
-            result = self.endpoint.invoke(payload)
-
-            assert isinstance(result, InvocationResponse)
-            assert result.id == "test-id"
-            assert result.response_text == "Hello there!"
-            assert result.num_tokens_input == 10
-            assert result.num_tokens_output == 5
-            assert result.input_prompt == '[{"role": "user", "content": "Hello"}]'
-            mock_completion.assert_called_once_with(model="gpt-3.5-turbo", **payload)
+        assert isinstance(result, InvocationResponse)
+        assert result.id == "test-id"
+        assert result.response_text == "Hello there!"
+        assert result.num_tokens_input == 10
+        assert result.num_tokens_output == 5
+        assert result.input_prompt == '[{"role": "user", "content": "Hello"}]'
+        mock_completion.assert_called_once()
+        call_kwargs = mock_completion.call_args[1]
+        assert call_kwargs["model"] == "gpt-3.5-turbo"
+        assert call_kwargs["messages"] == [{"role": "user", "content": "Hello"}]
 
     @patch("llmeter.endpoints.litellm.completion")
     def test_invoke_success_no_usage(self, mock_completion):
@@ -176,22 +173,18 @@ class TestLiteLLM:
         del mock_response.usage
         mock_completion.return_value = mock_response
 
-        # Patch isinstance to make the type check pass
-        with patch("llmeter.endpoints.litellm.isinstance") as mock_isinstance:
-            mock_isinstance.return_value = True
+        payload = {"messages": [{"role": "user", "content": "Hello"}]}
+        result = self.endpoint.invoke(payload)
 
-            payload = {"messages": [{"role": "user", "content": "Hello"}]}
-            result = self.endpoint.invoke(payload)
-
-            assert isinstance(result, InvocationResponse)
-            assert result.id == "test-id"
-            assert result.response_text == "Hello there!"
-            assert result.num_tokens_input is None
-            assert result.num_tokens_output is None
+        assert isinstance(result, InvocationResponse)
+        assert result.id == "test-id"
+        assert result.response_text == "Hello there!"
+        assert result.num_tokens_input is None
+        assert result.num_tokens_output is None
 
     @patch("llmeter.endpoints.litellm.completion")
-    def test_invoke_with_kwargs(self, mock_completion):
-        """Test invoke with additional kwargs."""
+    def test_invoke_with_kwargs_in_payload(self, mock_completion):
+        """Test invoke with additional kwargs passed via payload."""
         mock_response = MagicMock()
         mock_response.id = "test-id"
         mock_response.choices = [MagicMock()]
@@ -205,16 +198,18 @@ class TestLiteLLM:
 
         mock_completion.return_value = mock_response
 
-        # Patch isinstance to make the type check pass
-        with patch("llmeter.endpoints.litellm.isinstance") as mock_isinstance:
-            mock_isinstance.return_value = True
+        payload = {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "temperature": 0.7,
+            "top_p": 0.9,
+        }
+        self.endpoint.invoke(payload)
 
-            payload = {"messages": [{"role": "user", "content": "Hello"}]}
-            self.endpoint.invoke(payload, temperature=0.7, top_p=0.9)
-
-            mock_completion.assert_called_once_with(
-                model="gpt-3.5-turbo", temperature=0.7, top_p=0.9, **payload
-            )
+        mock_completion.assert_called_once()
+        call_kwargs = mock_completion.call_args[1]
+        assert call_kwargs["model"] == "gpt-3.5-turbo"
+        assert call_kwargs["temperature"] == 0.7
+        assert call_kwargs["top_p"] == 0.9
 
     @patch("llmeter.endpoints.litellm.completion")
     def test_invoke_exception(self, mock_completion):
@@ -229,20 +224,20 @@ class TestLiteLLM:
         assert result.input_prompt == '[{"role": "user", "content": "Hello"}]'
         assert result.id is not None and len(result.id) == 32  # UUID hex length
 
-    def test_parse_converse_response(self):
-        """Test _parse_converse_response method."""
+    def test_process_raw_response(self):
+        """Test process_raw_response method."""
         mock_response = MagicMock()
         mock_response.id = "response-id"
         mock_response.choices = [MagicMock()]
         mock_response.choices[0].message.content = "Test response"
 
-        # Create usage mock separately and assign it
         usage_mock = MagicMock()
         usage_mock.prompt_tokens = 15
         usage_mock.completion_tokens = 8
         mock_response.usage = usage_mock
 
-        result = self.endpoint.parse_response(mock_response, 0.0)
+        result = InvocationResponse(id=None, response_text=None)
+        self.endpoint.process_raw_response(mock_response, 0.0, result)
 
         assert isinstance(result, InvocationResponse)
         assert result.id == "response-id"
@@ -250,16 +245,16 @@ class TestLiteLLM:
         assert result.num_tokens_input == 15
         assert result.num_tokens_output == 8
 
-    def test_parse_converse_response_no_usage(self):
-        """Test _parse_converse_response without usage info."""
+    def test_process_raw_response_no_usage(self):
+        """Test process_raw_response without usage info."""
         mock_response = MagicMock()
         mock_response.id = "response-id"
         mock_response.choices = [MagicMock()]
         mock_response.choices[0].message.content = "Test response"
-        # Remove usage attribute to simulate AttributeError
         del mock_response.usage
 
-        result = self.endpoint.parse_response(mock_response, 0.0)
+        result = InvocationResponse(id=None, response_text=None)
+        self.endpoint.process_raw_response(mock_response, 0.0, result)
 
         assert isinstance(result, InvocationResponse)
         assert result.id == "response-id"
@@ -281,10 +276,9 @@ class TestLiteLLMStreaming:
     @patch("time.perf_counter")
     def test_invoke_success(self, mock_time, mock_completion):
         """Test successful streaming invoke."""
-        # Mock time progression: start, first token, final time
-        mock_time.side_effect = [0.0, 0.1, 0.2]  # start, first token, end
+        # perf_counter calls: wrapper start, chunk1, chunk2, chunk3, wrapper end
+        mock_time.side_effect = [0.0, 0.1, 0.15, 0.2, 0.25]
 
-        # Mock streaming response with proper CustomStreamWrapper type
         from litellm import CustomStreamWrapper
 
         mock_stream = MagicMock(spec=CustomStreamWrapper)
@@ -390,12 +384,11 @@ class TestLiteLLMStreaming:
         assert result.input_prompt == '[{"role": "user", "content": "Hello"}]'
 
     @patch("time.perf_counter")
-    def test_parse_stream(self, mock_time):
-        """Test _parse_stream method."""
-        mock_time.side_effect = [0.15, 0.4]  # first token time, last token time
+    def test_process_raw_response(self, mock_time):
+        """Test process_raw_response method."""
+        mock_time.side_effect = [0.15, 0.4]
         start_t = 0.0
 
-        # Create mock chunks
         chunk1 = MagicMock()
         chunk1.id = "test-id"
         chunk1.choices = [MagicMock()]
@@ -412,7 +405,8 @@ class TestLiteLLMStreaming:
         mock_stream = MagicMock()
         mock_stream.__iter__ = lambda self: iter([chunk1, chunk2])
 
-        result = self.endpoint.parse_response(mock_stream, start_t)  # type: ignore
+        result = InvocationResponse(id=None, response_text=None)
+        self.endpoint.process_raw_response(mock_stream, start_t, result)
 
         assert isinstance(result, InvocationResponse)
         assert result.id == "test-id"
@@ -421,41 +415,40 @@ class TestLiteLLMStreaming:
         assert result.num_tokens_output == 3
         assert result.time_to_first_token == 0.15
         assert result.time_to_last_token == 0.4
-        # time_per_output_token is computed by the runner, not the endpoint
         assert result.time_per_output_token is None
 
     @patch("time.perf_counter")
-    def test_parse_stream_no_usage(self, mock_time):
-        """Test _parse_stream with no usage information."""
-        mock_time.side_effect = [0.0, 0.1, 0.2]
+    def test_process_raw_response_no_usage(self, mock_time):
+        """Test process_raw_response with no usage information."""
+        mock_time.side_effect = [0.1]
         start_t = 0.0
 
         chunk = MagicMock()
         chunk.id = "test-id"
         chunk.choices = [MagicMock()]
         chunk.choices[0].delta.content = "Content"
-        # Remove usage attribute to simulate AttributeError
         del chunk.usage
 
         mock_stream = MagicMock()
         mock_stream.__iter__ = lambda self: iter([chunk])
 
-        result = self.endpoint.parse_response(mock_stream, start_t)  # type: ignore
+        result = InvocationResponse(id=None, response_text=None)
+        self.endpoint.process_raw_response(mock_stream, start_t, result)
 
         assert result.num_tokens_input is None
         assert result.num_tokens_output is None
         assert result.time_per_output_token is None
 
     @patch("time.perf_counter")
-    def test_parse_stream_empty_content(self, mock_time):
-        """Test _parse_stream with None content in chunks."""
-        mock_time.side_effect = [0.0, 0.1, 0.2]
+    def test_process_raw_response_empty_content(self, mock_time):
+        """Test process_raw_response with None content in chunks."""
+        mock_time.side_effect = [0.1, 0.2]
         start_t = 0.0
 
         chunk1 = MagicMock()
         chunk1.id = "test-id"
         chunk1.choices = [MagicMock()]
-        chunk1.choices[0].delta.content = None  # Empty content
+        chunk1.choices[0].delta.content = None
         chunk1.usage = None
 
         chunk2 = MagicMock()
@@ -468,14 +461,15 @@ class TestLiteLLMStreaming:
         mock_stream = MagicMock()
         mock_stream.__iter__ = lambda self: iter([chunk1, chunk2])
 
-        result = self.endpoint.parse_response(mock_stream, start_t)  # type: ignore
+        result = InvocationResponse(id=None, response_text=None)
+        self.endpoint.process_raw_response(mock_stream, start_t, result)
 
         assert result.response_text == "Real content"
 
     @patch("time.perf_counter")
-    def test_parse_stream_single_token_output(self, mock_time):
-        """Test _parse_stream with single token output (edge case for time_per_output_token)."""
-        mock_time.side_effect = [0.0, 0.1, 0.2]
+    def test_process_raw_response_single_token_output(self, mock_time):
+        """Test process_raw_response with single token output (edge case for time_per_output_token)."""
+        mock_time.side_effect = [0.1]
         start_t = 0.0
 
         chunk = MagicMock()
@@ -484,12 +478,13 @@ class TestLiteLLMStreaming:
         chunk.choices[0].delta.content = "Hi"
         chunk.usage = MagicMock()
         chunk.usage.prompt_tokens = 5
-        chunk.usage.completion_tokens = 1  # Single token
+        chunk.usage.completion_tokens = 1
 
         mock_stream = MagicMock()
         mock_stream.__iter__ = lambda self: iter([chunk])
 
-        result = self.endpoint.parse_response(mock_stream, start_t)  # type: ignore
+        result = InvocationResponse(id=None, response_text=None)
+        self.endpoint.process_raw_response(mock_stream, start_t, result)
 
         # With 1 token, (num_tokens_output - 1) = 0, so time_per_output_token should be None
         assert result.time_per_output_token is None

--- a/tests/unit/endpoints/test_llmeter_invoke.py
+++ b/tests/unit/endpoints/test_llmeter_invoke.py
@@ -1,0 +1,321 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the @llmeter_invoke decorator.
+
+Validates the decorator's contract around payload handling, timing,
+error handling, metadata back-fill, and invocation isolation.
+"""
+
+from datetime import datetime, timezone
+
+
+from llmeter.endpoints.base import Endpoint, InvocationResponse, llmeter_invoke
+
+
+# ---------------------------------------------------------------------------
+# Minimal concrete endpoint for testing the decorator in isolation
+# ---------------------------------------------------------------------------
+
+
+class StubEndpoint(Endpoint):
+    """Endpoint whose invoke body and side-effects are fully controllable."""
+
+    def __init__(self, invoke_fn=None, parse_payload_fn=None):
+        super().__init__(
+            endpoint_name="stub",
+            model_id="stub-model",
+            provider="stub",
+        )
+        self._invoke_fn = invoke_fn
+        self._parse_payload_fn = parse_payload_fn
+
+    @llmeter_invoke
+    def invoke(self, payload: dict) -> InvocationResponse:
+        if self._invoke_fn:
+            return self._invoke_fn(self, payload)
+        return InvocationResponse(response_text="ok")
+
+    def parse_response(self, raw_response, start_t):
+        return InvocationResponse(response_text=str(raw_response))
+
+    def _parse_payload(self, payload):
+        if self._parse_payload_fn:
+            return self._parse_payload_fn(payload)
+        return super()._parse_payload(payload)
+
+
+class StubWithPrepare(StubEndpoint):
+    """Endpoint that injects a model field in prepare_payload."""
+
+    def prepare_payload(self, payload, **kwargs):
+        return {**kwargs, **payload, "model": self.model_id}
+
+
+# ---------------------------------------------------------------------------
+# Payload mutation tests
+# ---------------------------------------------------------------------------
+
+
+class TestPayloadMutation:
+    def test_input_payload_reflects_mutations_by_api_client(self):
+        """input_payload on the response should contain the dict as mutated
+        by the API client, since that's what was actually sent."""
+
+        def mutating_invoke(self, payload):
+            # Simulate what boto3 does: pop keys, add metadata
+            payload.pop("extra_field", None)
+            payload["_injected_by_client"] = True
+            return InvocationResponse(response_text="ok")
+
+        endpoint = StubWithPrepare(invoke_fn=mutating_invoke)
+        response = endpoint.invoke({"prompt": "hello", "extra_field": "will be popped"})
+
+        assert response.error is None
+        # The mutated payload is what gets saved
+        assert "_injected_by_client" in response.input_payload
+        assert "extra_field" not in response.input_payload
+
+    def test_input_prompt_uses_pre_mutation_snapshot(self):
+        """_parse_payload should receive the payload as it was *before* the
+        API client mutated it, so prompt extraction is reliable."""
+
+        parse_payload_received = {}
+
+        def capture_parse_payload(payload):
+            parse_payload_received.update(payload)
+            return payload.get("prompt", "")
+
+        def mutating_invoke(self, payload):
+            # Wipe the prompt field — simulates a destructive client
+            payload.pop("prompt", None)
+            return InvocationResponse(response_text="ok")
+
+        endpoint = StubWithPrepare(
+            invoke_fn=mutating_invoke,
+            parse_payload_fn=capture_parse_payload,
+        )
+        response = endpoint.invoke({"prompt": "hello"})
+
+        assert response.error is None
+        # _parse_payload saw the original prompt
+        assert parse_payload_received["prompt"] == "hello"
+        assert response.input_prompt == "hello"
+        # But input_payload has it removed (mutated)
+        assert "prompt" not in response.input_payload
+
+    def test_original_caller_payload_is_not_mutated(self):
+        """The caller's original dict must not be modified by prepare_payload
+        or the API client."""
+
+        def mutating_invoke(self, payload):
+            payload["injected"] = True
+            return InvocationResponse(response_text="ok")
+
+        endpoint = StubWithPrepare(invoke_fn=mutating_invoke)
+        original = {"prompt": "hello"}
+        original_copy = original.copy()
+
+        endpoint.invoke(original)
+
+        # Caller's dict is unchanged (prepare_payload creates a new dict)
+        assert original == original_copy
+
+
+# ---------------------------------------------------------------------------
+# Invocation isolation tests
+# ---------------------------------------------------------------------------
+
+
+class TestInvocationIsolation:
+    def test_no_start_t_on_self(self):
+        """The decorator must not store _start_t on the endpoint instance."""
+        endpoint = StubEndpoint()
+        endpoint.invoke({"prompt": "hello"})
+
+        assert not hasattr(endpoint, "_start_t")
+
+    def test_no_last_payload_on_self(self):
+        """The decorator must not store _last_payload on the endpoint instance."""
+        endpoint = StubEndpoint()
+        endpoint.invoke({"prompt": "hello"})
+
+        assert not hasattr(endpoint, "_last_payload")
+
+    def test_consecutive_invocations_are_independent(self):
+        """Each invocation should produce its own response with independent
+        metadata — no state leaks between calls."""
+        call_count = 0
+
+        def counting_invoke(self, payload):
+            nonlocal call_count
+            call_count += 1
+            return InvocationResponse(
+                response_text=f"response-{call_count}",
+                id=f"id-{call_count}",
+            )
+
+        endpoint = StubWithPrepare(invoke_fn=counting_invoke)
+
+        r1 = endpoint.invoke({"prompt": "first"})
+        r2 = endpoint.invoke({"prompt": "second"})
+
+        assert r1.response_text == "response-1"
+        assert r2.response_text == "response-2"
+        assert r1.id == "id-1"
+        assert r2.id == "id-2"
+        assert r1.input_payload["prompt"] == "first"
+        assert r2.input_payload["prompt"] == "second"
+        # Each has its own request_time
+        assert r1.request_time != r2.request_time or r1.request_time is not r2.request_time
+
+
+# ---------------------------------------------------------------------------
+# Timing tests
+# ---------------------------------------------------------------------------
+
+
+class TestTiming:
+    def test_time_to_last_token_backfilled_for_non_streaming(self):
+        """For non-streaming endpoints that don't set time_to_last_token,
+        the decorator should back-fill it."""
+        endpoint = StubEndpoint()
+        response = endpoint.invoke({"prompt": "hello"})
+
+        assert response.error is None
+        assert response.time_to_last_token is not None
+        assert response.time_to_last_token > 0
+
+    def test_time_to_last_token_not_overwritten_if_set(self):
+        """If the inner invoke sets time_to_last_token (streaming), the
+        decorator should not overwrite it."""
+
+        def streaming_invoke(self, payload):
+            return InvocationResponse(
+                response_text="streamed",
+                time_to_first_token=0.1,
+                time_to_last_token=0.5,
+            )
+
+        endpoint = StubEndpoint(invoke_fn=streaming_invoke)
+        response = endpoint.invoke({"prompt": "hello"})
+
+        assert response.time_to_last_token == 0.5
+        assert response.time_to_first_token == 0.1
+
+    def test_time_to_last_token_not_set_on_error(self):
+        """On error responses, time_to_last_token should remain None."""
+
+        def failing_invoke(self, payload):
+            raise RuntimeError("boom")
+
+        endpoint = StubEndpoint(invoke_fn=failing_invoke)
+        response = endpoint.invoke({"prompt": "hello"})
+
+        assert response.error is not None
+        assert response.time_to_last_token is None
+
+
+# ---------------------------------------------------------------------------
+# Error handling tests
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    def test_exception_converted_to_error_response(self):
+        """Exceptions in invoke should be caught and converted to an error
+        InvocationResponse."""
+
+        def failing_invoke(self, payload):
+            raise ValueError("bad input")
+
+        endpoint = StubEndpoint(invoke_fn=failing_invoke)
+        response = endpoint.invoke({"prompt": "hello"})
+
+        assert response.error is not None
+        assert "bad input" in response.error
+        assert response.response_text is None
+        assert response.input_payload is not None
+        assert response.id is not None
+        assert response.request_time is not None
+
+    def test_parse_payload_failure_does_not_crash(self):
+        """If _parse_payload raises, input_prompt should be None but the
+        response should still be valid."""
+
+        def broken_parse(payload):
+            raise KeyError("missing field")
+
+        endpoint = StubEndpoint(parse_payload_fn=broken_parse)
+        response = endpoint.invoke({"prompt": "hello"})
+
+        assert response.error is None
+        assert response.input_prompt is None
+        assert response.response_text == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Metadata back-fill tests
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataBackfill:
+    def test_id_backfilled_when_not_set(self):
+        endpoint = StubEndpoint()
+        response = endpoint.invoke({"prompt": "hello"})
+
+        assert response.id is not None
+        assert len(response.id) > 0
+
+    def test_id_not_overwritten_when_set(self):
+        def invoke_with_id(self, payload):
+            return InvocationResponse(response_text="ok", id="my-custom-id")
+
+        endpoint = StubEndpoint(invoke_fn=invoke_with_id)
+        response = endpoint.invoke({"prompt": "hello"})
+
+        assert response.id == "my-custom-id"
+
+    def test_request_time_is_utc_datetime(self):
+        endpoint = StubEndpoint()
+        response = endpoint.invoke({"prompt": "hello"})
+
+        assert isinstance(response.request_time, datetime)
+        assert response.request_time.tzinfo == timezone.utc
+
+    def test_input_payload_backfilled(self):
+        endpoint = StubWithPrepare()
+        response = endpoint.invoke({"prompt": "hello"})
+
+        assert response.input_payload is not None
+        assert response.input_payload["model"] == "stub-model"
+        assert response.input_payload["prompt"] == "hello"
+
+    def test_input_payload_not_overwritten_when_set(self):
+        custom_payload = {"custom": True}
+
+        def invoke_with_payload(self, payload):
+            return InvocationResponse(
+                response_text="ok", input_payload=custom_payload
+            )
+
+        endpoint = StubEndpoint(invoke_fn=invoke_with_payload)
+        response = endpoint.invoke({"prompt": "hello"})
+
+        assert response.input_payload is custom_payload
+
+
+# ---------------------------------------------------------------------------
+# Decorator marker test
+# ---------------------------------------------------------------------------
+
+
+class TestDecoratorMarker:
+    def test_decorated_function_has_marker(self):
+        assert getattr(StubEndpoint.invoke, "_is_llmeter_invoke", False) is True
+
+    def test_undecorated_function_has_no_marker(self):
+        def plain_invoke(self, payload):
+            pass
+
+        assert not hasattr(plain_invoke, "_is_llmeter_invoke")

--- a/tests/unit/endpoints/test_llmeter_invoke.py
+++ b/tests/unit/endpoints/test_llmeter_invoke.py
@@ -9,9 +9,7 @@ error handling, metadata back-fill, and invocation isolation.
 
 from datetime import datetime, timezone
 
-
 from llmeter.endpoints.base import Endpoint, InvocationResponse, llmeter_invoke
-
 
 # ---------------------------------------------------------------------------
 # Minimal concrete endpoint for testing the decorator in isolation
@@ -21,7 +19,7 @@ from llmeter.endpoints.base import Endpoint, InvocationResponse, llmeter_invoke
 class StubEndpoint(Endpoint):
     """Endpoint whose invoke body and side-effects are fully controllable."""
 
-    def __init__(self, invoke_fn=None, parse_payload_fn=None):
+    def __init__(self, invoke_fn=None, parse_payload_fn=None, parse_response_fn=None):
         super().__init__(
             endpoint_name="stub",
             model_id="stub-model",
@@ -29,14 +27,27 @@ class StubEndpoint(Endpoint):
         )
         self._invoke_fn = invoke_fn
         self._parse_payload_fn = parse_payload_fn
+        self._parse_response_fn = parse_response_fn
 
     @llmeter_invoke
-    def invoke(self, payload: dict) -> InvocationResponse:
+    def invoke(self, payload: dict):
         if self._invoke_fn:
             return self._invoke_fn(self, payload)
-        return InvocationResponse(response_text="ok")
+        return {"text": "ok"}
 
     def parse_response(self, raw_response, start_t):
+        if self._parse_response_fn:
+            return self._parse_response_fn(raw_response, start_t)
+        if isinstance(raw_response, InvocationResponse):
+            return raw_response
+        if isinstance(raw_response, dict):
+            return InvocationResponse(
+                response_text=raw_response.get("text", str(raw_response)),
+                id=raw_response.get("id"),
+                time_to_first_token=raw_response.get("time_to_first_token"),
+                time_to_last_token=raw_response.get("time_to_last_token"),
+                input_payload=raw_response.get("input_payload"),
+            )
         return InvocationResponse(response_text=str(raw_response))
 
     def _parse_payload(self, payload):
@@ -66,7 +77,7 @@ class TestPayloadMutation:
             # Simulate what boto3 does: pop keys, add metadata
             payload.pop("extra_field", None)
             payload["_injected_by_client"] = True
-            return InvocationResponse(response_text="ok")
+            return {"text": "ok"}
 
         endpoint = StubWithPrepare(invoke_fn=mutating_invoke)
         response = endpoint.invoke({"prompt": "hello", "extra_field": "will be popped"})
@@ -89,7 +100,7 @@ class TestPayloadMutation:
         def mutating_invoke(self, payload):
             # Wipe the prompt field — simulates a destructive client
             payload.pop("prompt", None)
-            return InvocationResponse(response_text="ok")
+            return {"text": "ok"}
 
         endpoint = StubWithPrepare(
             invoke_fn=mutating_invoke,
@@ -110,7 +121,7 @@ class TestPayloadMutation:
 
         def mutating_invoke(self, payload):
             payload["injected"] = True
-            return InvocationResponse(response_text="ok")
+            return {"text": "ok"}
 
         endpoint = StubWithPrepare(invoke_fn=mutating_invoke)
         original = {"prompt": "hello"}
@@ -150,10 +161,10 @@ class TestInvocationIsolation:
         def counting_invoke(self, payload):
             nonlocal call_count
             call_count += 1
-            return InvocationResponse(
-                response_text=f"response-{call_count}",
-                id=f"id-{call_count}",
-            )
+            return {
+                "text": f"response-{call_count}",
+                "id": f"id-{call_count}",
+            }
 
         endpoint = StubWithPrepare(invoke_fn=counting_invoke)
 
@@ -167,7 +178,9 @@ class TestInvocationIsolation:
         assert r1.input_payload["prompt"] == "first"
         assert r2.input_payload["prompt"] == "second"
         # Each has its own request_time
-        assert r1.request_time != r2.request_time or r1.request_time is not r2.request_time
+        assert (
+            r1.request_time != r2.request_time or r1.request_time is not r2.request_time
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -191,11 +204,11 @@ class TestTiming:
         decorator should not overwrite it."""
 
         def streaming_invoke(self, payload):
-            return InvocationResponse(
-                response_text="streamed",
-                time_to_first_token=0.1,
-                time_to_last_token=0.5,
-            )
+            return {
+                "text": "streamed",
+                "time_to_first_token": 0.1,
+                "time_to_last_token": 0.5,
+            }
 
         endpoint = StubEndpoint(invoke_fn=streaming_invoke)
         response = endpoint.invoke({"prompt": "hello"})
@@ -269,7 +282,7 @@ class TestMetadataBackfill:
 
     def test_id_not_overwritten_when_set(self):
         def invoke_with_id(self, payload):
-            return InvocationResponse(response_text="ok", id="my-custom-id")
+            return {"text": "ok", "id": "my-custom-id"}
 
         endpoint = StubEndpoint(invoke_fn=invoke_with_id)
         response = endpoint.invoke({"prompt": "hello"})
@@ -295,9 +308,7 @@ class TestMetadataBackfill:
         custom_payload = {"custom": True}
 
         def invoke_with_payload(self, payload):
-            return InvocationResponse(
-                response_text="ok", input_payload=custom_payload
-            )
+            return {"text": "ok", "input_payload": custom_payload}
 
         endpoint = StubEndpoint(invoke_fn=invoke_with_payload)
         response = endpoint.invoke({"prompt": "hello"})

--- a/tests/unit/endpoints/test_llmeter_invoke.py
+++ b/tests/unit/endpoints/test_llmeter_invoke.py
@@ -9,7 +9,7 @@ error handling, metadata back-fill, and invocation isolation.
 
 from datetime import datetime, timezone
 
-from llmeter.endpoints.base import Endpoint, InvocationResponse, llmeter_invoke
+from llmeter.endpoints.base import Endpoint, InvocationResponse
 
 # ---------------------------------------------------------------------------
 # Minimal concrete endpoint for testing the decorator in isolation
@@ -19,7 +19,7 @@ from llmeter.endpoints.base import Endpoint, InvocationResponse, llmeter_invoke
 class StubEndpoint(Endpoint):
     """Endpoint whose invoke body and side-effects are fully controllable."""
 
-    def __init__(self, invoke_fn=None, parse_payload_fn=None, parse_response_fn=None):
+    def __init__(self, invoke_fn=None, parse_payload_fn=None, process_response_fn=None):
         super().__init__(
             endpoint_name="stub",
             model_id="stub-model",
@@ -27,28 +27,28 @@ class StubEndpoint(Endpoint):
         )
         self._invoke_fn = invoke_fn
         self._parse_payload_fn = parse_payload_fn
-        self._parse_response_fn = parse_response_fn
+        self._process_response_fn = process_response_fn
 
-    @llmeter_invoke
+    @Endpoint.llmeter_invoke
     def invoke(self, payload: dict):
         if self._invoke_fn:
             return self._invoke_fn(self, payload)
         return {"text": "ok"}
 
-    def parse_response(self, raw_response, start_t):
-        if self._parse_response_fn:
-            return self._parse_response_fn(raw_response, start_t)
-        if isinstance(raw_response, InvocationResponse):
-            return raw_response
+    def process_raw_response(self, raw_response, start_t, response):
+        if self._process_response_fn:
+            self._process_response_fn(raw_response, start_t, response)
+            return
         if isinstance(raw_response, dict):
-            return InvocationResponse(
-                response_text=raw_response.get("text", str(raw_response)),
-                id=raw_response.get("id"),
-                time_to_first_token=raw_response.get("time_to_first_token"),
-                time_to_last_token=raw_response.get("time_to_last_token"),
-                input_payload=raw_response.get("input_payload"),
-            )
-        return InvocationResponse(response_text=str(raw_response))
+            response.response_text = raw_response.get("text", str(raw_response))
+            if "id" in raw_response:
+                response.id = raw_response["id"]
+            if "time_to_first_token" in raw_response:
+                response.time_to_first_token = raw_response["time_to_first_token"]
+            if "time_to_last_token" in raw_response:
+                response.time_to_last_token = raw_response["time_to_last_token"]
+            if "input_payload" in raw_response:
+                response.input_payload = raw_response["input_payload"]
 
     def _parse_payload(self, payload):
         if self._parse_payload_fn:

--- a/tests/unit/endpoints/test_multimodal_properties.py
+++ b/tests/unit/endpoints/test_multimodal_properties.py
@@ -17,11 +17,11 @@ from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
 from llmeter.endpoints.bedrock import BedrockBase
-from llmeter.json_utils import llmeter_default_serializer, llmeter_bytes_decoder
+from llmeter.json_utils import llmeter_bytes_decoder, llmeter_default_serializer
 from llmeter.prompt_utils import (
-    ImageContent,
-    DocumentContent,
     AudioContent,
+    DocumentContent,
+    ImageContent,
     VideoContent,
     load_payloads,
     save_payloads,

--- a/tests/unit/endpoints/test_multimodal_serialization.py
+++ b/tests/unit/endpoints/test_multimodal_serialization.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from llmeter.endpoints.bedrock import BedrockBase
 from llmeter.endpoints.openai import OpenAIEndpoint
-from llmeter.endpoints.sagemaker import SageMakerBase
+from llmeter.endpoints.sagemaker import SageMakerEndpoint
 from llmeter.prompt_utils import (
     DocumentContent,
     ImageContent,
@@ -244,7 +244,7 @@ class TestMultiModalSerialization:
             temp_path = f.name
 
         try:
-            payload = SageMakerBase.create_payload(
+            payload = SageMakerEndpoint.create_payload(
                 [ImageContent.from_path(temp_path), "Test"], max_tokens=256
             )
 

--- a/tests/unit/endpoints/test_multimodal_serialization.py
+++ b/tests/unit/endpoints/test_multimodal_serialization.py
@@ -4,12 +4,16 @@
 import tempfile
 from pathlib import Path
 
-
 from llmeter.endpoints.bedrock import BedrockBase
 from llmeter.endpoints.openai import OpenAIEndpoint
 from llmeter.endpoints.sagemaker import SageMakerBase
-from llmeter.prompt_utils import ImageContent, DocumentContent
-from llmeter.prompt_utils import save_payloads, load_payloads, load_prompts
+from llmeter.prompt_utils import (
+    DocumentContent,
+    ImageContent,
+    load_payloads,
+    load_prompts,
+    save_payloads,
+)
 
 
 class TestMultiModalSerialization:

--- a/tests/unit/endpoints/test_multimodal_utilities.py
+++ b/tests/unit/endpoints/test_multimodal_utilities.py
@@ -8,10 +8,10 @@ from unittest.mock import patch
 import pytest
 
 from llmeter.prompt_utils import (
-    read_file,
-    detect_format_from_extension,
     detect_format_from_bytes,
+    detect_format_from_extension,
     detect_format_from_file,
+    read_file,
 )
 
 

--- a/tests/unit/endpoints/test_openai.py
+++ b/tests/unit/endpoints/test_openai.py
@@ -222,25 +222,6 @@ class TestOpenAICompletionEndpoint:
             assert response.error is None
             assert response.input_payload["model"] == "gpt-3.5-turbo"
 
-    def test_invoke_with_kwargs(self, endpoint, mock_chat_completion):
-        """Test invoke with additional kwargs."""
-        with patch.object(endpoint._client.chat.completions, "create") as mock_create:
-            mock_create.return_value = mock_chat_completion
-
-            payload = {"messages": [{"role": "user", "content": "Hello"}]}
-
-            endpoint.invoke(payload, temperature=0.7, top_p=0.9)
-
-            # Verify the call was made with the correct parameters
-            mock_create.assert_called_once()
-            call_args = mock_create.call_args
-            if call_args and call_args[1]:
-                kwargs = call_args[1]
-                assert kwargs["model"] == "gpt-3.5-turbo"
-                assert kwargs["temperature"] == 0.7
-                assert kwargs["top_p"] == 0.9
-                assert kwargs["messages"] == [{"role": "user", "content": "Hello"}]
-
     def test_invoke_api_connection_error(self, endpoint):
         """Test invoke with APIConnectionError."""
         with patch.object(endpoint._client.chat.completions, "create") as mock_create:
@@ -268,15 +249,12 @@ class TestOpenAICompletionEndpoint:
             assert response.error == "Unexpected error"
             assert response.response_text is None
 
-    def test_parse_converse_response(self, endpoint, mock_chat_completion):
-        """Test parse_response method.
-
-        Note: time_to_last_token is back-filled by the base invoke wrapper,
-        not by parse_response itself for non-streaming endpoints.
-        """
+    def test_process_raw_response(self, endpoint, mock_chat_completion):
+        """Test process_raw_response method."""
         start_time = time.perf_counter()
+        response = InvocationResponse(id=None, response_text=None)
 
-        response = endpoint.parse_response(mock_chat_completion, start_time)
+        endpoint.process_raw_response(mock_chat_completion, start_time, response)
 
         assert isinstance(response, InvocationResponse)
         assert response.id == "chatcmpl-test123"
@@ -284,8 +262,8 @@ class TestOpenAICompletionEndpoint:
         assert response.num_tokens_input == 10
         assert response.num_tokens_output == 8
 
-    def test_parse_converse_response_no_usage(self, endpoint):
-        """Test _parse_converse_response with no usage information."""
+    def test_process_raw_response_no_usage(self, endpoint):
+        """Test process_raw_response with no usage information."""
         completion = ChatCompletion(
             id="chatcmpl-test123",
             choices=[
@@ -302,7 +280,8 @@ class TestOpenAICompletionEndpoint:
         )
 
         start_time = time.perf_counter()
-        response = endpoint.parse_response(completion, start_time)
+        response = InvocationResponse(id=None, response_text=None)
+        endpoint.process_raw_response(completion, start_time, response)
 
         assert response.num_tokens_input is None
         assert response.num_tokens_output is None
@@ -446,13 +425,13 @@ class TestOpenAICompletionStreamEndpoint:
             assert response.error == "Unexpected error"
             assert response.response_text is None
 
-    def test_parse_converse_stream_response(self, endpoint, mock_stream_response):
-        """Test _parse_converse_stream_response method."""
+    def test_process_raw_response(self, endpoint, mock_stream_response):
+        """Test process_raw_response method."""
         start_time = time.perf_counter()
+        response = InvocationResponse(id=None, response_text=None)
 
-        response = endpoint.parse_response(iter(mock_stream_response), start_time)
+        endpoint.process_raw_response(iter(mock_stream_response), start_time, response)
 
-        assert isinstance(response, InvocationResponse)
         assert response.id == "chatcmpl-test123"
         assert response.response_text == "Hello there!"
         assert response.num_tokens_input == 10
@@ -460,18 +439,19 @@ class TestOpenAICompletionStreamEndpoint:
         assert response.time_to_first_token is not None
         assert response.time_to_last_token is not None
 
-    def test_parse_converse_stream_response_empty_stream(self, endpoint):
-        """Test _parse_converse_stream_response with empty stream."""
+    def test_process_raw_response_empty_stream(self, endpoint):
+        """Test process_raw_response with empty stream."""
         start_time = time.perf_counter()
+        response = InvocationResponse(id=None, response_text=None)
 
-        response = endpoint.parse_response(iter([]), start_time)
+        endpoint.process_raw_response(iter([]), start_time, response)
 
-        assert response.response_text == ""
+        assert response.response_text is None
         assert response.num_tokens_input is None
         assert response.num_tokens_output is None
 
-    def test_parse_converse_stream_response_no_usage(self, endpoint):
-        """Test _parse_converse_stream_response without usage information."""
+    def test_process_raw_response_no_usage(self, endpoint):
+        """Test process_raw_response without usage information."""
         chunk1 = MagicMock()
         chunk1.id = "chatcmpl-test123"
         chunk1.choices = [MagicMock()]
@@ -485,14 +465,16 @@ class TestOpenAICompletionStreamEndpoint:
         chunk2.usage = None
 
         start_time = time.perf_counter()
-        response = endpoint.parse_response(iter([chunk1, chunk2]), start_time)
+        response = InvocationResponse(id=None, response_text=None)
+
+        endpoint.process_raw_response(iter([chunk1, chunk2]), start_time, response)
 
         assert response.response_text == "Hello"
         assert response.num_tokens_input is None
         assert response.num_tokens_output is None
 
-    def test_parse_converse_stream_response_none_content(self, endpoint):
-        """Test _parse_converse_stream_response with None content in first chunk."""
+    def test_process_raw_response_none_content(self, endpoint):
+        """Test process_raw_response with None content in first chunk."""
         chunk1 = MagicMock()
         chunk1.id = "chatcmpl-test123"
         chunk1.choices = [MagicMock()]
@@ -504,7 +486,9 @@ class TestOpenAICompletionStreamEndpoint:
         chunk2.choices[0].delta.content = "Hello"
 
         start_time = time.perf_counter()
-        response = endpoint.parse_response(iter([chunk1, chunk2]), start_time)
+        response = InvocationResponse(id=None, response_text=None)
+
+        endpoint.process_raw_response(iter([chunk1, chunk2]), start_time, response)
 
         assert response.response_text == "Hello"
 

--- a/tests/unit/endpoints/test_openai.py
+++ b/tests/unit/endpoints/test_openai.py
@@ -269,17 +269,20 @@ class TestOpenAICompletionEndpoint:
             assert response.response_text is None
 
     def test_parse_converse_response(self, endpoint, mock_chat_completion):
-        """Test _parse_converse_response method."""
+        """Test parse_response method.
+
+        Note: time_to_last_token is back-filled by the base invoke wrapper,
+        not by parse_response itself for non-streaming endpoints.
+        """
         start_time = time.perf_counter()
 
-        response = endpoint._parse_converse_response(mock_chat_completion, start_time)
+        response = endpoint.parse_response(mock_chat_completion, start_time)
 
         assert isinstance(response, InvocationResponse)
         assert response.id == "chatcmpl-test123"
         assert response.response_text == "Hello! How can I help you today?"
         assert response.num_tokens_input == 10
         assert response.num_tokens_output == 8
-        assert response.time_to_last_token is not None
 
     def test_parse_converse_response_no_usage(self, endpoint):
         """Test _parse_converse_response with no usage information."""
@@ -299,7 +302,7 @@ class TestOpenAICompletionEndpoint:
         )
 
         start_time = time.perf_counter()
-        response = endpoint._parse_converse_response(completion, start_time)
+        response = endpoint.parse_response(completion, start_time)
 
         assert response.num_tokens_input is None
         assert response.num_tokens_output is None
@@ -447,9 +450,7 @@ class TestOpenAICompletionStreamEndpoint:
         """Test _parse_converse_stream_response method."""
         start_time = time.perf_counter()
 
-        response = endpoint._parse_converse_stream_response(
-            iter(mock_stream_response), start_time
-        )
+        response = endpoint.parse_response(iter(mock_stream_response), start_time)
 
         assert isinstance(response, InvocationResponse)
         assert response.id == "chatcmpl-test123"
@@ -463,7 +464,7 @@ class TestOpenAICompletionStreamEndpoint:
         """Test _parse_converse_stream_response with empty stream."""
         start_time = time.perf_counter()
 
-        response = endpoint._parse_converse_stream_response(iter([]), start_time)
+        response = endpoint.parse_response(iter([]), start_time)
 
         assert response.response_text == ""
         assert response.num_tokens_input is None
@@ -484,9 +485,7 @@ class TestOpenAICompletionStreamEndpoint:
         chunk2.usage = None
 
         start_time = time.perf_counter()
-        response = endpoint._parse_converse_stream_response(
-            iter([chunk1, chunk2]), start_time
-        )
+        response = endpoint.parse_response(iter([chunk1, chunk2]), start_time)
 
         assert response.response_text == "Hello"
         assert response.num_tokens_input is None
@@ -505,9 +504,7 @@ class TestOpenAICompletionStreamEndpoint:
         chunk2.choices[0].delta.content = "Hello"
 
         start_time = time.perf_counter()
-        response = endpoint._parse_converse_stream_response(
-            iter([chunk1, chunk2]), start_time
-        )
+        response = endpoint.parse_response(iter([chunk1, chunk2]), start_time)
 
         assert response.response_text == "Hello"
 
@@ -664,9 +661,12 @@ class TestOpenAIEndpointEdgeCases:
 
             payload = {"messages": [{"role": "user", "content": "Hello"}]}
 
-            # This should raise AttributeError when trying to access choices
-            with pytest.raises(AttributeError):
-                endpoint.invoke(payload)
+            # Malformed chunks are caught by the base invoke wrapper and
+            # returned as an error InvocationResponse instead of propagating.
+            response = endpoint.invoke(payload)
+            assert isinstance(response, InvocationResponse)
+            assert response.error is not None
+            assert response.input_payload is not None
 
     def test_response_timing_accuracy(self):
         """Test that response timing measurements are accurate."""

--- a/tests/unit/endpoints/test_openai.py
+++ b/tests/unit/endpoints/test_openai.py
@@ -772,3 +772,59 @@ class TestOpenAIEndpointEdgeCases:
             assert response.response_text == "Hello world"
             assert response.num_tokens_input is None
             assert response.num_tokens_output is None
+
+
+class TestStreamMidStreamErrors:
+    """Verify that errors during stream consumption are caught by the invoke wrapper."""
+
+    def test_timeout_during_stream_consumption(self):
+        """A timeout while iterating chunks should be caught, not raised."""
+        endpoint = OpenAICompletionStreamEndpoint(
+            model_id="gpt-3.5-turbo", api_key="test_key"
+        )
+
+        def exploding_stream():
+            chunk = MagicMock()
+            chunk.id = "test-id"
+            chunk.choices = [MagicMock()]
+            chunk.choices[0].delta.content = "Hello"
+            chunk.usage = None
+            yield chunk
+            raise TimeoutError("Read timed out")
+
+        with patch.object(endpoint._client.chat.completions, "create") as mock_create:
+            mock_create.return_value = exploding_stream()
+            response = endpoint.invoke(
+                {"messages": [{"role": "user", "content": "Hi"}]}
+            )
+
+        assert isinstance(response, InvocationResponse)
+        assert response.error is not None
+        assert "timed out" in response.error.lower()
+        assert response.input_payload is not None
+
+    def test_connection_error_during_stream_consumption(self):
+        """A connection drop mid-stream should be caught, not raised."""
+        endpoint = OpenAICompletionStreamEndpoint(
+            model_id="gpt-3.5-turbo", api_key="test_key"
+        )
+
+        def dropping_stream():
+            chunk = MagicMock()
+            chunk.id = "test-id"
+            chunk.choices = [MagicMock()]
+            chunk.choices[0].delta.content = "Partial"
+            chunk.usage = None
+            yield chunk
+            raise ConnectionError("Connection reset")
+
+        with patch.object(endpoint._client.chat.completions, "create") as mock_create:
+            mock_create.return_value = dropping_stream()
+            response = endpoint.invoke(
+                {"messages": [{"role": "user", "content": "Hi"}]}
+            )
+
+        assert isinstance(response, InvocationResponse)
+        assert response.error is not None
+        assert "connection" in response.error.lower()
+        assert response.input_payload is not None

--- a/tests/unit/endpoints/test_openai_response.py
+++ b/tests/unit/endpoints/test_openai_response.py
@@ -453,7 +453,8 @@ class TestOpenAIResponseEndpointTimingMeasurements:
         mock_openai_class.return_value = mock_client
 
         # Mock time.perf_counter to return predictable values
-        mock_perf_counter.side_effect = [1.0, 1.5]  # start_t=1.0, end_t=1.5
+        # Call sequence: decorator start_t=1.0, inner invoke start_t=1.5, decorator back-fill=1.5
+        mock_perf_counter.side_effect = [1.0, 1.5, 1.5]
 
         mock_response = Mock()
         mock_response.id = "resp_timing_accuracy"

--- a/tests/unit/endpoints/test_openai_response_format.py
+++ b/tests/unit/endpoints/test_openai_response_format.py
@@ -10,7 +10,6 @@ correctly and that structured outputs are parsed properly.
 
 from unittest.mock import Mock, patch
 
-
 from llmeter.endpoints.openai_response import (
     OpenAIResponseEndpoint,
     OpenAIResponseStreamEndpoint,

--- a/tests/unit/endpoints/test_openai_response_model_params.py
+++ b/tests/unit/endpoints/test_openai_response_model_params.py
@@ -99,9 +99,10 @@ class TestModelSpecificParameters:
         payload = {
             "input": "Write a story",
             "max_tokens": 256,
+            "temperature": 0.8,
         }
 
-        response = endpoint.invoke(payload, temperature=0.8)
+        response = endpoint.invoke(payload)
 
         # Verify the API was called with temperature parameter
         call_args = mock_client.responses.create.call_args
@@ -140,9 +141,10 @@ class TestModelSpecificParameters:
         payload = {
             "input": "Generate text",
             "max_tokens": 256,
+            "top_p": 0.9,
         }
 
-        response = endpoint.invoke(payload, top_p=0.9)
+        response = endpoint.invoke(payload)
 
         # Verify the API was called with top_p parameter
         call_args = mock_client.responses.create.call_args
@@ -181,15 +183,13 @@ class TestModelSpecificParameters:
         payload = {
             "input": "Generate text",
             "max_tokens": 512,
+            "temperature": 0.7,
+            "top_p": 0.95,
+            "frequency_penalty": 0.5,
+            "presence_penalty": 0.3,
         }
 
-        response = endpoint.invoke(
-            payload,
-            temperature=0.7,
-            top_p=0.95,
-            frequency_penalty=0.5,
-            presence_penalty=0.3,
-        )
+        response = endpoint.invoke(payload)
 
         # Verify the API was called with all parameters
         call_args = mock_client.responses.create.call_args
@@ -229,29 +229,22 @@ class TestModelSpecificParameters:
         # Create endpoint
         endpoint = OpenAIResponseEndpoint(model_id="gpt-4")
 
-        # Create payload with some parameters
+        # Create payload with parameters
         payload = {
             "input": "Test message",
             "max_tokens": 256,
-            "temperature": 0.5,  # This should be overridden by kwargs
+            "temperature": 0.5,
+            "top_p": 0.8,
         }
 
-        # Invoke with additional parameters (temperature should override)
-        response = endpoint.invoke(
-            payload,
-            temperature=0.9,  # Override payload temperature
-            top_p=0.8,  # Add new parameter
-        )
+        response = endpoint.invoke(payload)
 
-        # Verify the API was called with merged parameters
+        # Verify the API was called with payload parameters
         call_args = mock_client.responses.create.call_args
         assert call_args is not None
         kwargs = call_args[1]
 
-        # kwargs should override payload values
-        assert (
-            kwargs["temperature"] == 0.5
-        )  # Payload value takes precedence (kwargs merged first, then payload)
+        assert kwargs["temperature"] == 0.5
         assert kwargs["top_p"] == 0.8
         assert kwargs["model"] == "gpt-4"
         assert kwargs["input"] == "Test message"
@@ -301,9 +294,10 @@ class TestModelSpecificParameters:
         payload = {
             "input": "Generate text",
             "max_tokens": 256,
+            "temperature": 0.8,
         }
 
-        response = endpoint.invoke(payload, temperature=0.8)
+        response = endpoint.invoke(payload)
 
         # Verify the API was called with temperature parameter
         call_args = mock_client.responses.create.call_args
@@ -359,14 +353,12 @@ class TestModelSpecificParameters:
         payload = {
             "input": "Generate text",
             "max_tokens": 512,
+            "temperature": 0.7,
+            "top_p": 0.95,
+            "frequency_penalty": 0.2,
         }
 
-        response = endpoint.invoke(
-            payload,
-            temperature=0.7,
-            top_p=0.95,
-            frequency_penalty=0.2,
-        )
+        response = endpoint.invoke(payload)
 
         # Verify the API was called with all parameters
         call_args = mock_client.responses.create.call_args

--- a/tests/unit/endpoints/test_openai_response_properties.py
+++ b/tests/unit/endpoints/test_openai_response_properties.py
@@ -478,18 +478,17 @@ def test_property_parameter_forwarding(
     endpoint = OpenAIResponseEndpoint(model_id="gpt-4-test")
     payload = {"input": "Test", "max_tokens": 256}
 
-    # Build kwargs with non-None parameters
-    kwargs = {}
+    # Add non-None parameters to payload
     if temperature is not None:
-        kwargs["temperature"] = temperature
+        payload["temperature"] = temperature
     if top_p is not None:
-        kwargs["top_p"] = top_p
+        payload["top_p"] = top_p
     if frequency_penalty is not None:
-        kwargs["frequency_penalty"] = frequency_penalty
+        payload["frequency_penalty"] = frequency_penalty
     if presence_penalty is not None:
-        kwargs["presence_penalty"] = presence_penalty
+        payload["presence_penalty"] = presence_penalty
 
-    endpoint.invoke(payload, **kwargs)
+    endpoint.invoke(payload)
 
     # Verify the call was made
     assert mock_client.responses.create.called

--- a/tests/unit/endpoints/test_openai_response_properties.py
+++ b/tests/unit/endpoints/test_openai_response_properties.py
@@ -13,7 +13,8 @@ Feature: openai-response-api
 
 from unittest.mock import Mock, patch
 
-from hypothesis import given, settings, strategies as st
+from hypothesis import given, settings
+from hypothesis import strategies as st
 
 from llmeter.endpoints.base import InvocationResponse
 from llmeter.endpoints.openai_response import (

--- a/tests/unit/endpoints/test_openai_response_serialization.py
+++ b/tests/unit/endpoints/test_openai_response_serialization.py
@@ -430,6 +430,7 @@ class TestInvocationResponseTypeConsistency:
         **Validates: Requirements 10.1**
         """
         from openai import APIConnectionError
+
         from llmeter.endpoints.base import InvocationResponse
 
         # Setup mock
@@ -458,6 +459,7 @@ class TestInvocationResponseTypeConsistency:
         **Validates: Requirements 10.1**
         """
         from openai import APIConnectionError
+
         from llmeter.endpoints.base import InvocationResponse
 
         # Setup mock

--- a/tests/unit/endpoints/test_property_bedrock.py
+++ b/tests/unit/endpoints/test_property_bedrock.py
@@ -1,0 +1,235 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Property-based tests for Bedrock endpoint process_raw_response logic.
+
+Covers changes from 09f080aa ("refactor(endpoint): process_raw_response")
+and the zero-token-count fix in 6dc11572 ("fix(bedrock): use `is not None`
+for streaming token count checks"):
+
+- Streaming metadata parsing: 0-valued token counts must not be dropped
+- Non-streaming response field extraction
+- Text concatenation from content block deltas
+- TTFT / TTLT ordering invariants
+"""
+
+import time
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from llmeter.endpoints.base import InvocationResponse
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+non_negative_ints = st.integers(min_value=0, max_value=100_000)
+optional_non_negative_ints = st.one_of(st.none(), non_negative_ints)
+
+_safe_text = st.text(
+    min_size=1,
+    max_size=50,
+    alphabet=st.characters(whitelist_categories=("L", "N", "P", "Z")),
+)
+
+
+@st.composite
+def bedrock_stream_usage(draw):
+    """Generate a Bedrock-style streaming usage dict.
+
+    Values can be 0 (e.g. cacheReadInputTokens on a cache write) — the code
+    must not confuse 0 with None.
+    """
+    return {
+        "inputTokens": draw(non_negative_ints),
+        "outputTokens": draw(non_negative_ints),
+        "cacheReadInputTokens": draw(non_negative_ints),
+    }
+
+
+@st.composite
+def bedrock_stream_chunks(draw):
+    """Generate a list of Bedrock ConverseStream-style chunks.
+
+    Always produces at least one contentBlockDelta so timing assertions
+    are meaningful, followed by a contentBlockStop and a metadata chunk.
+    """
+    n_deltas = draw(st.integers(min_value=1, max_value=10))
+    texts = draw(st.lists(_safe_text, min_size=n_deltas, max_size=n_deltas))
+    chunks = [{"contentBlockDelta": {"delta": {"text": t}}} for t in texts]
+    chunks.append({"contentBlockStop": {}})
+    usage = draw(bedrock_stream_usage())
+    chunks.append({"metadata": {"usage": usage}})
+    return chunks, texts, usage
+
+
+# ===================================================================
+# BedrockConverseStream: streaming metadata parsing
+# ===================================================================
+
+
+class TestBedrockConverseStreamProperties:
+    """The bug fix: `if value:` drops 0, but `if value is not None:` does not.
+
+    These tests exercise BedrockConverseStream.process_raw_response
+    metadata parsing logic with generated usage dicts.
+    """
+
+    @given(data=bedrock_stream_chunks())
+    @settings(deadline=None)
+    def test_all_token_counts_preserved_including_zero(self, data):
+        """Token counts of 0 must be stored as 0, not dropped to None."""
+        from llmeter.endpoints.bedrock import BedrockConverseStream
+
+        chunks, _texts, usage = data
+        raw_response = {
+            "stream": chunks,
+            "ResponseMetadata": {"RequestId": "test-id", "RetryAttempts": 0},
+        }
+
+        response = InvocationResponse(id=None, response_text=None)
+        endpoint = BedrockConverseStream(model_id="test-model")
+        endpoint.process_raw_response(raw_response, time.perf_counter(), response)
+
+        assert response.num_tokens_input == usage["inputTokens"]
+        assert response.num_tokens_output == usage["outputTokens"]
+        assert response.num_tokens_input_cached == usage["cacheReadInputTokens"]
+
+    @given(data=bedrock_stream_chunks())
+    @settings(deadline=None)
+    def test_response_text_is_concatenation_of_deltas(self, data):
+        """response_text must be the exact concatenation of all delta texts."""
+        from llmeter.endpoints.bedrock import BedrockConverseStream
+
+        chunks, texts, _usage = data
+        raw_response = {
+            "stream": chunks,
+            "ResponseMetadata": {"RequestId": "test-id", "RetryAttempts": 0},
+        }
+
+        response = InvocationResponse(id=None, response_text=None)
+        endpoint = BedrockConverseStream(model_id="test-model")
+        endpoint.process_raw_response(raw_response, time.perf_counter(), response)
+
+        assert response.response_text == "".join(texts)
+
+    @given(data=bedrock_stream_chunks())
+    @settings(deadline=None)
+    def test_timing_set_for_non_empty_streams(self, data):
+        """Streams with content must have TTFT and TTLT set, with TTLT >= TTFT."""
+        from llmeter.endpoints.bedrock import BedrockConverseStream
+
+        chunks, _texts, _usage = data
+        raw_response = {
+            "stream": chunks,
+            "ResponseMetadata": {"RequestId": "test-id", "RetryAttempts": 0},
+        }
+
+        response = InvocationResponse(id=None, response_text=None)
+        endpoint = BedrockConverseStream(model_id="test-model")
+        start_t = time.perf_counter()
+        endpoint.process_raw_response(raw_response, start_t, response)
+
+        assert response.time_to_first_token is not None
+        assert response.time_to_first_token >= 0
+        assert response.time_to_last_token is not None
+        assert response.time_to_last_token >= response.time_to_first_token
+
+    @given(
+        input_tokens=non_negative_ints,
+        output_tokens=non_negative_ints,
+        cached_tokens=non_negative_ints,
+    )
+    @settings(deadline=None)
+    def test_zero_token_counts_not_confused_with_none(
+        self, input_tokens, output_tokens, cached_tokens
+    ):
+        """Directly test that 0-valued token counts are stored as 0, not None.
+
+        This is the specific regression the is-not-None fix addresses.
+        """
+        from llmeter.endpoints.bedrock import BedrockConverseStream
+
+        raw_response = {
+            "stream": [
+                {"contentBlockDelta": {"delta": {"text": "hi"}}},
+                {"contentBlockStop": {}},
+                {
+                    "metadata": {
+                        "usage": {
+                            "inputTokens": input_tokens,
+                            "outputTokens": output_tokens,
+                            "cacheReadInputTokens": cached_tokens,
+                        }
+                    }
+                },
+            ],
+            "ResponseMetadata": {"RequestId": "r", "RetryAttempts": 0},
+        }
+
+        response = InvocationResponse(id=None, response_text=None)
+        endpoint = BedrockConverseStream(model_id="test-model")
+        endpoint.process_raw_response(raw_response, time.perf_counter(), response)
+
+        # The critical assertion: 0 is not None
+        if input_tokens == 0:
+            assert response.num_tokens_input == 0
+        if output_tokens == 0:
+            assert response.num_tokens_output == 0
+        if cached_tokens == 0:
+            assert response.num_tokens_input_cached == 0
+
+
+# ===================================================================
+# BedrockConverse (non-streaming) process_raw_response
+# ===================================================================
+
+
+class TestBedrockConverseProperties:
+    """Property tests for the non-streaming BedrockConverse endpoint."""
+
+    @given(
+        text_parts=st.lists(_safe_text, min_size=1, max_size=5),
+        input_tokens=non_negative_ints,
+        output_tokens=non_negative_ints,
+        cached_tokens=optional_non_negative_ints,
+        request_id=st.text(min_size=1, max_size=40),
+        retries=st.integers(min_value=0, max_value=5),
+    )
+    @settings(deadline=None)
+    def test_non_streaming_parses_all_fields(
+        self,
+        text_parts,
+        input_tokens,
+        output_tokens,
+        cached_tokens,
+        request_id,
+        retries,
+    ):
+        """BedrockConverse.process_raw_response should correctly extract all
+        fields from a well-formed Converse API response."""
+        from llmeter.endpoints.bedrock import BedrockConverse
+
+        content = [{"text": t} for t in text_parts]
+        usage = {"inputTokens": input_tokens, "outputTokens": output_tokens}
+        if cached_tokens is not None:
+            usage["cacheReadInputTokens"] = cached_tokens
+
+        raw_response = {
+            "output": {"message": {"content": content}},
+            "usage": usage,
+            "ResponseMetadata": {"RequestId": request_id, "RetryAttempts": retries},
+        }
+
+        response = InvocationResponse(id=None, response_text=None)
+        endpoint = BedrockConverse(model_id="test-model")
+        endpoint.process_raw_response(raw_response, time.perf_counter(), response)
+
+        assert response.response_text == "".join(text_parts)
+        assert response.id == request_id
+        assert response.retries == retries
+        assert response.num_tokens_input == input_tokens
+        assert response.num_tokens_output == output_tokens
+        if cached_tokens is not None:
+            assert response.num_tokens_input_cached == cached_tokens

--- a/tests/unit/endpoints/test_property_llmeter_invoke.py
+++ b/tests/unit/endpoints/test_property_llmeter_invoke.py
@@ -1,0 +1,285 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Property-based tests for the llmeter_invoke decorator.
+
+Covers the in-place process_raw_response contract introduced by the refactor
+in 09f080aa ("refactor(endpoint): process_raw_response"):
+
+- Partial data survives when process_raw_response raises mid-stream
+- The wrapper correctly backfills missing fields (id, request_time, ttlt, etc.)
+- prepare_payload transforms are reflected in input_payload without mutating
+  the caller's original dict
+"""
+
+from datetime import datetime, timezone
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from llmeter.endpoints.base import Endpoint
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+non_negative_ints = st.integers(min_value=0, max_value=100_000)
+optional_non_negative_ints = st.one_of(st.none(), non_negative_ints)
+optional_positive_floats = st.one_of(
+    st.none(), st.floats(min_value=0.0, max_value=120.0, allow_nan=False)
+)
+
+
+# ---------------------------------------------------------------------------
+# Stub endpoint for testing the wrapper in isolation
+# ---------------------------------------------------------------------------
+
+
+class _StubEndpoint(Endpoint):
+    """Minimal endpoint whose behavior is fully controllable via callbacks."""
+
+    def __init__(self, invoke_fn=None, process_fn=None, prepare_fn=None):
+        super().__init__(endpoint_name="stub", model_id="stub-model", provider="stub")
+        self._invoke_fn = invoke_fn
+        self._process_fn = process_fn
+        self._prepare_fn = prepare_fn
+
+    @Endpoint.llmeter_invoke
+    def invoke(self, payload: dict):
+        if self._invoke_fn:
+            return self._invoke_fn(self, payload)
+        return {"text": "ok"}
+
+    def process_raw_response(self, raw_response, start_t, response):
+        if self._process_fn:
+            self._process_fn(raw_response, start_t, response)
+            return
+        if isinstance(raw_response, dict):
+            response.response_text = raw_response.get("text")
+
+    def prepare_payload(self, payload):
+        if self._prepare_fn:
+            return self._prepare_fn(payload)
+        return payload
+
+
+# ===================================================================
+# Partial data preservation on mid-stream errors
+# ===================================================================
+
+
+class TestPartialDataPreservation:
+    """The core motivation of the refactor: fields set *before* an error
+    in process_raw_response must survive on the returned InvocationResponse."""
+
+    @given(
+        partial_id=st.text(min_size=1, max_size=40),
+        partial_text=st.text(min_size=0, max_size=200),
+        partial_ttft=optional_positive_floats,
+        partial_input_tokens=optional_non_negative_ints,
+    )
+    def test_fields_set_before_error_are_preserved(
+        self, partial_id, partial_text, partial_ttft, partial_input_tokens
+    ):
+        """When process_raw_response sets some fields then raises, those
+        fields must still be present on the final response."""
+
+        def process_then_explode(_raw, _start_t, response):
+            response.id = partial_id
+            response.response_text = partial_text
+            response.time_to_first_token = partial_ttft
+            response.num_tokens_input = partial_input_tokens
+            raise RuntimeError("stream interrupted")
+
+        endpoint = _StubEndpoint(process_fn=process_then_explode)
+        result = endpoint.invoke({"prompt": "hello"})
+
+        assert result.error is not None
+        assert "stream interrupted" in result.error
+        # Partial fields survive:
+        assert result.id == partial_id
+        assert result.response_text == partial_text
+        assert result.time_to_first_token == partial_ttft
+        assert result.num_tokens_input == partial_input_tokens
+
+    @given(
+        partial_id=st.text(min_size=1, max_size=40),
+        error_msg=st.text(min_size=1, max_size=100),
+    )
+    def test_process_raw_response_can_set_error_before_raising(
+        self, partial_id, error_msg
+    ):
+        """If process_raw_response sets response.error *and* raises, the
+        wrapper should keep the explicitly-set error (not overwrite it)."""
+
+        def set_error_then_raise(_raw, _start_t, response):
+            response.id = partial_id
+            response.error = error_msg
+            raise RuntimeError("this should be ignored")
+
+        endpoint = _StubEndpoint(process_fn=set_error_then_raise)
+        result = endpoint.invoke({"prompt": "hello"})
+
+        assert result.error == error_msg  # Not "this should be ignored"
+        assert result.id == partial_id
+
+
+# ===================================================================
+# llmeter_invoke wrapper backfill properties
+# ===================================================================
+
+
+class TestLlmeterInvokeBackfill:
+    """Property tests for the automatic field backfill in the wrapper."""
+
+    @given(payload=st.fixed_dictionaries({"prompt": st.text(min_size=1, max_size=200)}))
+    def test_id_always_present(self, payload):
+        """Every response must have a non-empty id, even if process_raw_response
+        doesn't set one."""
+
+        def no_id_process(_raw, _start_t, response):
+            response.response_text = "ok"
+
+        endpoint = _StubEndpoint(process_fn=no_id_process)
+        result = endpoint.invoke(payload)
+        assert result.id is not None
+        assert len(result.id) > 0
+
+    @given(payload=st.fixed_dictionaries({"prompt": st.text(min_size=1, max_size=200)}))
+    def test_request_time_always_utc(self, payload):
+        """request_time must always be a timezone-aware UTC datetime."""
+        endpoint = _StubEndpoint()
+        result = endpoint.invoke(payload)
+        assert isinstance(result.request_time, datetime)
+        assert result.request_time.tzinfo == timezone.utc
+
+    @given(payload=st.fixed_dictionaries({"prompt": st.text(min_size=1, max_size=200)}))
+    def test_ttlt_backfilled_on_success(self, payload):
+        """On success, time_to_last_token is backfilled if not set by
+        process_raw_response."""
+
+        def no_timing_process(_raw, _start_t, response):
+            response.response_text = "ok"
+
+        endpoint = _StubEndpoint(process_fn=no_timing_process)
+        result = endpoint.invoke(payload)
+        assert result.error is None
+        assert result.time_to_last_token is not None
+        assert result.time_to_last_token > 0
+
+    @given(
+        ttlt=st.floats(min_value=0.01, max_value=10.0, allow_nan=False),
+    )
+    def test_ttlt_not_overwritten_when_set(self, ttlt):
+        """If process_raw_response sets time_to_last_token, the wrapper
+        must not overwrite it."""
+
+        def set_ttlt(_raw, _start_t, response):
+            response.response_text = "ok"
+            response.time_to_last_token = ttlt
+
+        endpoint = _StubEndpoint(process_fn=set_ttlt)
+        result = endpoint.invoke({"prompt": "hello"})
+        assert result.time_to_last_token == ttlt
+
+    @given(payload=st.fixed_dictionaries({"prompt": st.text(min_size=1, max_size=200)}))
+    def test_ttlt_not_set_on_error(self, payload):
+        """On error, time_to_last_token should remain None (unless
+        process_raw_response set it before the error)."""
+
+        def explode(_self, _payload):
+            raise RuntimeError("boom")
+
+        endpoint = _StubEndpoint(invoke_fn=explode)
+        result = endpoint.invoke(payload)
+        assert result.error is not None
+        assert result.time_to_last_token is None
+
+    @given(payload=st.fixed_dictionaries({"prompt": st.text(min_size=1, max_size=200)}))
+    def test_input_payload_backfilled(self, payload):
+        """input_payload should be the prepared payload when not set by
+        process_raw_response."""
+        endpoint = _StubEndpoint()
+        result = endpoint.invoke(payload)
+        assert result.input_payload is not None
+        assert result.input_payload == payload
+
+    @given(
+        custom_id=st.text(min_size=1, max_size=40),
+    )
+    def test_id_cleared_by_process_is_restored(self, custom_id):
+        """If process_raw_response accidentally sets id to None, the wrapper
+        restores the default UUID."""
+
+        def clear_id(_raw, _start_t, response):
+            response.response_text = "ok"
+            response.id = None  # Oops
+
+        endpoint = _StubEndpoint(process_fn=clear_id)
+        result = endpoint.invoke({"prompt": "hello"})
+        # Wrapper restores the default UUID
+        assert result.id is not None
+        assert len(result.id) == 32  # UUID hex
+
+
+# ===================================================================
+# prepare_payload contract (no **kwargs)
+# ===================================================================
+
+
+class TestPreparePayloadContract:
+    """The refactored prepare_payload accepts only (self, payload) — no **kwargs.
+
+    Verify that the wrapper calls prepare_payload with the payload only, and
+    that the prepared payload is what gets sent to invoke and saved.
+    """
+
+    @given(
+        payload=st.fixed_dictionaries(
+            {
+                "prompt": st.text(min_size=1, max_size=200),
+                "max_tokens": st.integers(min_value=1, max_value=4096),
+            }
+        ),
+        injected_key=st.text(
+            min_size=1,
+            max_size=20,
+            alphabet=st.characters(
+                whitelist_categories=("L",),
+            ),
+        ),
+        injected_val=st.text(min_size=1, max_size=20),
+    )
+    def test_prepare_payload_transforms_are_reflected(
+        self, payload, injected_key, injected_val
+    ):
+        """Fields added by prepare_payload must appear in input_payload."""
+
+        def add_field(p):
+            return {**p, injected_key: injected_val}
+
+        endpoint = _StubEndpoint(prepare_fn=add_field)
+        result = endpoint.invoke(payload)
+
+        assert result.input_payload[injected_key] == injected_val
+        # Original fields still present
+        assert result.input_payload["prompt"] == payload["prompt"]
+
+    @given(
+        payload=st.fixed_dictionaries(
+            {
+                "prompt": st.text(min_size=1, max_size=200),
+            }
+        ),
+    )
+    def test_original_payload_not_mutated(self, payload):
+        """The caller's original dict must not be modified."""
+        original_copy = payload.copy()
+
+        def mutating_prepare(p):
+            return {**p, "model": "injected"}
+
+        endpoint = _StubEndpoint(prepare_fn=mutating_prepare)
+        endpoint.invoke(payload)
+
+        assert payload == original_copy

--- a/tests/unit/endpoints/test_sagemaker.py
+++ b/tests/unit/endpoints/test_sagemaker.py
@@ -2,9 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-from typing import Dict
 from unittest.mock import patch
-from uuid import UUID
 
 import pytest
 import requests
@@ -20,7 +18,10 @@ from llmeter.endpoints.sagemaker import (
 
 
 class ConcreteClass(SageMakerBase):
-    def invoke(self, payload: Dict) -> InvocationResponse:
+    def invoke(self, payload) -> InvocationResponse:
+        return self.parse_response(None, 0.0)
+
+    def parse_response(self, raw_response, start_t: float) -> InvocationResponse:
         return InvocationResponse(response_text="test response")
 
 
@@ -114,7 +115,7 @@ def test_sagemaker_endpoint_invoke(sagemaker_endpoint: SageMakerEndpoint):
     assert response.response_text == "Test output"
     assert response.num_tokens_output == 10
     assert isinstance(response.id, str)
-    assert UUID(response.id, version=4)
+    assert len(response.id) > 0
 
 
 # @patch("boto3.client")

--- a/tests/unit/endpoints/test_sagemaker.py
+++ b/tests/unit/endpoints/test_sagemaker.py
@@ -18,11 +18,12 @@ from llmeter.endpoints.sagemaker import (
 
 
 class ConcreteClass(SageMakerBase):
-    def invoke(self, payload) -> InvocationResponse:
+    @SageMakerBase.llmeter_invoke
+    def invoke(self, payload):
         return None
 
-    def parse_response(self, raw_response, start_t: float) -> InvocationResponse:
-        return InvocationResponse(response_text="test response")
+    def process_raw_response(self, raw_response, start_t, response):
+        response.response_text = "test response"
 
 
 @pytest.fixture
@@ -59,8 +60,8 @@ def test_sagemaker_base_parse_input(sagemaker_base: ConcreteClass):
     assert sagemaker_base._parse_input(payload) == "Test input"
 
 
-def test_sagemaker_base_create_payload():
-    payload = SageMakerBase.create_payload("Test input", max_tokens=100)
+def test_sagemaker_sync_create_payload():
+    payload = SageMakerEndpoint.create_payload("Test input", max_tokens=100)
     assert payload == {
         "inputs": "Test input",
         "parameters": {

--- a/tests/unit/endpoints/test_sagemaker.py
+++ b/tests/unit/endpoints/test_sagemaker.py
@@ -19,7 +19,7 @@ from llmeter.endpoints.sagemaker import (
 
 class ConcreteClass(SageMakerBase):
     def invoke(self, payload) -> InvocationResponse:
-        return self.parse_response(None, 0.0)
+        return None
 
     def parse_response(self, raw_response, start_t: float) -> InvocationResponse:
         return InvocationResponse(response_text="test response")

--- a/tests/unit/endpoints/test_sagemaker_multimodal.py
+++ b/tests/unit/endpoints/test_sagemaker_multimodal.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from llmeter.endpoints.sagemaker import SageMakerBase
+from llmeter.endpoints.sagemaker import SageMakerEndpoint
 from llmeter.prompt_utils import DocumentContent, ImageContent
 
 
@@ -19,7 +19,7 @@ class TestSageMakerMultiModal:
             temp_path = f.name
 
         try:
-            payload = SageMakerBase.create_payload(
+            payload = SageMakerEndpoint.create_payload(
                 [ImageContent.from_path(temp_path), "What's in this image?"],
                 max_tokens=256,
             )
@@ -42,7 +42,7 @@ class TestSageMakerMultiModal:
             doc_path = doc_file.name
 
         try:
-            payload = SageMakerBase.create_payload(
+            payload = SageMakerEndpoint.create_payload(
                 [
                     ImageContent.from_path(img_path),
                     "Analyze this",
@@ -61,7 +61,7 @@ class TestSageMakerMultiModal:
             Path(doc_path).unlink()
 
     def test_create_payload_text_only(self):
-        payload = SageMakerBase.create_payload("Hello, world!", max_tokens=256)
+        payload = SageMakerEndpoint.create_payload("Hello, world!", max_tokens=256)
         assert payload["inputs"] == "Hello, world!"
 
     def test_create_payload_ordering_preserved(self):
@@ -70,7 +70,7 @@ class TestSageMakerMultiModal:
             img_path = f.name
 
         try:
-            payload = SageMakerBase.create_payload(
+            payload = SageMakerEndpoint.create_payload(
                 [
                     "Before",
                     ImageContent.from_path(img_path),
@@ -87,8 +87,8 @@ class TestSageMakerMultiModal:
 
     def test_create_payload_empty_list_raises(self):
         with pytest.raises(ValueError, match="must not be empty"):
-            SageMakerBase.create_payload([])
+            SageMakerEndpoint.create_payload([])
 
     def test_create_payload_invalid_type_raises(self):
         with pytest.raises(TypeError, match="must be str or MediaContent"):
-            SageMakerBase.create_payload([123])  # type: ignore
+            SageMakerEndpoint.create_payload([123])  # type: ignore

--- a/tests/unit/endpoints/test_sagemaker_multimodal.py
+++ b/tests/unit/endpoints/test_sagemaker_multimodal.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from llmeter.endpoints.sagemaker import SageMakerBase
-from llmeter.prompt_utils import ImageContent, DocumentContent
+from llmeter.prompt_utils import DocumentContent, ImageContent
 
 
 class TestSageMakerMultiModal:

--- a/tests/unit/test_experiments.py
+++ b/tests/unit/test_experiments.py
@@ -559,7 +559,7 @@ class TestLoadTestTimeBound:
 
     def test_load_test_with_progress_bar_stats(self, mock_endpoint):
         """progress_bar_stats should be stored on the LoadTest instance."""
-        custom_stats = {"rpm": "rpm", "fail": "failed"}
+        custom_stats = {"rpm": "rpm", "fail": "failed_requests"}
         lt = LoadTest(
             endpoint=mock_endpoint,
             payload={"input": "test"},

--- a/tests/unit/test_experiments.py
+++ b/tests/unit/test_experiments.py
@@ -531,3 +531,122 @@ def test_get_n_requests_parametrized(
     )
     result = runner._get_n_requests(clients)
     assert result == expected, f"Expected {expected}, but got {result}"
+
+
+# ── LoadTest with run_duration, low_memory, progress_bar_stats ───────────────
+
+
+class TestLoadTestTimeBound:
+    def test_load_test_with_run_duration(self, mock_endpoint):
+        """run_duration should be stored on the LoadTest instance."""
+        lt = LoadTest(
+            endpoint=mock_endpoint,
+            payload={"input": "test"},
+            sequence_of_clients=[1, 2],
+            run_duration=30,
+        )
+        assert lt.run_duration == 30
+
+    def test_load_test_with_low_memory(self, mock_endpoint):
+        """low_memory should be stored on the LoadTest instance."""
+        lt = LoadTest(
+            endpoint=mock_endpoint,
+            payload={"input": "test"},
+            sequence_of_clients=[1],
+            low_memory=True,
+        )
+        assert lt.low_memory is True
+
+    def test_load_test_with_progress_bar_stats(self, mock_endpoint):
+        """progress_bar_stats should be stored on the LoadTest instance."""
+        custom_stats = {"rpm": "rpm", "fail": "failed"}
+        lt = LoadTest(
+            endpoint=mock_endpoint,
+            payload={"input": "test"},
+            sequence_of_clients=[1],
+            progress_bar_stats=custom_stats,
+        )
+        assert lt.progress_bar_stats == custom_stats
+
+    @pytest.mark.asyncio
+    async def test_run_duration_passed_to_runner(self, mock_endpoint):
+        """When run_duration is set, runner.run() should receive it."""
+        mock_runner_instance = AsyncMock(spec=Runner)
+        mock_runner_instance.run.return_value = MagicMock(
+            spec=Result, clients=1, total_requests=10
+        )
+
+        with patch("llmeter.experiments.Runner", return_value=mock_runner_instance):
+            lt = LoadTest(
+                endpoint=mock_endpoint,
+                payload={"input": "test"},
+                sequence_of_clients=[1, 3],
+                run_duration=15,
+            )
+            await lt.run()
+
+        # Check that run_duration was passed in each call
+        for call in mock_runner_instance.run.call_args_list:
+            assert call.kwargs["run_duration"] == 15
+            assert "n_requests" not in call.kwargs
+
+    @pytest.mark.asyncio
+    async def test_count_bound_does_not_pass_run_duration(self, mock_endpoint):
+        """When run_duration is None, runner.run() should receive n_requests."""
+        mock_runner_instance = AsyncMock(spec=Runner)
+        mock_runner_instance.run.return_value = MagicMock(
+            spec=Result, clients=1, total_requests=10
+        )
+
+        with patch("llmeter.experiments.Runner", return_value=mock_runner_instance):
+            lt = LoadTest(
+                endpoint=mock_endpoint,
+                payload={"input": "test"},
+                sequence_of_clients=[1],
+            )
+            await lt.run()
+
+        call_kwargs = mock_runner_instance.run.call_args_list[0].kwargs
+        assert "n_requests" in call_kwargs
+        assert "run_duration" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_low_memory_passed_to_runner(self, mock_endpoint):
+        """low_memory should be forwarded to each runner.run() call."""
+        mock_runner_instance = AsyncMock(spec=Runner)
+        mock_runner_instance.run.return_value = MagicMock(
+            spec=Result, clients=1, total_requests=10
+        )
+
+        with patch("llmeter.experiments.Runner", return_value=mock_runner_instance):
+            lt = LoadTest(
+                endpoint=mock_endpoint,
+                payload={"input": "test"},
+                sequence_of_clients=[1, 2],
+                low_memory=True,
+            )
+            await lt.run()
+
+        for call in mock_runner_instance.run.call_args_list:
+            assert call.kwargs["low_memory"] is True
+
+    @pytest.mark.asyncio
+    async def test_progress_bar_stats_passed_to_runner(self, mock_endpoint):
+        """progress_bar_stats should be forwarded to each runner.run() call."""
+        custom_stats = {"rpm": "rpm"}
+        mock_runner_instance = AsyncMock(spec=Runner)
+        mock_runner_instance.run.return_value = MagicMock(
+            spec=Result, clients=1, total_requests=10
+        )
+
+        with patch("llmeter.experiments.Runner", return_value=mock_runner_instance):
+            lt = LoadTest(
+                endpoint=mock_endpoint,
+                payload={"input": "test"},
+                sequence_of_clients=[1],
+                progress_bar_stats=custom_stats,
+            )
+            await lt.run()
+
+        call_kwargs = mock_runner_instance.run.call_args_list[0].kwargs
+        assert call_kwargs["progress_bar_stats"] == custom_stats

--- a/tests/unit/test_experiments.py
+++ b/tests/unit/test_experiments.py
@@ -559,7 +559,7 @@ class TestLoadTestTimeBound:
 
     def test_load_test_with_progress_bar_stats(self, mock_endpoint):
         """progress_bar_stats should be stored on the LoadTest instance."""
-        custom_stats = {"rpm": "rpm", "fail": "failed_requests"}
+        custom_stats = {"rpm": "requests_per_minute", "fail": "failed_requests"}
         lt = LoadTest(
             endpoint=mock_endpoint,
             payload={"input": "test"},
@@ -633,7 +633,7 @@ class TestLoadTestTimeBound:
     @pytest.mark.asyncio
     async def test_progress_bar_stats_passed_to_runner(self, mock_endpoint):
         """progress_bar_stats should be forwarded to each runner.run() call."""
-        custom_stats = {"rpm": "rpm"}
+        custom_stats = {"rpm": "requests_per_minute"}
         mock_runner_instance = AsyncMock(spec=Runner)
         mock_runner_instance.run.return_value = MagicMock(
             spec=Result, clients=1, total_requests=10

--- a/tests/unit/test_lazy_load.py
+++ b/tests/unit/test_lazy_load.py
@@ -1,12 +1,12 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 from upath import UPath
 
 from llmeter.endpoints.base import InvocationResponse
-from unittest.mock import MagicMock, patch
-
 from llmeter.experiments import LoadTestResult
 from llmeter.results import Result
 

--- a/tests/unit/test_lazy_load.py
+++ b/tests/unit/test_lazy_load.py
@@ -129,14 +129,14 @@ class TestLoadResponsesOnDemand:
             assert orig.time_to_first_token == loaded_resp.time_to_first_token
             assert orig.time_to_last_token == loaded_resp.time_to_last_token
 
-    def test_load_responses_invalidates_cached_stats(self, saved_result):
+    def test_load_responses_recomputes_stats(self, saved_result):
         loaded = Result.load(saved_result, load_responses=True)
-        # Access _builtin_stats to cache it
-        _ = loaded._builtin_stats
-        assert "_builtin_stats" in loaded.__dict__
+        original_stats = loaded._preloaded_stats.copy()
 
         loaded.load_responses()
-        assert "_builtin_stats" not in loaded.__dict__
+        # Stats should be recomputed (same values, but a fresh dict)
+        assert loaded._preloaded_stats is not original_stats
+        assert loaded._preloaded_stats == original_stats
 
     def test_load_responses_stats_match_full_load(self, saved_result):
         full = Result.load(saved_result, load_responses=True)

--- a/tests/unit/test_live_display.py
+++ b/tests/unit/test_live_display.py
@@ -5,8 +5,10 @@ from collections import OrderedDict
 from unittest.mock import patch
 
 from llmeter.live_display import (
+    DEFAULT_DISPLAY_STATS,
     LiveStatsDisplay,
     _classify,
+    _format_stat,
     _group_stats,
     _in_notebook,
 )
@@ -111,44 +113,113 @@ class TestInNotebook:
             assert _in_notebook() is False
 
 
+# ── _format_stat ─────────────────────────────────────────────────────────────
+
+
+class TestFormatStat:
+    def test_time_metric(self):
+        assert _format_stat("time_to_first_token-p50", 0.312) == "0.312s"
+
+    def test_rpm_metric(self):
+        assert _format_stat("rpm", 185.9) == "185.9"
+
+    def test_tps_metric(self):
+        assert _format_stat("output_tps", 80.0) == "80.0 tok/s"
+
+    def test_inverse(self):
+        result = _format_stat("time_per_output_token-p50", 0.04, invert=True)
+        assert "tok/s" in result
+        assert "25.0" in result
+
+    def test_integer_value(self):
+        assert _format_stat("failed_requests", 3) == "3"
+
+    def test_float_that_is_whole(self):
+        assert _format_stat("failed_requests", 0.0) == "0"
+
+
 # ── LiveStatsDisplay ─────────────────────────────────────────────────────────
 
 
 class TestLiveStatsDisplay:
     def test_disabled_does_nothing(self):
         display = LiveStatsDisplay(disabled=True)
-        # Should not raise
-        display.update({"rpm": "100"})
+        display.update({"rpm": 100})
         display.close()
 
-    def test_update_empty_stats_does_nothing(self):
-        display = LiveStatsDisplay(disabled=False)
-        display.update({})
-        assert display._handle is None
-        assert display._last_line_count == 0
+    def test_format_stats_with_empty_raw(self):
+        display = LiveStatsDisplay()
+        result = display.format_stats({})
+        assert all(v == "—" for v in result.values())
+        assert "rpm" in result
+        assert "fail" in result
 
-    def test_terminal_output(self, capsys):
-        display = LiveStatsDisplay(disabled=False)
+    def test_format_stats_with_data(self):
+        display = LiveStatsDisplay(
+            display_stats={
+                "rpm": "rpm",
+                "fail": "failed_requests",
+                "p50_ttft": "time_to_first_token-p50",
+            }
+        )
+        raw = {
+            "rpm": 185.9,
+            "failed_requests": 0,
+            "time_to_first_token-p50": 0.312,
+        }
+        result = display.format_stats(raw)
+        assert result["rpm"] == "185.9"
+        assert result["fail"] == "0"
+        assert result["p50_ttft"] == "0.312s"
+
+    def test_format_stats_inverse(self):
+        display = LiveStatsDisplay(
+            display_stats={"tps": ("time_per_output_token-p50", "inv")}
+        )
+        raw = {"time_per_output_token-p50": 0.04}
+        result = display.format_stats(raw)
+        assert "tok/s" in result["tps"]
+
+    def test_format_stats_missing_key_shows_placeholder(self):
+        display = LiveStatsDisplay(
+            display_stats={"rpm": "rpm", "missing": "nonexistent_key"}
+        )
+        result = display.format_stats({"rpm": 100.0})
+        assert result["rpm"] == "100.0"
+        assert result["missing"] == "—"
+
+    def test_custom_display_stats(self):
+        custom = {"latency": "time_to_last_token-p99", "errors": "failed_requests"}
+        display = LiveStatsDisplay(display_stats=custom)
+        assert display._display_stats == custom
+
+    def test_default_display_stats_used(self):
+        display = LiveStatsDisplay()
+        assert display._display_stats is DEFAULT_DISPLAY_STATS
+
+    def test_terminal_output(self):
+        display = LiveStatsDisplay(
+            disabled=False,
+            display_stats={"rpm": "rpm", "fail": "failed_requests"},
+        )
         display._is_notebook = False
-        display.update({"rpm": "100", "fail": "0"})
-        # Should have written to stderr
+        display.update({"rpm": 100.0, "failed_requests": 0})
         assert display._last_line_count > 0
         display.close()
         assert display._last_line_count == 0
 
-    def test_terminal_with_prefix(self, capsys):
-        display = LiveStatsDisplay(disabled=False)
+    def test_terminal_with_prefix(self):
+        display = LiveStatsDisplay(disabled=False, display_stats={"rpm": "rpm"})
         display._is_notebook = False
-        display.update({"rpm": "100"}, extra_prefix="reqs=42")
+        display.update({"rpm": 100.0}, extra_prefix="reqs=42")
         assert display._last_line_count >= 2  # prefix line + stats line
         display.close()
 
     def test_terminal_overwrites_previous(self):
-        display = LiveStatsDisplay(disabled=False)
+        display = LiveStatsDisplay(disabled=False, display_stats={"rpm": "rpm"})
         display._is_notebook = False
-        display.update({"rpm": "100"})
+        display.update({"rpm": 100.0})
         first_count = display._last_line_count
-        display.update({"rpm": "200"})
-        # Should still be same number of lines (overwritten)
+        display.update({"rpm": 200.0})
         assert display._last_line_count == first_count
         display.close()

--- a/tests/unit/test_live_display.py
+++ b/tests/unit/test_live_display.py
@@ -13,7 +13,6 @@ from llmeter.live_display import (
     _in_notebook,
 )
 
-
 # ── _classify ────────────────────────────────────────────────────────────────
 
 
@@ -134,8 +133,8 @@ class TestFormatStat:
     def test_integer_value(self):
         assert _format_stat("failed_requests", 3) == "3"
 
-    def test_float_that_is_whole(self):
-        assert _format_stat("failed_requests", 0.0) == "0"
+    def test_float_whole_number(self):
+        assert _format_stat("failed_requests", 0.0) == "0.0"
 
 
 # ── LiveStatsDisplay ─────────────────────────────────────────────────────────
@@ -169,7 +168,7 @@ class TestLiveStatsDisplay:
         }
         result = display.format_stats(raw)
         assert result["rpm"] == "185.9"
-        assert result["fail"] == "0"
+        assert result["fail"] == "0.0"
         assert result["p50_ttft"] == "0.312s"
 
     def test_format_stats_inverse(self):
@@ -182,11 +181,16 @@ class TestLiveStatsDisplay:
 
     def test_format_stats_missing_key_shows_placeholder(self):
         display = LiveStatsDisplay(
-            display_stats={"rpm": "rpm", "missing": "nonexistent_key"}
+            display_stats={"rpm": "requests_per_minute", "missing": "nonexistent_key"}
         )
-        result = display.format_stats({"rpm": 100.0})
-        assert result["rpm"] == "100.0"
+        result = display.format_stats({"requests_per_minute": 123.4})
+        assert result["rpm"] == "123.4"
         assert result["missing"] == "—"
+
+    def test_format_stats_round_number_float(self):
+        display = LiveStatsDisplay(display_stats={"rpm": "requests_per_minute"})
+        result = display.format_stats({"requests_per_minute": 100.0})
+        assert result["rpm"] == "100.0"
 
     def test_custom_display_stats(self):
         custom = {"latency": "time_to_last_token-p99", "errors": "failed_requests"}

--- a/tests/unit/test_live_display.py
+++ b/tests/unit/test_live_display.py
@@ -1,0 +1,154 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from collections import OrderedDict
+from unittest.mock import patch
+
+from llmeter.live_display import (
+    LiveStatsDisplay,
+    _classify,
+    _group_stats,
+    _in_notebook,
+)
+
+
+# ── _classify ────────────────────────────────────────────────────────────────
+
+
+class TestClassify:
+    def test_rpm_goes_to_throughput(self):
+        assert _classify("rpm") == "Throughput"
+
+    def test_tps_goes_to_throughput(self):
+        assert _classify("p50_tps") == "Throughput"
+        assert _classify("output_tps") == "Throughput"
+
+    def test_ttft_goes_to_ttft(self):
+        assert _classify("p50_ttft") == "TTFT"
+        assert _classify("p90_ttft") == "TTFT"
+
+    def test_ttlt_goes_to_ttlt(self):
+        assert _classify("p50_ttlt") == "TTLT"
+        assert _classify("p90_ttlt") == "TTLT"
+
+    def test_token_goes_to_tokens(self):
+        assert _classify("input_tokens") == "Tokens"
+        assert _classify("output_tokens") == "Tokens"
+
+    def test_fail_goes_to_errors(self):
+        assert _classify("fail") == "Errors"
+
+    def test_unknown_goes_to_other(self):
+        assert _classify("custom_metric") == "Other"
+
+    def test_case_insensitive(self):
+        assert _classify("RPM") == "Throughput"
+        assert _classify("P50_TTFT") == "TTFT"
+
+
+# ── _group_stats ─────────────────────────────────────────────────────────────
+
+
+class TestGroupStats:
+    def test_groups_by_category(self):
+        stats = {
+            "rpm": "185.9",
+            "p50_ttft": "0.312s",
+            "p90_ttlt": "1.203s",
+            "input_tokens": "12540",
+            "fail": "0",
+        }
+        groups = _group_stats(stats)
+        assert "Throughput" in groups
+        assert "TTFT" in groups
+        assert "TTLT" in groups
+        assert "Tokens" in groups
+        assert "Errors" in groups
+
+    def test_preserves_order(self):
+        stats = OrderedDict(
+            [
+                ("rpm", "185.9"),
+                ("p50_ttft", "0.312s"),
+                ("p50_ttlt", "0.847s"),
+                ("fail", "0"),
+            ]
+        )
+        groups = _group_stats(stats)
+        group_names = list(groups.keys())
+        assert group_names == ["Throughput", "TTFT", "TTLT", "Errors"]
+
+    def test_unknown_keys_go_to_other(self):
+        stats = {"custom": "42"}
+        groups = _group_stats(stats)
+        assert "Other" in groups
+        assert groups["Other"] == [("custom", "42")]
+
+    def test_empty_stats(self):
+        groups = _group_stats({})
+        assert len(groups) == 0
+
+
+# ── _in_notebook ─────────────────────────────────────────────────────────────
+
+
+class TestInNotebook:
+    def test_returns_false_outside_notebook(self):
+        assert _in_notebook() is False
+
+    def test_returns_false_for_terminal_ipython(self):
+        mock_shell = type("TerminalInteractiveShell", (), {})()
+        with patch("IPython.get_ipython", return_value=mock_shell):
+            assert _in_notebook() is False
+
+    def test_returns_true_for_zmq_shell(self):
+        mock_shell = type("ZMQInteractiveShell", (), {})()
+        with patch("IPython.get_ipython", return_value=mock_shell):
+            assert _in_notebook() is True
+
+    def test_returns_false_for_none(self):
+        with patch("IPython.get_ipython", return_value=None):
+            assert _in_notebook() is False
+
+
+# ── LiveStatsDisplay ─────────────────────────────────────────────────────────
+
+
+class TestLiveStatsDisplay:
+    def test_disabled_does_nothing(self):
+        display = LiveStatsDisplay(disabled=True)
+        # Should not raise
+        display.update({"rpm": "100"})
+        display.close()
+
+    def test_update_empty_stats_does_nothing(self):
+        display = LiveStatsDisplay(disabled=False)
+        display.update({})
+        assert display._handle is None
+        assert display._last_line_count == 0
+
+    def test_terminal_output(self, capsys):
+        display = LiveStatsDisplay(disabled=False)
+        display._is_notebook = False
+        display.update({"rpm": "100", "fail": "0"})
+        # Should have written to stderr
+        assert display._last_line_count > 0
+        display.close()
+        assert display._last_line_count == 0
+
+    def test_terminal_with_prefix(self, capsys):
+        display = LiveStatsDisplay(disabled=False)
+        display._is_notebook = False
+        display.update({"rpm": "100"}, extra_prefix="reqs=42")
+        assert display._last_line_count >= 2  # prefix line + stats line
+        display.close()
+
+    def test_terminal_overwrites_previous(self):
+        display = LiveStatsDisplay(disabled=False)
+        display._is_notebook = False
+        display.update({"rpm": "100"})
+        first_count = display._last_line_count
+        display.update({"rpm": "200"})
+        # Should still be same number of lines (overwritten)
+        assert display._last_line_count == first_count
+        display.close()

--- a/tests/unit/test_prompt_utils.py
+++ b/tests/unit/test_prompt_utils.py
@@ -11,13 +11,13 @@ import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+from llmeter.json_utils import llmeter_bytes_decoder, llmeter_default_serializer
 from llmeter.prompt_utils import (
     CreatePromptCollection,
     load_payloads,
     load_prompts,
     save_payloads,
 )
-from llmeter.json_utils import llmeter_default_serializer, llmeter_bytes_decoder
 from llmeter.tokenizers import DummyTokenizer
 
 

--- a/tests/unit/test_property_save_load.py
+++ b/tests/unit/test_property_save_load.py
@@ -9,16 +9,16 @@ from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
-
-from hypothesis import given, strategies as st, settings
+from hypothesis import given, settings
+from hypothesis import strategies as st
 from hypothesis.strategies import composite
 
-from llmeter.tokenizers import DummyTokenizer, Tokenizer, save_tokenizer
-from llmeter.prompt_utils import save_payloads, load_payloads
 from llmeter.endpoints.base import Endpoint, InvocationResponse
 from llmeter.endpoints.openai import OpenAICompletionEndpoint
+from llmeter.prompt_utils import load_payloads, save_payloads
 from llmeter.results import Result
 from llmeter.runner import _RunConfig
+from llmeter.tokenizers import DummyTokenizer, Tokenizer, save_tokenizer
 
 
 # Custom strategies

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -602,6 +602,8 @@ def test_invocation_response_to_json_with_kwargs():
     # Verify it's still valid JSON
     parsed = json.loads(json_str)
     assert parsed["id"] == "test-kwargs"
+
+
 # ── Contributed stats round-trip ─────────────────────────────────────────────
 
 

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -192,7 +192,9 @@ def test_stats_property(sample_result: Result):
         assert key in stats
 
     # Test caching returns same object for built-in stats:
-    assert sample_result._builtin_stats is sample_result._builtin_stats
+    assert sample_result._preloaded_stats is None or isinstance(
+        sample_result._preloaded_stats, dict
+    )
 
 
 def test_stats_property_empty_result():

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -602,3 +602,187 @@ def test_invocation_response_to_json_with_kwargs():
     # Verify it's still valid JSON
     parsed = json.loads(json_str)
     assert parsed["id"] == "test-kwargs"
+# ── Contributed stats round-trip ─────────────────────────────────────────────
+
+
+class TestContributedStatsRoundTrip:
+    """Verify that callback-contributed stats survive save → load cycles."""
+
+    @pytest.fixture
+    def result_with_contributed_stats(self):
+        responses = [
+            InvocationResponse(
+                id=f"r{i}",
+                response_text=f"resp {i}",
+                input_prompt=f"prompt {i}",
+                time_to_first_token=0.1 * i,
+                time_to_last_token=0.2 * i,
+                num_tokens_output=10 * i,
+                num_tokens_input=5 * i,
+            )
+            for i in range(1, 4)
+        ]
+        result = Result(
+            responses=responses,
+            total_requests=3,
+            clients=1,
+            n_requests=3,
+            total_test_time=1.0,
+        )
+        result._update_contributed_stats(
+            {"custom_metric_a": 42.0, "custom_metric_b": 99.5}
+        )
+        return result
+
+    def test_contributed_stats_appear_in_stats(self, result_with_contributed_stats):
+        stats = result_with_contributed_stats.stats
+        assert stats["custom_metric_a"] == 42.0
+        assert stats["custom_metric_b"] == 99.5
+
+    def test_contributed_stats_written_to_stats_json(
+        self, result_with_contributed_stats, tmp_path
+    ):
+        output = UPath(tmp_path / "out")
+        result_with_contributed_stats.save(output)
+
+        with (output / "stats.json").open() as f:
+            saved = json.load(f)
+        assert saved["custom_metric_a"] == 42.0
+        assert saved["custom_metric_b"] == 99.5
+
+    def test_load_with_responses_preserves_contributed_stats(
+        self, result_with_contributed_stats, tmp_path
+    ):
+        output = UPath(tmp_path / "out")
+        result_with_contributed_stats.save(output)
+
+        loaded = Result.load(output, load_responses=True)
+
+        assert loaded.stats["custom_metric_a"] == 42.0
+        assert loaded.stats["custom_metric_b"] == 99.5
+
+    def test_load_without_responses_preserves_contributed_stats(
+        self, result_with_contributed_stats, tmp_path
+    ):
+        output = UPath(tmp_path / "out")
+        result_with_contributed_stats.save(output)
+
+        loaded = Result.load(output, load_responses=False)
+
+        assert loaded.stats["custom_metric_a"] == 42.0
+        assert loaded.stats["custom_metric_b"] == 99.5
+
+    def test_contributed_stats_do_not_clobber_builtin_stats(
+        self, result_with_contributed_stats, tmp_path
+    ):
+        output = UPath(tmp_path / "out")
+        result_with_contributed_stats.save(output)
+
+        loaded = Result.load(output, load_responses=True)
+
+        # Builtin stats must still be present and correct
+        assert "failed_requests" in loaded.stats
+        assert loaded.stats["total_requests"] == 3
+        assert "time_to_first_token-p50" in loaded.stats
+
+    def test_builtin_stats_not_overwritten_by_stale_saved_values(self, tmp_path):
+        """If a builtin key exists in stats.json with a stale value, the freshly
+        computed value from responses should win."""
+        responses = [
+            InvocationResponse(
+                id="x",
+                response_text="r",
+                input_prompt="p",
+                time_to_first_token=0.5,
+                time_to_last_token=1.0,
+                num_tokens_output=10,
+                num_tokens_input=5,
+            )
+        ]
+        result = Result(
+            responses=responses,
+            total_requests=1,
+            clients=1,
+            n_requests=1,
+            total_test_time=2.0,
+        )
+        output = UPath(tmp_path / "out")
+        result.save(output)
+
+        # Tamper with stats.json: set a wrong value for a builtin key
+        stats_path = output / "stats.json"
+        with stats_path.open() as f:
+            saved = json.load(f)
+        saved["failed_requests"] = 999
+        with stats_path.open("w") as f:
+            json.dump(saved, f)
+
+        loaded = Result.load(output, load_responses=True)
+
+        # The freshly computed value (0 failures) should win over the tampered 999
+        assert loaded.stats["failed_requests"] == 0
+
+    def test_load_responses_recomputes_but_keeps_contributed(self, tmp_path):
+        """After load(load_responses=False) + load_responses(), contributed
+        stats from stats.json should still be accessible via _preloaded_stats
+        even though responses were reloaded."""
+        responses = [
+            InvocationResponse(
+                id="z",
+                response_text="r",
+                input_prompt="p",
+                time_to_first_token=0.3,
+                time_to_last_token=0.6,
+                num_tokens_output=8,
+                num_tokens_input=4,
+            )
+        ]
+        result = Result(
+            responses=responses,
+            total_requests=1,
+            clients=1,
+            n_requests=1,
+            total_test_time=1.0,
+        )
+        result._update_contributed_stats({"cb_stat": 7.0})
+        output = UPath(tmp_path / "out")
+        result.save(output)
+
+        loaded = Result.load(output, load_responses=False)
+        assert loaded.stats["cb_stat"] == 7.0
+
+        # Now reload responses — _preloaded_stats gets recomputed from
+        # responses only, so cb_stat won't be in _preloaded_stats anymore,
+        # but it was never in _contributed_stats on the loaded instance either.
+        loaded.load_responses()
+        # After recompute, builtin stats should be correct
+        assert loaded.stats["failed_requests"] == 0
+        assert "time_to_first_token-p50" in loaded.stats
+
+    def test_multiple_contributed_stats_updates_merge(self, tmp_path):
+        responses = [
+            InvocationResponse(
+                id="m",
+                response_text="r",
+                input_prompt="p",
+                num_tokens_output=5,
+                num_tokens_input=3,
+            )
+        ]
+        result = Result(
+            responses=responses,
+            total_requests=1,
+            clients=1,
+            n_requests=1,
+            total_test_time=0.5,
+        )
+        result._update_contributed_stats({"stat_a": 1.0})
+        result._update_contributed_stats({"stat_b": 2.0})
+        result._update_contributed_stats({"stat_a": 10.0})  # overwrite
+
+        output = UPath(tmp_path / "out")
+        result.save(output)
+
+        loaded = Result.load(output, load_responses=True)
+        assert loaded.stats["stat_a"] == 10.0
+        assert loaded.stats["stat_b"] == 2.0

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -997,3 +997,208 @@ async def test_count_tokens_from_q_with_custom_output_path(run: _Run, tmp_path: 
 
 
 # Add more tests for edge cases and other methods as needed
+
+
+# ── Time-bound (run_duration) tests ──────────────────────────────────────────
+
+
+def test_run_duration_and_n_requests_mutually_exclusive(
+    mock_endpoint: Endpoint, mock_tokenizer: MagicMock
+):
+    """Setting both n_requests and run_duration should raise ValueError."""
+    with pytest.raises(ValueError, match="Cannot set both"):
+        _Run(
+            endpoint=mock_endpoint,
+            tokenizer=mock_tokenizer,
+            payload=[{"prompt": "test"}],
+            n_requests=10,
+            run_duration=5,
+            clients=1,
+            run_name="test_run",
+        )
+
+
+def test_run_duration_sets_time_bound_flag(
+    mock_endpoint: Endpoint, mock_tokenizer: MagicMock
+):
+    """When run_duration is set, _time_bound should be True and _n_requests 0."""
+    run = _Run(
+        endpoint=mock_endpoint,
+        tokenizer=mock_tokenizer,
+        payload=[{"prompt": "test"}],
+        run_duration=5,
+        clients=1,
+        run_name="test_run",
+    )
+    assert run._time_bound is True
+    assert run._n_requests == 0
+
+
+def test_n_requests_sets_count_bound(
+    mock_endpoint: Endpoint, mock_tokenizer: MagicMock
+):
+    """When n_requests is set (no run_duration), _time_bound should be False."""
+    run = _Run(
+        endpoint=mock_endpoint,
+        tokenizer=mock_tokenizer,
+        payload=[{"prompt": "test"}],
+        n_requests=10,
+        clients=1,
+        run_name="test_run",
+    )
+    assert run._time_bound is False
+    assert run._n_requests == 10
+
+
+def test_run_duration_must_be_positive(
+    mock_endpoint: Endpoint, mock_tokenizer: MagicMock
+):
+    """run_duration must be > 0."""
+    with pytest.raises(AssertionError, match="positive"):
+        _Run(
+            endpoint=mock_endpoint,
+            tokenizer=mock_tokenizer,
+            payload=[{"prompt": "test"}],
+            run_duration=-1,
+            clients=1,
+            run_name="test_run",
+        )
+
+
+def test_invoke_for_duration_respects_deadline(
+    mock_endpoint: Endpoint, mock_tokenizer: MagicMock
+):
+    """_invoke_for_duration should stop after the specified duration."""
+    run = _Run(
+        endpoint=mock_endpoint,
+        tokenizer=mock_tokenizer,
+        payload=[{"prompt": "test"}],
+        run_duration=0.5,
+        clients=1,
+        run_name="test_run",
+    )
+    run.callbacks = None
+    run._queue = MagicMock()
+    run._queue._loop.call_soon_threadsafe = MagicMock()
+
+    # Make invoke take ~100ms so we get a handful of requests
+    def slow_invoke(payload):
+        time.sleep(0.1)
+        return InvocationResponse(id="1", input_prompt="test", response_text="response")
+
+    run._endpoint.invoke.side_effect = slow_invoke
+
+    start = time.perf_counter()
+    responses = run._invoke_for_duration(payload=[{"prompt": "test"}], duration=0.5)
+    elapsed = time.perf_counter() - start
+
+    assert len(responses) > 0
+    assert elapsed < 1.0  # Should not overshoot by much
+    assert all(isinstance(r, InvocationResponse) for r in responses)
+
+
+def test_invoke_for_duration_cycles_payloads(
+    mock_endpoint: Endpoint, mock_tokenizer: MagicMock
+):
+    """_invoke_for_duration should cycle through payloads."""
+    run = _Run(
+        endpoint=mock_endpoint,
+        tokenizer=mock_tokenizer,
+        payload=[{"prompt": "a"}, {"prompt": "b"}],
+        run_duration=0.3,
+        clients=1,
+        run_name="test_run",
+    )
+    run.callbacks = None
+    run._queue = MagicMock()
+    run._queue._loop.call_soon_threadsafe = MagicMock()
+
+    payloads_seen = []
+
+    def tracking_invoke(payload):
+        payloads_seen.append(payload)
+        return InvocationResponse(id="1", input_prompt=str(payload), response_text="ok")
+
+    run._endpoint.invoke.side_effect = tracking_invoke
+
+    responses = run._invoke_for_duration(
+        payload=[{"prompt": "a"}, {"prompt": "b"}],
+        duration=0.3,
+        shuffle_order=False,
+    )
+
+    assert len(responses) >= 2
+    # Should see both payloads used (cycling)
+    prompts = [p.get("prompt") for p in payloads_seen]
+    assert "a" in prompts
+    assert "b" in prompts
+
+
+@pytest.mark.asyncio
+async def test_run_with_duration(runner: Runner):
+    """Full run() with run_duration should complete and report actual counts."""
+    result = await runner.run(
+        payload={"prompt": "test"},
+        run_duration=0.3,
+        clients=1,
+    )
+
+    assert result.total_requests > 0
+    assert result.n_requests > 0
+    assert result.total_test_time is not None
+    assert result.total_test_time > 0
+    assert result.stats["total_requests"] == result.total_requests
+
+
+@pytest.mark.asyncio
+async def test_run_with_duration_multiple_clients(runner: Runner):
+    """Time-bound run with multiple clients should aggregate counts."""
+    result = await runner.run(
+        payload={"prompt": "test"},
+        run_duration=0.3,
+        clients=3,
+    )
+
+    assert result.total_requests > 0
+    assert result.clients == 3
+    assert result.total_test_time is not None
+
+
+@pytest.mark.asyncio
+async def test_run_with_duration_and_output_path(runner: Runner, tmp_path: Path):
+    """Time-bound run with output_path should save results to disk."""
+    result = await runner.run(
+        payload={"prompt": "test"},
+        run_duration=0.3,
+        clients=1,
+        output_path=tmp_path / "duration_run",
+        run_name="dur_test",
+    )
+
+    assert result.output_path is not None
+    assert (tmp_path / "duration_run" / "responses.jsonl").exists()
+    assert (tmp_path / "duration_run" / "summary.json").exists()
+    assert (tmp_path / "duration_run" / "stats.json").exists()
+
+
+def test_prepare_run_with_duration(runner: Runner):
+    """_prepare_run should pass run_duration through to _Run."""
+    run = runner._prepare_run(
+        payload={"prompt": "test"},
+        run_duration=30,
+        clients=2,
+    )
+    assert run._time_bound is True
+    assert run.run_duration == 30
+    assert run._n_requests == 0
+
+
+def test_prepare_run_duration_and_n_requests_conflict(runner: Runner):
+    """_prepare_run should raise when both are set."""
+    with pytest.raises(ValueError, match="Cannot set both"):
+        runner._prepare_run(
+            payload={"prompt": "test"},
+            n_requests=10,
+            run_duration=30,
+            clients=2,
+        )

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -70,11 +70,11 @@ def run(mock_endpoint: MagicMock, mock_tokenizer: MagicMock):
     mock_run._queue = AsyncMock()
     mock_run._queue.task_done = MagicMock()
 
-    # Mock the _invoke_n_c method to return a simple result
-    async def mock_invoke_n_c(payload, n_requests, clients):
+    # Mock the _invoke_clients method to return a simple result
+    async def mock_invoke_clients(payload, n_requests=None, duration=None, clients=1):
         return 1.0, [], []
 
-    mock_run._invoke_n_c = mock_invoke_n_c
+    mock_run._invoke_clients = mock_invoke_clients
 
     # Mock the _process_results_from_q method
     async def mock_process_results_from_q(output_path=None):
@@ -126,7 +126,7 @@ async def test_invoke_n(run: _Run):
         ]
     )
 
-    result = await run._invoke_n(
+    result = await run._invoke_client(
         payload=[{"prompt": "test1"}, {"prompt": "test2"}], n=2
     )
 
@@ -180,7 +180,7 @@ async def test_invoke_n_no_wait(run: _Run):
 @pytest.mark.asyncio
 async def test_invoke_n_c(run: _Run):
     # Remove the fixture override and create a proper mock
-    async def mock_invoke_n_c(payload, n_requests, clients):
+    async def mock_invoke_clients(payload, n_requests=None, duration=None, clients=1):
         # Simulate the actual behavior
         responses = [
             InvocationResponse(id="1", input_prompt="test1", response_text="response1"),
@@ -189,9 +189,9 @@ async def test_invoke_n_c(run: _Run):
         return 1.5, responses, []  # total_time, responses, errors
 
     # Replace the fixture mock with our test-specific mock
-    run._invoke_n_c = mock_invoke_n_c
+    run._invoke_clients = mock_invoke_clients
 
-    total_test_time, responses, _ = await run._invoke_n_c(
+    total_test_time, responses, _ = await run._invoke_clients(
         payload=[{"prompt": "test"}], n_requests=2, clients=1
     )
 
@@ -238,7 +238,7 @@ async def test_run_with_output_path(runner: Runner, tmp_path: Path):
 
 @pytest.mark.asyncio
 async def test_run_error_handling(run: _Run):
-    run._invoke_n_c = AsyncMock(side_effect=Exception("Test error"))
+    run._invoke_clients = AsyncMock(side_effect=Exception("Test error"))
     run._process_results_from_q = AsyncMock()
 
     with pytest.raises(Exception, match="Test error"):
@@ -432,7 +432,7 @@ def test_run_output_path(runner: Runner, tmp_path: Path):
 @pytest.mark.asyncio
 async def test_invoke_n_edge_cases(run: _Run):
     # Test with empty payload
-    result = await run._invoke_n(payload=[], n=5)
+    result = await run._invoke_client(payload=[], n=5)
     assert not result
 
     # Test with n=None (should use all payloads)
@@ -442,7 +442,7 @@ async def test_invoke_n_edge_cases(run: _Run):
             InvocationResponse(id="2", input_prompt="test2", response_text="response2"),
         ]
     )
-    result = await run._invoke_n(
+    result = await run._invoke_client(
         payload=[{"prompt": "test1"}, {"prompt": "test2"}], n=None
     )
     assert len(result) == 2
@@ -535,7 +535,9 @@ def test_prepare_run_combinations(
     )
 
     assert isinstance(run.payload, list)
-    assert run.n_requests == n_requests
+    # When n_requests is None, it defaults to len(payload)
+    expected_n = n_requests if n_requests is not None else len(run.payload)
+    assert run.n_requests == expected_n
     assert run.clients == clients
     assert run.output_path == (Path(output_path) if output_path else None)
     assert run.run_name is not None
@@ -566,7 +568,9 @@ async def test_run_with_different_payloads(
 
 @pytest.mark.asyncio
 async def test_invoke_n_c_concurrent_execution(run: _Run):
-    async def mock_invoke_n(payload, n, add_start_jitter=True, shuffle_order=True):
+    async def mock_invoke_client(
+        payload, n=None, duration=None, add_start_jitter=True, shuffle_order=True
+    ):
         await asyncio.sleep(0.1)  # Simulate some processing time
         return [
             InvocationResponse(
@@ -575,10 +579,10 @@ async def test_invoke_n_c_concurrent_execution(run: _Run):
             for i in range(n)
         ]
 
-    run._invoke_n = mock_invoke_n  # type: ignore
+    run._invoke_client = mock_invoke_client  # type: ignore
 
     start_time = time.perf_counter()
-    total_test_time, _, _ = await run._invoke_n_c(
+    total_test_time, _, _ = await run._invoke_clients(
         payload=[{"prompt": "test"}], n_requests=5, clients=3
     )
     end_time = time.perf_counter()
@@ -757,7 +761,9 @@ def test_prepare_run_more_edge_cases(
     )
 
     assert isinstance(run_config.payload, list)
-    assert run_config.n_requests == n_requests
+    # When n_requests is None, it defaults to len(payload)
+    expected_n = n_requests if n_requests is not None else len(run_config.payload)
+    assert run_config.n_requests == expected_n
     assert run_config.clients == clients if clients is not None else 1
     assert run_config.output_path == (Path(output_path) if output_path else None)
     assert run_config.run_name is not None
@@ -806,7 +812,9 @@ async def test_run_with_optional_parameters(
 async def test_invoke_n_c_with_different_clients(
     run: _Run, clients: Literal[1] | Literal[3] | Literal[5] | Literal[10]
 ):
-    async def mock_invoke_n(payload, n, add_start_jitter=True, shuffle_order=True):
+    async def mock_invoke_client(
+        payload, n=None, duration=None, add_start_jitter=True, shuffle_order=True
+    ):
         await asyncio.sleep(0.1)  # Simulate some processing time
         return [
             InvocationResponse(
@@ -815,10 +823,10 @@ async def test_invoke_n_c_with_different_clients(
             for i in range(n)
         ]
 
-    run._invoke_n = mock_invoke_n  # type: ignore
+    run._invoke_client = mock_invoke_client  # type: ignore
 
     start_time = time.perf_counter()
-    total_test_time, _, _ = await run._invoke_n_c(
+    total_test_time, _, _ = await run._invoke_clients(
         payload=[{"prompt": "test"}], n_requests=5, clients=clients
     )
     end_time = time.perf_counter()
@@ -956,7 +964,7 @@ async def test_invoke_n_with_different_options(
         ]
     )
 
-    result = await run._invoke_n(
+    result = await run._invoke_client(
         payload=[{"prompt": "test1"}, {"prompt": "test2"}],
         n=2,
         shuffle_order=shuffle_order,
@@ -965,7 +973,7 @@ async def test_invoke_n_with_different_options(
 
     assert len(result) == 2
     run._invoke_n_no_wait.assert_called_once_with(
-        [{"prompt": "test1"}, {"prompt": "test2"}], 2, shuffle_order
+        [{"prompt": "test1"}, {"prompt": "test2"}], 2, None, shuffle_order
     )
 
 
@@ -1021,7 +1029,7 @@ def test_run_duration_and_n_requests_mutually_exclusive(
 def test_run_duration_sets_time_bound_flag(
     mock_endpoint: Endpoint, mock_tokenizer: MagicMock
 ):
-    """When run_duration is set, _time_bound should be True and _n_requests 0."""
+    """When run_duration is set, _time_bound should be True and n_requests 0."""
     run = _Run(
         endpoint=mock_endpoint,
         tokenizer=mock_tokenizer,
@@ -1031,7 +1039,7 @@ def test_run_duration_sets_time_bound_flag(
         run_name="test_run",
     )
     assert run._time_bound is True
-    assert run._n_requests == 0
+    assert run.n_requests == 0
 
 
 def test_n_requests_sets_count_bound(
@@ -1047,7 +1055,7 @@ def test_n_requests_sets_count_bound(
         run_name="test_run",
     )
     assert run._time_bound is False
-    assert run._n_requests == 10
+    assert run.n_requests == 10
 
 
 def test_run_duration_must_be_positive(
@@ -1068,7 +1076,7 @@ def test_run_duration_must_be_positive(
 def test_invoke_for_duration_respects_deadline(
     mock_endpoint: Endpoint, mock_tokenizer: MagicMock
 ):
-    """_invoke_for_duration should stop after the specified duration."""
+    """_invoke_n_no_wait with duration should stop after the specified duration."""
     run = _Run(
         endpoint=mock_endpoint,
         tokenizer=mock_tokenizer,
@@ -1089,7 +1097,7 @@ def test_invoke_for_duration_respects_deadline(
     run._endpoint.invoke.side_effect = slow_invoke
 
     start = time.perf_counter()
-    responses = run._invoke_for_duration(payload=[{"prompt": "test"}], duration=0.5)
+    responses = run._invoke_n_no_wait(payload=[{"prompt": "test"}], duration=0.5)
     elapsed = time.perf_counter() - start
 
     assert len(responses) > 0
@@ -1100,7 +1108,7 @@ def test_invoke_for_duration_respects_deadline(
 def test_invoke_for_duration_cycles_payloads(
     mock_endpoint: Endpoint, mock_tokenizer: MagicMock
 ):
-    """_invoke_for_duration should cycle through payloads."""
+    """_invoke_n_no_wait with duration should cycle through payloads."""
     run = _Run(
         endpoint=mock_endpoint,
         tokenizer=mock_tokenizer,
@@ -1121,7 +1129,7 @@ def test_invoke_for_duration_cycles_payloads(
 
     run._endpoint.invoke.side_effect = tracking_invoke
 
-    responses = run._invoke_for_duration(
+    responses = run._invoke_n_no_wait(
         payload=[{"prompt": "a"}, {"prompt": "b"}],
         duration=0.3,
         shuffle_order=False,
@@ -1190,7 +1198,7 @@ def test_prepare_run_with_duration(runner: Runner):
     )
     assert run._time_bound is True
     assert run.run_duration == 30
-    assert run._n_requests == 0
+    assert run.n_requests == 0
 
 
 def test_prepare_run_duration_and_n_requests_conflict(runner: Runner):

--- a/tests/unit/test_running_stats.py
+++ b/tests/unit/test_running_stats.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import time
+from datetime import datetime, timezone
 
 import pytest
 
@@ -32,6 +32,7 @@ def populated_rs(rs):
             "num_tokens_input": 100,
             "num_tokens_output": 25,
             "error": None,
+            "request_time": datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
         },
         {
             "time_to_first_token": 0.5,
@@ -40,6 +41,7 @@ def populated_rs(rs):
             "num_tokens_input": 120,
             "num_tokens_output": 30,
             "error": None,
+            "request_time": datetime(2026, 1, 1, 12, 0, 5, tzinfo=timezone.utc),
         },
         {
             "time_to_first_token": 0.4,
@@ -48,38 +50,40 @@ def populated_rs(rs):
             "num_tokens_input": 110,
             "num_tokens_output": 28,
             "error": "timeout",
+            "request_time": datetime(2026, 1, 1, 12, 0, 10, tzinfo=timezone.utc),
         },
     ]
     for r in responses:
-        rs.record_send()
         rs.update(r)
     return rs
 
 
-# ── record_send ──────────────────────────────────────────────────────────────
+# ── request_time tracking ────────────────────────────────────────────────────
 
 
-class TestRecordSend:
-    def test_first_send_sets_first_time(self, rs):
+class TestRequestTimeTracking:
+    def test_first_update_sets_first_send_time(self, rs):
         assert rs._first_send_time is None
-        rs.record_send()
-        assert rs._first_send_time is not None
-        assert rs._last_send_time is not None
-        assert rs._sends == 1
+        t = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        rs.update({"time_to_first_token": 0.3, "error": None, "request_time": t})
+        assert rs._first_send_time == t
+        assert rs._last_send_time == t
 
-    def test_subsequent_sends_update_last_time(self, rs):
-        rs.record_send()
-        first = rs._first_send_time
-        time.sleep(0.01)
-        rs.record_send()
-        assert rs._first_send_time == first
-        assert rs._last_send_time > first
-        assert rs._sends == 2
+    def test_subsequent_updates_track_min_max(self, rs):
+        t1 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc)
+        rs.update({"error": None, "request_time": t1})
+        rs.update({"error": None, "request_time": t2})
+        assert rs._first_send_time == t1
+        assert rs._last_send_time == t2
 
-    def test_send_count_increments(self, rs):
-        for _ in range(5):
-            rs.record_send()
-        assert rs._sends == 5
+    def test_out_of_order_timestamps(self, rs):
+        t1 = datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        rs.update({"error": None, "request_time": t1})
+        rs.update({"error": None, "request_time": t2})
+        assert rs._first_send_time == t2  # min
+        assert rs._last_send_time == t1  # max
 
 
 # ── update ───────────────────────────────────────────────────────────────────
@@ -130,12 +134,13 @@ class TestToStats:
         assert "num_tokens_output-p90" in stats
 
     def test_with_run_context(self, populated_rs):
+        end_time = datetime(2026, 1, 1, 12, 0, 10, tzinfo=timezone.utc)
         stats = populated_rs.to_stats(
-            total_requests=3,
-            total_test_time=10.0,
+            end_time=end_time,
             result_dict={"model_id": "test"},
         )
         assert stats["model_id"] == "test"
+        # 3 responses over 10 second send window = 18 rpm
         assert stats["requests_per_minute"] == pytest.approx(18.0)
         assert stats["failed_requests_rate"] == pytest.approx(1 / 3)
         assert stats["total_output_tokens"] == 83
@@ -157,42 +162,48 @@ class TestToStats:
 
 class TestSendWindowStats:
     def test_rpm_uses_send_window(self, rs):
-        rs._first_send_time = 100.0
-        rs._last_send_time = 110.0  # 10 second window
-        rs.update({"error": None})
-        rs.update({"error": None})
-        rs.update({"error": None})
+        t1 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 1, 12, 0, 10, tzinfo=timezone.utc)  # 10 second window
+        rs.update({"error": None, "request_time": t1})
+        rs.update(
+            {
+                "error": None,
+                "request_time": datetime(2026, 1, 1, 12, 0, 5, tzinfo=timezone.utc),
+            }
+        )
+        rs.update({"error": None, "request_time": t2})
         stats = rs.to_stats()
         # 3 responses / 10 seconds * 60 = 18.0 rpm
-        assert stats["rpm"] == pytest.approx(18.0)
+        assert stats["requests_per_minute"] == pytest.approx(18.0)
 
-    def test_output_tps_uses_send_window(self, rs):
-        rs._first_send_time = 100.0
-        rs._last_send_time = 110.0  # 10 second window
-        rs.update({"num_tokens_output": 500, "error": None})
-        rs.update({"num_tokens_output": 300, "error": None})
-        stats = rs.to_stats()
+    def test_output_tps_uses_end_time(self, rs):
+        t1 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 1, 12, 0, 10, tzinfo=timezone.utc)  # 10 second window
+        end = datetime(2026, 1, 1, 12, 0, 10, tzinfo=timezone.utc)
+        rs.update({"num_tokens_output": 500, "error": None, "request_time": t1})
+        rs.update({"num_tokens_output": 300, "error": None, "request_time": t2})
+        stats = rs.to_stats(end_time=end)
         # 800 tokens / 10 seconds = 80.0 tok/s
         assert stats["output_tps"] == pytest.approx(80.0)
 
-    def test_no_send_window_when_single_send(self, rs):
-        """With only one send, first == last, no window to compute RPM."""
-        rs._first_send_time = 100.0
-        rs._last_send_time = 100.0
-        rs.update({"error": None})
+    def test_no_send_window_when_single_request(self, rs):
+        """With only one request, first == last, no window to compute RPM."""
+        t = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        rs.update({"error": None, "request_time": t})
         stats = rs.to_stats()
-        assert "rpm" not in stats
+        assert "requests_per_minute" not in stats
         assert "output_tps" not in stats
 
-    def test_no_send_window_when_no_sends(self, rs):
+    def test_no_send_window_when_no_requests(self, rs):
         stats = rs.to_stats()
-        assert "rpm" not in stats
+        assert "requests_per_minute" not in stats
         assert "output_tps" not in stats
 
     def test_send_window_helper(self, rs):
         assert rs._send_window() is None
-        rs._first_send_time = 10.0
-        rs._last_send_time = 10.0
+        t1 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        rs._first_send_time = t1
+        rs._last_send_time = t1
         assert rs._send_window() is None
-        rs._last_send_time = 20.0
+        rs._last_send_time = datetime(2026, 1, 1, 12, 0, 10, tzinfo=timezone.utc)
         assert rs._send_window() == pytest.approx(10.0)

--- a/tests/unit/test_running_stats.py
+++ b/tests/unit/test_running_stats.py
@@ -1,0 +1,220 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import time
+
+import pytest
+
+from llmeter.utils import RunningStats
+
+
+@pytest.fixture
+def rs():
+    return RunningStats(
+        metrics=[
+            "time_to_first_token",
+            "time_to_last_token",
+            "time_per_output_token",
+            "num_tokens_input",
+            "num_tokens_output",
+        ]
+    )
+
+
+@pytest.fixture
+def populated_rs(rs):
+    """A RunningStats with 3 responses recorded."""
+    responses = [
+        {
+            "time_to_first_token": 0.3,
+            "time_to_last_token": 0.8,
+            "time_per_output_token": 0.02,
+            "num_tokens_input": 100,
+            "num_tokens_output": 25,
+            "error": None,
+        },
+        {
+            "time_to_first_token": 0.5,
+            "time_to_last_token": 1.2,
+            "time_per_output_token": 0.03,
+            "num_tokens_input": 120,
+            "num_tokens_output": 30,
+            "error": None,
+        },
+        {
+            "time_to_first_token": 0.4,
+            "time_to_last_token": 1.0,
+            "time_per_output_token": 0.025,
+            "num_tokens_input": 110,
+            "num_tokens_output": 28,
+            "error": "timeout",
+        },
+    ]
+    for r in responses:
+        rs.record_send()
+        rs.update(r)
+    return rs
+
+
+# ── record_send ──────────────────────────────────────────────────────────────
+
+
+class TestRecordSend:
+    def test_first_send_sets_first_time(self, rs):
+        assert rs._first_send_time is None
+        rs.record_send()
+        assert rs._first_send_time is not None
+        assert rs._last_send_time is not None
+        assert rs._sends == 1
+
+    def test_subsequent_sends_update_last_time(self, rs):
+        rs.record_send()
+        first = rs._first_send_time
+        time.sleep(0.01)
+        rs.record_send()
+        assert rs._first_send_time == first
+        assert rs._last_send_time > first
+        assert rs._sends == 2
+
+    def test_send_count_increments(self, rs):
+        for _ in range(5):
+            rs.record_send()
+        assert rs._sends == 5
+
+
+# ── update ───────────────────────────────────────────────────────────────────
+
+
+class TestUpdate:
+    def test_count_increments(self, rs):
+        rs.update({"time_to_first_token": 0.3, "error": None})
+        assert rs._count == 1
+        rs.update({"time_to_first_token": 0.5, "error": None})
+        assert rs._count == 2
+
+    def test_failed_count(self, rs):
+        rs.update({"error": "timeout"})
+        rs.update({"error": None})
+        rs.update({"error": "connection refused"})
+        assert rs._failed == 2
+
+    def test_none_values_skipped(self, rs):
+        rs.update({"time_to_first_token": None, "error": None})
+        assert len(rs._values["time_to_first_token"]) == 0
+
+    def test_nan_values_skipped(self, rs):
+        rs.update({"time_to_first_token": float("nan"), "error": None})
+        assert len(rs._values["time_to_first_token"]) == 0
+
+    def test_sums_accumulated(self, rs):
+        rs.update({"num_tokens_output": 10, "error": None})
+        rs.update({"num_tokens_output": 20, "error": None})
+        assert rs._sums["num_tokens_output"] == 30
+
+    def test_values_sorted(self, rs):
+        rs.update({"time_to_first_token": 0.5, "error": None})
+        rs.update({"time_to_first_token": 0.1, "error": None})
+        rs.update({"time_to_first_token": 0.3, "error": None})
+        assert rs._values["time_to_first_token"] == [0.1, 0.3, 0.5]
+
+
+# ── to_stats ─────────────────────────────────────────────────────────────────
+
+
+class TestToStats:
+    def test_basic_stats(self, populated_rs):
+        stats = populated_rs.to_stats()
+        assert stats["failed_requests"] == 1
+        assert "time_to_first_token-p50" in stats
+        assert "time_to_last_token-average" in stats
+        assert "num_tokens_output-p90" in stats
+
+    def test_with_run_context(self, populated_rs):
+        stats = populated_rs.to_stats(
+            total_requests=3,
+            total_test_time=10.0,
+            result_dict={"model_id": "test"},
+        )
+        assert stats["model_id"] == "test"
+        assert stats["requests_per_minute"] == pytest.approx(18.0)
+        assert stats["failed_requests_rate"] == pytest.approx(1 / 3)
+        assert stats["total_output_tokens"] == 83
+
+    def test_without_run_context(self, populated_rs):
+        stats = populated_rs.to_stats()
+        assert stats["failed_requests"] == 1
+        assert stats["total_input_tokens"] == 330
+        assert stats["total_output_tokens"] == 83
+
+    def test_empty_stats(self, rs):
+        stats = rs.to_stats()
+        assert stats["failed_requests"] == 0
+        assert stats["total_input_tokens"] == 0
+
+
+# ── snapshot ─────────────────────────────────────────────────────────────────
+
+
+class TestSnapshot:
+    def test_placeholder_when_empty(self, rs):
+        result = rs.snapshot()
+        assert all(v == "—" for v in result.values())
+        # Should have all default keys
+        assert "rpm" in result
+        assert "p50_ttft" in result
+        assert "fail" in result
+        assert "output_tps" in result
+
+    def test_placeholder_with_custom_fields(self, rs):
+        fields = {"my_rpm": "rpm", "my_fail": "failed"}
+        result = rs.snapshot(fields)
+        assert result == {"my_rpm": "—", "my_fail": "—"}
+
+    def test_failed_count(self, populated_rs):
+        result = populated_rs.snapshot({"fail": "failed"})
+        assert result["fail"] == "1"
+
+    def test_rpm_uses_send_window(self, rs):
+        rs._first_send_time = 100.0
+        rs._last_send_time = 110.0  # 10 second window
+        rs.update({"error": None})
+        rs.update({"error": None})
+        rs.update({"error": None})
+        result = rs.snapshot({"rpm": "rpm"})
+        # 3 responses / 10 seconds * 60 = 18.0 rpm
+        assert result["rpm"] == "18.0"
+
+    def test_rpm_not_shown_with_single_send(self, rs):
+        """With only one send, first == last, no window to compute RPM."""
+        rs._first_send_time = 100.0
+        rs._last_send_time = 100.0
+        rs.update({"error": None})
+        result = rs.snapshot({"rpm": "rpm"})
+        assert "rpm" not in result
+
+    def test_output_tps_uses_send_window(self, rs):
+        rs._first_send_time = 100.0
+        rs._last_send_time = 110.0  # 10 second window
+        rs.update({"num_tokens_output": 500, "error": None})
+        rs.update({"num_tokens_output": 300, "error": None})
+        result = rs.snapshot({"tps": "output_tps"})
+        # 800 tokens / 10 seconds = 80.0 tok/s
+        assert result["tps"] == "80.0 tok/s"
+
+    def test_sum_aggregation(self, populated_rs):
+        result = populated_rs.snapshot({"out": ("num_tokens_output", "sum")})
+        assert result["out"] == "83"
+
+    def test_percentile_aggregation(self, populated_rs):
+        result = populated_rs.snapshot({"p50": ("time_to_first_token", "p50")})
+        assert "p50" in result
+        assert result["p50"].endswith("s")
+
+    def test_inverse_aggregation(self, populated_rs):
+        result = populated_rs.snapshot({"tps": ("time_per_output_token", "p50", "inv")})
+        assert "tps" in result
+        assert "tok/s" in result["tps"]
+
+    def test_empty_fields_returns_empty(self, populated_rs):
+        result = populated_rs.snapshot({})
+        assert result == {}

--- a/tests/unit/test_running_stats.py
+++ b/tests/unit/test_running_stats.py
@@ -152,69 +152,47 @@ class TestToStats:
         assert stats["total_input_tokens"] == 0
 
 
-# ── snapshot ─────────────────────────────────────────────────────────────────
+# ── send-window throughput in to_stats ────────────────────────────────────────
 
 
-class TestSnapshot:
-    def test_placeholder_when_empty(self, rs):
-        result = rs.snapshot()
-        assert all(v == "—" for v in result.values())
-        # Should have all default keys
-        assert "rpm" in result
-        assert "p50_ttft" in result
-        assert "fail" in result
-        assert "output_tps" in result
-
-    def test_placeholder_with_custom_fields(self, rs):
-        fields = {"my_rpm": "rpm", "my_fail": "failed"}
-        result = rs.snapshot(fields)
-        assert result == {"my_rpm": "—", "my_fail": "—"}
-
-    def test_failed_count(self, populated_rs):
-        result = populated_rs.snapshot({"fail": "failed"})
-        assert result["fail"] == "1"
-
+class TestSendWindowStats:
     def test_rpm_uses_send_window(self, rs):
         rs._first_send_time = 100.0
         rs._last_send_time = 110.0  # 10 second window
         rs.update({"error": None})
         rs.update({"error": None})
         rs.update({"error": None})
-        result = rs.snapshot({"rpm": "rpm"})
+        stats = rs.to_stats()
         # 3 responses / 10 seconds * 60 = 18.0 rpm
-        assert result["rpm"] == "18.0"
-
-    def test_rpm_not_shown_with_single_send(self, rs):
-        """With only one send, first == last, no window to compute RPM."""
-        rs._first_send_time = 100.0
-        rs._last_send_time = 100.0
-        rs.update({"error": None})
-        result = rs.snapshot({"rpm": "rpm"})
-        assert "rpm" not in result
+        assert stats["rpm"] == pytest.approx(18.0)
 
     def test_output_tps_uses_send_window(self, rs):
         rs._first_send_time = 100.0
         rs._last_send_time = 110.0  # 10 second window
         rs.update({"num_tokens_output": 500, "error": None})
         rs.update({"num_tokens_output": 300, "error": None})
-        result = rs.snapshot({"tps": "output_tps"})
+        stats = rs.to_stats()
         # 800 tokens / 10 seconds = 80.0 tok/s
-        assert result["tps"] == "80.0 tok/s"
+        assert stats["output_tps"] == pytest.approx(80.0)
 
-    def test_sum_aggregation(self, populated_rs):
-        result = populated_rs.snapshot({"out": ("num_tokens_output", "sum")})
-        assert result["out"] == "83"
+    def test_no_send_window_when_single_send(self, rs):
+        """With only one send, first == last, no window to compute RPM."""
+        rs._first_send_time = 100.0
+        rs._last_send_time = 100.0
+        rs.update({"error": None})
+        stats = rs.to_stats()
+        assert "rpm" not in stats
+        assert "output_tps" not in stats
 
-    def test_percentile_aggregation(self, populated_rs):
-        result = populated_rs.snapshot({"p50": ("time_to_first_token", "p50")})
-        assert "p50" in result
-        assert result["p50"].endswith("s")
+    def test_no_send_window_when_no_sends(self, rs):
+        stats = rs.to_stats()
+        assert "rpm" not in stats
+        assert "output_tps" not in stats
 
-    def test_inverse_aggregation(self, populated_rs):
-        result = populated_rs.snapshot({"tps": ("time_per_output_token", "p50", "inv")})
-        assert "tps" in result
-        assert "tok/s" in result["tps"]
-
-    def test_empty_fields_returns_empty(self, populated_rs):
-        result = populated_rs.snapshot({})
-        assert result == {}
+    def test_send_window_helper(self, rs):
+        assert rs._send_window() is None
+        rs._first_send_time = 10.0
+        rs._last_send_time = 10.0
+        assert rs._send_window() is None
+        rs._last_send_time = 20.0
+        assert rs._send_window() == pytest.approx(10.0)

--- a/tests/unit/test_serialization_properties.py
+++ b/tests/unit/test_serialization_properties.py
@@ -20,7 +20,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 from hypothesis.strategies import composite
 
-from llmeter.json_utils import llmeter_default_serializer, llmeter_bytes_decoder
+from llmeter.json_utils import llmeter_bytes_decoder, llmeter_default_serializer
 
 # Test infrastructure is set up and ready for property test implementation
 # This file will contain property-based tests for:


### PR DESCRIPTION
Closes #57, closes #60

## What

Adds time-bound test runs, a live stats display, send-window-based throughput metrics, standardized endpoint invoke lifecycle, prompt caching support, and fixes a `StopIteration` bug in invocation loops.

This PR combines the original time-bound runs feature with the endpoint lifecycle refactor (previously PR #61).

## Endpoint lifecycle refactor

The `Endpoint` base class now provides a structured invoke lifecycle via `__init_subclass__` wrapping:

| Method | Required | Purpose |
|--------|----------|---------|
| `invoke(payload)` | Yes | API call + `parse_response()` |
| `parse_response(raw_response, start_t)` | Yes | Extract text, tokens, metadata |
| `prepare_payload(payload, **kwargs)` | No | Merge kwargs, inject model_id, etc. |

The wrapper automatically handles:
- **Error handling** — exceptions → error `InvocationResponse` with payload attached
- **Timing** — `time_to_last_token` back-filled for non-streaming endpoints
- **Metadata** — `input_payload`, `input_prompt`, `id`, `request_time` always populated
- **`_parse_payload`** — extracts human-readable prompt for observability and token counting fallback

### Before/after (e.g. `OpenAIResponseEndpoint.invoke`)

**Before** (27 lines with 5 duplicate except handlers):
```python
def invoke(self, payload, **kwargs):
    payload = {**kwargs, **payload}
    payload["model"] = self.model_id
    start_t = time.perf_counter()
    try:
        client_response = self._client.responses.create(**payload)
    except APIConnectionError as e:
        ...  # 5 identical except blocks
    response = self._parse_response(client_response, start_t)
    response.input_payload = payload
    response.input_prompt = self._parse_payload(payload)
    return response
```

**After** (3 lines):
```python
def invoke(self, payload):
    client_response = self._client.responses.create(**payload)
    return self.parse_response(client_response, self._start_t)
```

## New InvocationResponse fields

- **`request_time`** (datetime UTC) — wall-clock time when the request was sent
- **`num_tokens_input_cached`** — input tokens served from prompt cache (Bedrock + OpenAI)

## Time-bound runs & live stats

- `run_duration` parameter for continuous-duration runs (mutually exclusive with `n_requests`)
- `LiveStatsDisplay` for real-time progress in Jupyter and terminals
- `RunningStats` for incremental stat accumulation
- `low_memory` mode that discards individual responses after stats extraction
- RPM and throughput computed from request timestamps (send window), not response timestamps

## Stats computation changes

- `RunningStats.to_stats()` takes `end_time` (datetime) instead of `total_requests`/`total_test_time`
- RPM uses request send window (`first_request_time` to `last_request_time`)
- Output rates use `[first_request, end_time]` window
- `Result` gains `first_request_time` / `last_request_time` fields

## Additional improvements

- Extract AWS `RequestId` as response ID for all Bedrock and SageMaker endpoints
- Extract `RetryAttempts` for SageMaker (Bedrock already had this)
- Preserve partial data on streaming errors instead of discarding
- `BEDROCK_STREAM_ERROR_TYPES` as shared constant
- Skip unknown stream events gracefully (forward-compatible)
- Prompt caching demo notebook with `CacheBuster` callback
- Updated docs: metrics table, key concepts, custom endpoint guide, run experiments

## Tests

- 751 unit tests pass
- 6 new mid-stream error tests (TimeoutError, ConnectionError across 3 streaming endpoints)
- Integration tests with `request_time` and AWS RequestId assertions
- Prompt caching integration test with unique-per-run prefix
