### PR TITLE
Standardize Endpoint invoke lifecycle with centralized error handling

### DIFF
--- a/docs/user_guide/connect_endpoints.md
+++ b/docs/user_guide/connect_endpoints.md
@@ -14,6 +14,49 @@ The [endpoints](../reference/endpoints/index.md) section of the API reference li
 
 You can also **create your own integrations** by extending the [`Endpoint`](../reference/endpoints/base.md#llmeter.endpoints.base.Endpoint) class interface, if your target isn't already supported by the built-in endpoints or through the [LiteLLM Endpoint](../reference/endpoints/litellm.md) and [LiteLLM Python SDK](https://docs.litellm.ai/#basic-usage).
 
+### Custom endpoint example
+
+To create a custom endpoint, implement three methods:
+
+- **`invoke(payload)`** — call the API and pass the raw response to `parse_response()`
+- **`parse_response(raw_response, start_t)`** — extract text, token counts, and metadata into an `InvocationResponse`
+- **`prepare_payload(payload, **kwargs)`** *(optional)* — transform the caller's payload before invocation (merge kwargs, inject model ID, etc.)
+
+The base class automatically wraps `invoke` with error handling, timing, and metadata back-fill, so your implementation only needs the happy path:
+
+```python
+from llmeter.endpoints.base import Endpoint, InvocationResponse
+
+class MyEndpoint(Endpoint):
+    def __init__(self, model_id: str, api_key: str):
+        super().__init__(
+            endpoint_name="my-service",
+            model_id=model_id,
+            provider="my-provider",
+        )
+        self._api_key = api_key
+
+    def invoke(self, payload: dict) -> InvocationResponse:
+        raw_response = my_api_call(payload, api_key=self._api_key)
+        return self.parse_response(raw_response, self._start_t)
+
+    def parse_response(self, raw_response, start_t: float) -> InvocationResponse:
+        return InvocationResponse(
+            response_text=raw_response["text"],
+            num_tokens_input=raw_response.get("input_tokens"),
+            num_tokens_output=raw_response.get("output_tokens"),
+        )
+
+    def prepare_payload(self, payload, **kwargs):
+        return {**payload, **kwargs, "model": self.model_id}
+
+    @staticmethod
+    def create_payload(user_message: str, max_tokens: int = 256) -> dict:
+        return {"prompt": user_message, "max_tokens": max_tokens}
+```
+
+You don't need to handle errors, set `time_to_last_token`, `input_payload`, `input_prompt`, or `id` — the base class does all of that. If your `invoke` or `parse_response` raises an exception, it's caught and converted to an error `InvocationResponse` with the prepared payload attached.
+
 Note that [Amazon Bedrock](https://aws.amazon.com/bedrock/) supports several different APIs for accessing Foundation Models. Depending on your target API, you can use LLMeter's:
 
 - [`bedrock`](../reference/endpoints/bedrock.md) endpoints for connecting to Bedrock's [Converse](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html) or [ConverseStream](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html) APIs

--- a/docs/user_guide/key_concepts.md
+++ b/docs/user_guide/key_concepts.md
@@ -4,7 +4,15 @@ To break down the complex task of performance testing in a modular way, LLMeter 
 
 ## [Endpoint](connect_endpoints.md): An instrumented LLM/API
 
-An `Endpoint` is the Python interface through which LLMeter connects to whatever model or API you want to evaluate. It provides an `invoke()` method which calls the model, but also stores metadata like the time the request took to process and number of input/output tokens consumed.
+An `Endpoint` is the Python interface through which LLMeter connects to whatever model or API you want to evaluate. It provides an `invoke()` method which calls the model, and automatically captures metadata like request timing, token counts, and error information in an [`InvocationResponse`](../reference/endpoints/base.md#llmeter.endpoints.base.InvocationResponse).
+
+The base `Endpoint` class handles common concerns (error handling, timing, metadata) automatically via an invoke lifecycle:
+
+1. **`prepare_payload(payload, **kwargs)`** — merges caller kwargs and injects provider-specific fields (model ID, streaming options, etc.)
+2. **`invoke(payload)`** — makes the API call and delegates to `parse_response()`
+3. **`parse_response(raw_response, start_t)`** — extracts text, token counts, and other metadata from the provider's raw response
+
+Subclasses implement these three methods with their provider-specific logic. The base class wraps `invoke` with standardized error handling, timing (`time_to_last_token`), and metadata back-fill (`input_payload`, `input_prompt`, `id`), so individual endpoints don't need to duplicate that boilerplate.
 
 LLMeter provides a [range of built-in Endpoint connectors](connect_endpoints.md) for different types of Cloud-deployed or local LLM, or you can also define your own custom integrations.
 

--- a/docs/user_guide/metrics.md
+++ b/docs/user_guide/metrics.md
@@ -121,12 +121,13 @@ After a batch of requests completes, the `Runner` computes aggregate statistics 
 | `failed_requests_rate` | Ratio of failed requests to total requests (0.0 to 1.0). |
 | `total_input_tokens` | Sum of `num_tokens_input` across all requests. |
 | `total_output_tokens` | Sum of `num_tokens_output` across all requests. |
+| `total_cached_input_tokens` | Sum of `num_tokens_input_cached` across all requests. Only non-zero when prompt caching is active. |
 | `average_input_tokens_per_minute` | Total input tokens divided by test time, scaled to per-minute rate. |
 | `average_output_tokens_per_minute` | Total output tokens divided by test time, scaled to per-minute rate. |
 
 #### Distribution statistics
 
-For each of the four core per-request metrics (`time_to_last_token`, `time_to_first_token`, `num_tokens_output`, `num_tokens_input`), LLMeter computes distributional aggregates across all successful responses. Each metric gets the following aggregations, accessible as `{metric}-{aggregation}` keys in `Result.stats`:
+For each of the five core per-request metrics (`time_to_last_token`, `time_to_first_token`, `num_tokens_output`, `num_tokens_input`, `num_tokens_input_cached`), LLMeter computes distributional aggregates across all successful responses. Each metric gets the following aggregations, accessible as `{metric}-{aggregation}` keys in `Result.stats`:
 
 | Aggregation | Key suffix | Description |
 | --- | --- | --- |

--- a/docs/user_guide/metrics.md
+++ b/docs/user_guide/metrics.md
@@ -95,12 +95,18 @@ Each request produces an `InvocationResponse` with:
 
 | Field | Unit | Description |
 | --- | --- | --- |
+| `response_text` | string | The generated text from the model. `None` on error. |
+| `id` | string | A unique identifier for the invocation. Extracted from the API response when available (e.g. OpenAI response ID, AWS RequestId), otherwise auto-generated. |
 | `time_to_first_token` | seconds | TTFT. Only populated for streaming endpoints. |
 | `time_to_last_token` | seconds | TTLT. Always populated on successful requests. |
 | `time_per_output_token` | seconds | TPOT. Only available when `num_tokens_output > 1`. |
 | `num_tokens_input` | count | Input token count. Reported by the endpoint or estimated by a tokenizer configured on the `Runner`. |
 | `num_tokens_output` | count | Output token count. Reported by the endpoint or estimated by a tokenizer configured on the `Runner`. |
-| `error` | string | Error message if the request failed, `None` otherwise. |
+| `num_tokens_input_cached` | count | Input tokens served from prompt cache. Reported by Bedrock (`cacheReadInputTokens`) and OpenAI (`cached_tokens`). `None` when caching is not active. |
+| `input_payload` | dict | The full API request payload as sent to the provider (after `prepare_payload` processing). |
+| `input_prompt` | string | The user-facing input text extracted from the payload, used for observability and as a token-counting fallback. |
+| `error` | string | Error message if the request failed, `None` otherwise. Partial data (text, timing) may still be present alongside an error for streaming endpoints that fail mid-stream. |
+| `retries` | count | Number of retries attempted by the underlying SDK. Reported by AWS endpoints (Bedrock, SageMaker) via `ResponseMetadata.RetryAttempts`. `None` for providers that don't expose this. |
 
 ### Run-level statistics
 

--- a/examples/Prompt caching latency.ipynb
+++ b/examples/Prompt caching latency.ipynb
@@ -1,0 +1,2734 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Measuring the latency impact of prompt caching\n",
+    "\n",
+    "This notebook demonstrates how to measure the latency benefit of [prompt caching](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html) on Amazon Bedrock using LLMeter.\n",
+    "\n",
+    "Prompt caching allows the model to skip reprocessing a static prefix (e.g. a long system prompt) on repeated requests, reducing both **time to first token (TTFT)** and **cost**. This notebook compares TTFT distributions with and without cache hits, using a `before_invoke` callback to bust the cache on demand."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install \"llmeter[plotting]<1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llmeter.endpoints import BedrockConverseStream\n",
+    "from llmeter.runner import Runner"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Choose a model that supports prompt caching. Amazon Nova models support caching with a minimum of 1024 tokens in the cached prefix. You must use an [inference profile ID](https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html) (e.g. `us.amazon.nova-lite-v1:0`), not the base model ID. See the [supported models table](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html) for details."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_id = \"us.amazon.nova-lite-v1:0\"\n",
+    "\n",
+    "endpoint = BedrockConverseStream(\n",
+    "    model_id=model_id,\n",
+    "    # region=\"us-east-1\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Building a cacheable payload\n",
+    "\n",
+    "Prompt caching requires:\n",
+    "1. A static prefix long enough to meet the model's minimum (1024 tokens for Nova)\n",
+    "2. A `cachePoint` marker after the content to cache\n",
+    "\n",
+    "We'll use a long system prompt as the cached prefix, with a short user message that varies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Build a system prompt that exceeds the 1024-token minimum.\n",
+    "# Each rule line is ~25 tokens, so 80 lines ≈ 2000 tokens.\n",
+    "long_system_text = \"You are a helpful assistant. Follow these rules:\\n\" + \"\\n\".join(\n",
+    "    f\"Rule {i}: Always be concise, accurate, and helpful in your responses. \"\n",
+    "    \"This is an important guideline that must be followed at all times.\"\n",
+    "    for i in range(1, 81)\n",
+    ")\n",
+    "\n",
+    "payload_with_cache = {\n",
+    "    \"system\": [\n",
+    "        {\"text\": long_system_text},\n",
+    "        {\"cachePoint\": {\"type\": \"default\"}},\n",
+    "    ],\n",
+    "    \"messages\": [\n",
+    "        {\n",
+    "            \"role\": \"user\",\n",
+    "            \"content\": [{\"text\": \"What is the capital of France? Answer in one word.\"}],\n",
+    "        }\n",
+    "    ],\n",
+    "    \"inferenceConfig\": {\"maxTokens\": 50},\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's verify caching works with a quick test — the first call writes to cache, the second should read from it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Call 1: TTFT=1.126s, cached_tokens=0\n",
+      "Call 2: TTFT=0.576s, cached_tokens=2435\n"
+     ]
+    }
+   ],
+   "source": [
+    "import time\n",
+    "from uuid import uuid4\n",
+    "\n",
+    "# Use a unique prefix so re-running the notebook doesn't hit a stale cache\n",
+    "verify_prefix = f\"[verify-{uuid4().hex}] \"\n",
+    "verify_payload = {\n",
+    "    **payload_with_cache,\n",
+    "    \"system\": [\n",
+    "        {\"text\": verify_prefix + long_system_text},\n",
+    "        {\"cachePoint\": {\"type\": \"default\"}},\n",
+    "    ],\n",
+    "}\n",
+    "\n",
+    "# First call: cache write (fresh prefix guarantees a miss)\n",
+    "r1 = endpoint.invoke(verify_payload)\n",
+    "print(\n",
+    "    f\"Call 1: TTFT={r1.time_to_first_token:.3f}s, cached_tokens={r1.num_tokens_input_cached}\"\n",
+    ")\n",
+    "\n",
+    "time.sleep(1)  # Brief pause for cache propagation\n",
+    "\n",
+    "# Second call: same prefix, should hit the cache\n",
+    "r2 = endpoint.invoke(verify_payload)\n",
+    "print(\n",
+    "    f\"Call 2: TTFT={r2.time_to_first_token:.3f}s, cached_tokens={r2.num_tokens_input_cached}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cache-busting callback\n",
+    "\n",
+    "To measure latency **without** cache hits, we need every request to miss the cache. We do this with a `before_invoke` callback that prepends a unique random string to the system prompt before each request. This changes the prefix, guaranteeing a cache miss.\n",
+    "\n",
+    "The callback modifies the payload in-place (as required by the LLMeter callback contract)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from uuid import uuid4\n",
+    "\n",
+    "from llmeter.callbacks.base import Callback\n",
+    "\n",
+    "\n",
+    "class CacheBuster(Callback):\n",
+    "    \"\"\"Callback that injects a random prefix into the system prompt to prevent cache hits.\n",
+    "\n",
+    "    This is useful for measuring baseline latency without prompt caching,\n",
+    "    so you can compare it against the cached case.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    async def before_invoke(self, payload: dict) -> None:\n",
+    "        system = payload.get(\"system\")\n",
+    "        if not system:\n",
+    "            return\n",
+    "        # Find the first text block and prepend a unique string\n",
+    "        for block in system:\n",
+    "            if \"text\" in block:\n",
+    "                block[\"text\"] = f\"[session-{uuid4().hex}] \" + block[\"text\"]\n",
+    "                break"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run 1: With prompt caching (baseline)\n",
+    "\n",
+    "First, we prime the cache with a single call, then run the benchmark. All requests use the same system prompt prefix, so they should hit the cache after the first one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7c57c2eeddfb48fcb0a82212f1992c5a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Total requests:   0%|          | 0/90 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Prime the cache\n",
+    "_ = endpoint.invoke(payload_with_cache)\n",
+    "time.sleep(1)\n",
+    "\n",
+    "runner_cached = Runner(\n",
+    "    endpoint,\n",
+    "    output_path=f\"outputs/cache_comparison/{model_id}/cached\",\n",
+    ")\n",
+    "\n",
+    "result_cached = await runner_cached.run(\n",
+    "    payload=payload_with_cache,\n",
+    "    n_requests=30,\n",
+    "    clients=3,\n",
+    "    run_name=\"with-cache\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    \"total_requests\": 90,\n",
+      "    \"clients\": 3,\n",
+      "    \"n_requests\": 30,\n",
+      "    \"total_test_time\": 18.54739387508016,\n",
+      "    \"model_id\": \"us.amazon.nova-lite-v1:0\",\n",
+      "    \"output_path\": \"outputs/cache_comparison/us.amazon.nova-lite-v1:0/cached/with-cache\",\n",
+      "    \"endpoint_name\": \"amazon bedrock\",\n",
+      "    \"provider\": \"bedrock\",\n",
+      "    \"run_name\": \"with-cache\",\n",
+      "    \"run_description\": null,\n",
+      "    \"start_time\": \"2026-04-16T15:37:38Z\",\n",
+      "    \"end_time\": \"2026-04-16T15:37:56Z\",\n",
+      "    \"failed_requests\": 0,\n",
+      "    \"failed_requests_rate\": 0.0,\n",
+      "    \"requests_per_minute\": 291.14602495476805,\n",
+      "    \"total_input_tokens\": 1080,\n",
+      "    \"total_output_tokens\": 180,\n",
+      "    \"total_cached_input_tokens\": 211288,\n",
+      "    \"average_input_tokens_per_minute\": 3493.7522994572164,\n",
+      "    \"average_output_tokens_per_minute\": 582.2920499095361,\n",
+      "    \"time_to_last_token-average\": 0.2627643963619549,\n",
+      "    \"time_to_last_token-p50\": 0.2580558335175738,\n",
+      "    \"time_to_last_token-p90\": 0.5021386420703493,\n",
+      "    \"time_to_last_token-p99\": 0.6087397387891542,\n",
+      "    \"time_to_first_token-average\": 0.25380087868543344,\n",
+      "    \"time_to_first_token-p50\": 0.2532453959574923,\n",
+      "    \"time_to_first_token-p90\": 0.48823858397081493,\n",
+      "    \"time_to_first_token-p99\": 0.6012613537791185,\n",
+      "    \"num_tokens_output-average\": 2,\n",
+      "    \"num_tokens_output-p50\": 2.0,\n",
+      "    \"num_tokens_output-p90\": 2.0,\n",
+      "    \"num_tokens_output-p99\": 2.0,\n",
+      "    \"num_tokens_input-average\": 12,\n",
+      "    \"num_tokens_input-p50\": 12.0,\n",
+      "    \"num_tokens_input-p90\": 12.0,\n",
+      "    \"num_tokens_input-p99\": 12.0,\n",
+      "    \"num_tokens_input_cached-average\": 2347.6444444444446,\n",
+      "    \"num_tokens_input_cached-p50\": 2401.0,\n",
+      "    \"num_tokens_input_cached-p90\": 2401.0,\n",
+      "    \"num_tokens_input_cached-p99\": 2401.0\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(result_cached)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run 2: Without prompt caching (cache-busted)\n",
+    "\n",
+    "Now we run the same workload but with the `CacheBuster` callback, which ensures every request misses the cache."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "982e68a3503644439efa85617a5c2aa0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Total requests:   0%|          | 0/90 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "runner_uncached = Runner(\n",
+    "    endpoint,\n",
+    "    output_path=f\"outputs/cache_comparison/{model_id}/uncached\",\n",
+    "    callbacks=[CacheBuster()],\n",
+    ")\n",
+    "\n",
+    "result_uncached = await runner_uncached.run(\n",
+    "    payload=payload_with_cache,\n",
+    "    n_requests=30,\n",
+    "    clients=3,\n",
+    "    run_name=\"without-cache\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    \"total_requests\": 90,\n",
+      "    \"clients\": 3,\n",
+      "    \"n_requests\": 30,\n",
+      "    \"total_test_time\": 17.43987720797304,\n",
+      "    \"model_id\": \"us.amazon.nova-lite-v1:0\",\n",
+      "    \"output_path\": \"outputs/cache_comparison/us.amazon.nova-lite-v1:0/uncached/without-cache\",\n",
+      "    \"endpoint_name\": \"amazon bedrock\",\n",
+      "    \"provider\": \"bedrock\",\n",
+      "    \"run_name\": \"without-cache\",\n",
+      "    \"run_description\": null,\n",
+      "    \"start_time\": \"2026-04-16T15:37:57Z\",\n",
+      "    \"end_time\": \"2026-04-16T15:38:14Z\",\n",
+      "    \"failed_requests\": 0,\n",
+      "    \"failed_requests_rate\": 0.0,\n",
+      "    \"requests_per_minute\": 309.6352076109381,\n",
+      "    \"total_input_tokens\": 1080,\n",
+      "    \"total_output_tokens\": 183,\n",
+      "    \"total_cached_input_tokens\": 0,\n",
+      "    \"average_input_tokens_per_minute\": 3715.622491331257,\n",
+      "    \"average_output_tokens_per_minute\": 629.5915888089075,\n",
+      "    \"time_to_last_token-average\": 0.26112701249205406,\n",
+      "    \"time_to_last_token-p50\": 0.22509589605033398,\n",
+      "    \"time_to_last_token-p90\": 0.470116974634584,\n",
+      "    \"time_to_last_token-p99\": 0.6483631999033969,\n",
+      "    \"time_to_first_token-average\": 0.2492863449216303,\n",
+      "    \"time_to_first_token-p50\": 0.21820783341536298,\n",
+      "    \"time_to_first_token-p90\": 0.45226739965146406,\n",
+      "    \"time_to_first_token-p99\": 0.6457712807843927,\n",
+      "    \"num_tokens_output-average\": 2.033333333333333,\n",
+      "    \"num_tokens_output-p50\": 2.0,\n",
+      "    \"num_tokens_output-p90\": 2.0,\n",
+      "    \"num_tokens_output-p99\": 3.0,\n",
+      "    \"num_tokens_input-average\": 12,\n",
+      "    \"num_tokens_input-p50\": 12.0,\n",
+      "    \"num_tokens_input-p90\": 12.0,\n",
+      "    \"num_tokens_input-p99\": 12.0,\n",
+      "    \"num_tokens_input_cached-average\": 0,\n",
+      "    \"num_tokens_input_cached-p50\": 0.0,\n",
+      "    \"num_tokens_input_cached-p90\": 0.0,\n",
+      "    \"num_tokens_input_cached-p99\": 0.0\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(result_uncached)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Comparing the results\n",
+    "\n",
+    "Let's compare the TTFT distributions side by side."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import plotly.graph_objects as go\n",
+    "import plotly.io as pio\n",
+    "\n",
+    "from llmeter.plotting import boxplot_by_dimension, histogram_by_dimension\n",
+    "\n",
+    "pio.templates.default = \"plotly_white\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Summary statistics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "With cache:\n",
+      "  time_to_first_token-average: 0.2538s\n",
+      "  time_to_first_token-p50: 0.2532s\n",
+      "  time_to_first_token-p90: 0.4882s\n",
+      "  time_to_first_token-p99: 0.6013s\n",
+      "  total_cached_input_tokens: 211288\n",
+      "  num_tokens_input_cached-average: 2348\n",
+      "\n",
+      "Without cache:\n",
+      "  time_to_first_token-average: 0.2493s\n",
+      "  time_to_first_token-p50: 0.2182s\n",
+      "  time_to_first_token-p90: 0.4523s\n",
+      "  time_to_first_token-p99: 0.6458s\n",
+      "  total_cached_input_tokens: 0\n",
+      "  num_tokens_input_cached-average: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "dimension = \"time_to_first_token\"\n",
+    "\n",
+    "for label, result in [\n",
+    "    (\"With cache\", result_cached),\n",
+    "    (\"Without cache\", result_uncached),\n",
+    "]:\n",
+    "    stats = result.stats\n",
+    "    ttft_stats = {k: v for k, v in stats.items() if dimension in k}\n",
+    "    print(f\"\\n{label}:\")\n",
+    "    for k, v in ttft_stats.items():\n",
+    "        print(f\"  {k}: {v:.4f}s\")\n",
+    "    print(f\"  total_cached_input_tokens: {stats.get('total_cached_input_tokens', 0)}\")\n",
+    "    cached_avg = stats.get(\"num_tokens_input_cached-average\")\n",
+    "    if cached_avg is not None:\n",
+    "        print(f\"  num_tokens_input_cached-average: {cached_avg:.0f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Boxplot comparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "name": "with-cache",
+         "type": "box",
+         "x": [
+          0.524420875008218,
+          0.5013844160130247,
+          0.5104560409672558,
+          0.049560666899196804,
+          0.4561935410602018,
+          0.12974562495946884,
+          0.21377324999775738,
+          0.12177229195367545,
+          0.39698774996213615,
+          0.48881645896472037,
+          0.0863279999466613,
+          0.45013012492563576,
+          0.03540291707031429,
+          0.3445181659189984,
+          0.14262429205700755,
+          0.10628391697537154,
+          0.3792406660504639,
+          0.11809124995488673,
+          0.17569191695656627,
+          0.3633292498998344,
+          0.098407750017941,
+          0.039043082972057164,
+          0.36076000006869435,
+          0.1260559579823166,
+          0.13222329097334296,
+          0.4957298750523478,
+          0.4830377090256661,
+          0.1212633749237284,
+          0.33991666708607227,
+          0.3390210000798106,
+          0.09955895901657641,
+          0.35448570793960243,
+          0.3901331250090152,
+          0.10254704195540398,
+          0.3633966660127044,
+          0.19888037501368672,
+          0.03844391705933958,
+          0.2442422080785036,
+          0.14657262503169477,
+          0.06415404204744846,
+          0.2555985409999266,
+          0.25493729196023196,
+          0.10419383400585502,
+          0.1403009999776259,
+          0.2773136249743402,
+          0.30613087490200996,
+          0.22564754111226648,
+          0.24241437506861985,
+          0.2587809580145404,
+          0.2590472080046311,
+          0.257352500106208,
+          0.2734995000064373,
+          0.3049475000007078,
+          0.15805970795918256,
+          0.026100957999005914,
+          0.296802332974039,
+          0.22837300004903227,
+          0.22845725005026907,
+          0.26566270797047764,
+          0.19321954203769565,
+          0.15556533297058195,
+          0.17872724996414036,
+          0.26165424997452646,
+          0.0645332089625299,
+          0.1822019589599222,
+          0.20521420892328024,
+          0.142869041999802,
+          0.1557908330578357,
+          0.42695683403871953,
+          0.3014569169608876,
+          0.021311999997124076,
+          0.47384816699195653,
+          0.06698600004892796,
+          0.07626533298753202,
+          0.535533917020075,
+          0.5429042499745265,
+          0.09300095797516406,
+          0.3868948749732226,
+          0.3940903749316931,
+          0.2515534999547526,
+          0.20971187495160848,
+          0.2257149169454351,
+          0.25666016701143235,
+          0.28034375002607703,
+          0.2669626659480855,
+          0.25535108300391585,
+          0.2914488329552114,
+          0.26828825008124113,
+          0.5811707910615951,
+          0.5996024999767542
+         ]
+        },
+        {
+         "name": "without-cache",
+         "type": "box",
+         "x": [
+          0.49814399995375425,
+          0.5273453339468688,
+          0.5277198749827221,
+          0.4393974170088768,
+          0.06404616602230817,
+          0.03676820907276124,
+          0.41124558402225375,
+          0.13009104202501476,
+          0.17406516696792096,
+          0.3359577920055017,
+          0.15036595799028873,
+          0.1752173750428483,
+          0.3414169999305159,
+          0.15718429209664464,
+          0.09740962507203221,
+          0.21415700006764382,
+          0.2409779579611495,
+          0.07307174999732524,
+          0.15279483399353921,
+          0.33800158405210823,
+          0.39374562504235655,
+          0.2987165830563754,
+          0.4871455410029739,
+          0.5129253329942003,
+          0.4528837079415098,
+          0.4636999169597402,
+          0.19471087493002415,
+          0.2748476250562817,
+          0.053007832961156964,
+          0.21220287506002933,
+          0.19804320798721164,
+          0.09960612503346056,
+          0.22183516703080386,
+          0.13369970803614706,
+          0.270135665894486,
+          0.11137695889919996,
+          0.1841498330468312,
+          0.23511433403473347,
+          0.21772612491622567,
+          0.12037895899266005,
+          0.2503546249354258,
+          0.07388287503272295,
+          0.15341649996116757,
+          0.2480462919920683,
+          0.10353204200509936,
+          0.42999224993400276,
+          0.41810204193461686,
+          0.19567908300086856,
+          0.2640136250993237,
+          0.10896012501325458,
+          0.3398820840520784,
+          0.07650929095689207,
+          0.06610900000669062,
+          0.40121483290567994,
+          0.04764941695611924,
+          0.08737587498035282,
+          0.38532829110044986,
+          0.36511029105167836,
+          0.2470552499871701,
+          0.37109487503767014,
+          0.39710116607602686,
+          0.06253550003748387,
+          0.3949329589959234,
+          0.0713298749178648,
+          0.11779062508139759,
+          0.35637979197781533,
+          0.3564523329259828,
+          0.12023366603534669,
+          0.37385262502357364,
+          0.2071001660078764,
+          0.13892449997365475,
+          0.3197686669882387,
+          0.37101770797744393,
+          0.34225625009275973,
+          0.08316475001629442,
+          0.19003149995114654,
+          0.25015283294487745,
+          0.13797779195010662,
+          0.06796270806808025,
+          0.40804675000254065,
+          0.4454639999894425,
+          0.05131929100025445,
+          0.4467206250410527,
+          0.043923790915869176,
+          0.21618762507569045,
+          0.2186895419145003,
+          0.09605633397586644,
+          0.18128441693261266,
+          0.4784507090225816,
+          0.6360239170026034
+         ]
+        }
+       ],
+       "layout": {
+        "legend": {
+         "x": 0.99,
+         "xanchor": "right",
+         "y": 0.99,
+         "yanchor": "top"
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Time to First Token: cached vs uncached"
+        },
+        "xaxis": {
+         "title": {
+          "text": "seconds"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig = go.Figure()\n",
+    "fig.add_trace(boxplot_by_dimension(result=result_cached, dimension=dimension))\n",
+    "fig.add_trace(boxplot_by_dimension(result=result_uncached, dimension=dimension))\n",
+    "\n",
+    "fig.update_layout(\n",
+    "    title=\"Time to First Token: cached vs uncached\",\n",
+    "    xaxis_title=\"seconds\",\n",
+    "    legend=dict(yanchor=\"top\", y=0.99, xanchor=\"right\", x=0.99),\n",
+    ")\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Histogram comparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "histnorm": "probability",
+         "name": "with-cache",
+         "opacity": 0.7,
+         "type": "histogram",
+         "x": [
+          0.524420875008218,
+          0.5013844160130247,
+          0.5104560409672558,
+          0.049560666899196804,
+          0.4561935410602018,
+          0.12974562495946884,
+          0.21377324999775738,
+          0.12177229195367545,
+          0.39698774996213615,
+          0.48881645896472037,
+          0.0863279999466613,
+          0.45013012492563576,
+          0.03540291707031429,
+          0.3445181659189984,
+          0.14262429205700755,
+          0.10628391697537154,
+          0.3792406660504639,
+          0.11809124995488673,
+          0.17569191695656627,
+          0.3633292498998344,
+          0.098407750017941,
+          0.039043082972057164,
+          0.36076000006869435,
+          0.1260559579823166,
+          0.13222329097334296,
+          0.4957298750523478,
+          0.4830377090256661,
+          0.1212633749237284,
+          0.33991666708607227,
+          0.3390210000798106,
+          0.09955895901657641,
+          0.35448570793960243,
+          0.3901331250090152,
+          0.10254704195540398,
+          0.3633966660127044,
+          0.19888037501368672,
+          0.03844391705933958,
+          0.2442422080785036,
+          0.14657262503169477,
+          0.06415404204744846,
+          0.2555985409999266,
+          0.25493729196023196,
+          0.10419383400585502,
+          0.1403009999776259,
+          0.2773136249743402,
+          0.30613087490200996,
+          0.22564754111226648,
+          0.24241437506861985,
+          0.2587809580145404,
+          0.2590472080046311,
+          0.257352500106208,
+          0.2734995000064373,
+          0.3049475000007078,
+          0.15805970795918256,
+          0.026100957999005914,
+          0.296802332974039,
+          0.22837300004903227,
+          0.22845725005026907,
+          0.26566270797047764,
+          0.19321954203769565,
+          0.15556533297058195,
+          0.17872724996414036,
+          0.26165424997452646,
+          0.0645332089625299,
+          0.1822019589599222,
+          0.20521420892328024,
+          0.142869041999802,
+          0.1557908330578357,
+          0.42695683403871953,
+          0.3014569169608876,
+          0.021311999997124076,
+          0.47384816699195653,
+          0.06698600004892796,
+          0.07626533298753202,
+          0.535533917020075,
+          0.5429042499745265,
+          0.09300095797516406,
+          0.3868948749732226,
+          0.3940903749316931,
+          0.2515534999547526,
+          0.20971187495160848,
+          0.2257149169454351,
+          0.25666016701143235,
+          0.28034375002607703,
+          0.2669626659480855,
+          0.25535108300391585,
+          0.2914488329552114,
+          0.26828825008124113,
+          0.5811707910615951,
+          0.5996024999767542
+         ],
+         "xbins": {
+          "size": 0.02
+         }
+        },
+        {
+         "histnorm": "probability",
+         "name": "without-cache",
+         "opacity": 0.7,
+         "type": "histogram",
+         "x": [
+          0.49814399995375425,
+          0.5273453339468688,
+          0.5277198749827221,
+          0.4393974170088768,
+          0.06404616602230817,
+          0.03676820907276124,
+          0.41124558402225375,
+          0.13009104202501476,
+          0.17406516696792096,
+          0.3359577920055017,
+          0.15036595799028873,
+          0.1752173750428483,
+          0.3414169999305159,
+          0.15718429209664464,
+          0.09740962507203221,
+          0.21415700006764382,
+          0.2409779579611495,
+          0.07307174999732524,
+          0.15279483399353921,
+          0.33800158405210823,
+          0.39374562504235655,
+          0.2987165830563754,
+          0.4871455410029739,
+          0.5129253329942003,
+          0.4528837079415098,
+          0.4636999169597402,
+          0.19471087493002415,
+          0.2748476250562817,
+          0.053007832961156964,
+          0.21220287506002933,
+          0.19804320798721164,
+          0.09960612503346056,
+          0.22183516703080386,
+          0.13369970803614706,
+          0.270135665894486,
+          0.11137695889919996,
+          0.1841498330468312,
+          0.23511433403473347,
+          0.21772612491622567,
+          0.12037895899266005,
+          0.2503546249354258,
+          0.07388287503272295,
+          0.15341649996116757,
+          0.2480462919920683,
+          0.10353204200509936,
+          0.42999224993400276,
+          0.41810204193461686,
+          0.19567908300086856,
+          0.2640136250993237,
+          0.10896012501325458,
+          0.3398820840520784,
+          0.07650929095689207,
+          0.06610900000669062,
+          0.40121483290567994,
+          0.04764941695611924,
+          0.08737587498035282,
+          0.38532829110044986,
+          0.36511029105167836,
+          0.2470552499871701,
+          0.37109487503767014,
+          0.39710116607602686,
+          0.06253550003748387,
+          0.3949329589959234,
+          0.0713298749178648,
+          0.11779062508139759,
+          0.35637979197781533,
+          0.3564523329259828,
+          0.12023366603534669,
+          0.37385262502357364,
+          0.2071001660078764,
+          0.13892449997365475,
+          0.3197686669882387,
+          0.37101770797744393,
+          0.34225625009275973,
+          0.08316475001629442,
+          0.19003149995114654,
+          0.25015283294487745,
+          0.13797779195010662,
+          0.06796270806808025,
+          0.40804675000254065,
+          0.4454639999894425,
+          0.05131929100025445,
+          0.4467206250410527,
+          0.043923790915869176,
+          0.21618762507569045,
+          0.2186895419145003,
+          0.09605633397586644,
+          0.18128441693261266,
+          0.4784507090225816,
+          0.6360239170026034
+         ],
+         "xbins": {
+          "size": 0.02
+         }
+        }
+       ],
+       "layout": {
+        "barmode": "overlay",
+        "legend": {
+         "x": 0.99,
+         "xanchor": "right",
+         "y": 0.99,
+         "yanchor": "top"
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "TTFT distribution: cached vs uncached"
+        },
+        "xaxis": {
+         "title": {
+          "text": "seconds"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig = go.Figure()\n",
+    "fig.add_trace(histogram_by_dimension(result_cached, dimension, xbins=dict(size=0.02)))\n",
+    "fig.add_trace(histogram_by_dimension(result_uncached, dimension, xbins=dict(size=0.02)))\n",
+    "\n",
+    "fig.update_layout(\n",
+    "    title=\"TTFT distribution: cached vs uncached\",\n",
+    "    xaxis_title=\"seconds\",\n",
+    "    barmode=\"overlay\",\n",
+    "    legend=dict(yanchor=\"top\", y=0.99, xanchor=\"right\", x=0.99),\n",
+    ")\n",
+    "fig.update_traces(opacity=0.7)\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Cache hit verification\n",
+    "\n",
+    "We can verify that the cached run actually used the cache by comparing `total_cached_input_tokens` from `Result.stats`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cached run     — total_cached_input_tokens: 211,288, avg cached/request: 2,348\n",
+      "Uncached run   — total_cached_input_tokens:      0, avg cached/request: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "for label, result in [(\"Cached run\", result_cached), (\"Uncached run\", result_uncached)]:\n",
+    "    stats = result.stats\n",
+    "    total_cached = stats.get(\"total_cached_input_tokens\", 0)\n",
+    "    total_input = stats.get(\"total_input_tokens\", 0)\n",
+    "    cache_avg = stats.get(\"num_tokens_input_cached-average\", 0) or 0\n",
+    "    print(\n",
+    "        f\"{label:14s} — total_cached_input_tokens: {total_cached:>6,}, \"\n",
+    "        f\"avg cached/request: {cache_avg:,.0f}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Statistical comparison\n",
+    "\n",
+    "Latency data is typically skewed, so we use bootstrapping to estimate confidence intervals on the median TTFT for each run, and on the difference between them. This gives us a rigorous way to quantify the caching benefit beyond just comparing point estimates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from scipy.stats import bootstrap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Median TTFT for each run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_cached = [v for v in result_cached.get_dimension(dimension) if v is not None]\n",
+    "data_uncached = [v for v in result_uncached.get_dimension(dimension) if v is not None]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Median TTFT (with cache):\n",
+      "  0.2532s (0.2075, 0.2663)s\n"
+     ]
+    }
+   ],
+   "source": [
+    "res = bootstrap((data_cached,), np.median, confidence_level=0.95)\n",
+    "print(\n",
+    "    f\"Median TTFT (with cache):\\n\"\n",
+    "    f\"  {np.median(data_cached):.4f}s \"\n",
+    "    f\"({res.confidence_interval.low:.4f}, {res.confidence_interval.high:.4f})s\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Median TTFT (without cache):\n",
+      "  0.2182s (0.1871, 0.2671)s\n"
+     ]
+    }
+   ],
+   "source": [
+    "res = bootstrap((data_uncached,), np.median, confidence_level=0.95)\n",
+    "print(\n",
+    "    f\"Median TTFT (without cache):\\n\"\n",
+    "    f\"  {np.median(data_uncached):.4f}s \"\n",
+    "    f\"({res.confidence_interval.low:.4f}, {res.confidence_interval.high:.4f})s\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Difference between medians\n",
+    "\n",
+    "A positive value means the uncached run is slower (as expected). If the confidence interval excludes zero, the difference is statistically significant at the 95% level."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Median TTFT difference (uncached − cached):\n",
+      "  -0.0350s (-0.0815, 0.0128)s\n",
+      "\n",
+      "The difference is not statistically significant at the 95% level.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def median_difference(sample_cached, sample_uncached, axis=-1):\n",
+    "    return np.median(sample_uncached, axis=axis) - np.median(sample_cached, axis=axis)\n",
+    "\n",
+    "\n",
+    "res = bootstrap(\n",
+    "    (data_cached, data_uncached),\n",
+    "    median_difference,\n",
+    "    confidence_level=0.95,\n",
+    ")\n",
+    "\n",
+    "diff = median_difference(data_cached, data_uncached)\n",
+    "print(\n",
+    "    f\"Median TTFT difference (uncached − cached):\\n\"\n",
+    "    f\"  {diff:.4f}s ({res.confidence_interval.low:.4f}, {res.confidence_interval.high:.4f})s\\n\"\n",
+    ")\n",
+    "\n",
+    "if res.confidence_interval.low > 0:\n",
+    "    pct = diff / np.median(data_uncached) * 100\n",
+    "    print(f\"Prompt caching reduces median TTFT by ~{pct:.1f}%\")\n",
+    "else:\n",
+    "    print(\"The difference is not statistically significant at the 95% level.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Notes\n",
+    "\n",
+    "- **Cache TTL**: Bedrock prompt caches have a 5-minute TTL by default (1 hour for some Claude models with `\"ttl\": \"1h\"`). If your test run takes longer than this, later requests may miss the cache.\n",
+    "- **Token minimum**: Nova models require at least 1024 tokens in the cached prefix. Claude models require 1024–2048 depending on the variant. If your system prompt is too short, caching won't activate.\n",
+    "- **Cost**: Cached tokens are charged at a reduced rate for reads, but writes may cost more than standard input tokens. See [Bedrock pricing](https://aws.amazon.com/bedrock/pricing/) for details."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/llmeter/callbacks/cost/dimensions.py
+++ b/llmeter/callbacks/cost/dimensions.py
@@ -12,7 +12,7 @@ use to bring customized cost dimensions for your own cost models.
 """
 
 # Python Built-Ins:
-from abc import abstractmethod, ABC
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from math import ceil
 from typing import Optional

--- a/llmeter/callbacks/cost/providers/sagemaker.py
+++ b/llmeter/callbacks/cost/providers/sagemaker.py
@@ -4,8 +4,9 @@
 
 # Python Built-Ins:
 from __future__ import annotations
-from dataclasses import dataclass
+
 import json
+from dataclasses import dataclass
 from math import ceil
 
 # External Dependencies:

--- a/llmeter/endpoints/__init__.py
+++ b/llmeter/endpoints/__init__.py
@@ -12,9 +12,9 @@ from .sagemaker import SageMakerEndpoint, SageMakerStreamEndpoint  # noqa: F401
 spec = importlib.util.find_spec("openai")
 if spec:
     from .openai import (  # noqa: F401
-        OpenAIEndpoint,
         OpenAICompletionEndpoint,
         OpenAICompletionStreamEndpoint,
+        OpenAIEndpoint,
     )
     from .openai_response import (  # noqa: F401
         OpenAIResponseEndpoint,

--- a/llmeter/endpoints/base.py
+++ b/llmeter/endpoints/base.py
@@ -7,6 +7,8 @@ You can also use these classes to implement your own custom `Endpoint` types.
 
 import importlib
 import json
+import logging
+import time
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
 from typing import Any
@@ -17,6 +19,8 @@ from upath.types import ReadablePathLike, WritablePathLike
 
 from ..json_utils import llmeter_default_serializer
 from ..utils import ensure_path
+
+logger = logging.getLogger(__name__)
 
 
 # @dataclass(slots=True)
@@ -32,6 +36,7 @@ class InvocationResponse:
         time_to_first_token (float): The time taken to receive the first token of the response in seconds.
         num_tokens_output (Optional[int]): The number of tokens in the response.
         num_tokens_input (Optional[int]): The number of tokens in the invocation payload.
+        num_tokens_input_cached (Optional[int]): The number of input tokens served from cache (prompt caching).
         input_prompt (str): The input prompt used in the invocation.
         time_per_output_token (float): The average time taken to generate each token in the response.
         error (str): Any error that occurred during invocation.
@@ -45,6 +50,7 @@ class InvocationResponse:
     time_to_last_token: float | None = None
     num_tokens_input: int | None = None
     num_tokens_output: int | None = None
+    num_tokens_input_cached: int | None = None
     time_per_output_token: float | None = None
     error: str | None = None
     retries: int | None = None
@@ -123,22 +129,162 @@ class Endpoint(ABC):
 
     @abstractmethod
     def invoke(self, payload: dict) -> InvocationResponse:
-        """
-        Invoke the endpoint with the given payload.
+        """Invoke the endpoint with the given payload.
 
-        This method must be implemented by subclasses to define how the endpoint
-        is invoked and how the response is processed.
+        Subclasses implement this with their provider-specific API call,
+        passing the raw response to :meth:`parse_response`.  The payload
+        received here has already been through :meth:`prepare_payload`, so
+        ``**kwargs`` have been merged and provider-specific fields
+        (``model``, ``modelId``, etc.) are set.
+
+        The base class automatically wraps every subclass implementation with:
+
+        * **Timing** — ``self._start_t`` is set immediately before the call
+          and ``time_to_last_token`` is back-filled on the response if the
+          subclass didn't set it (streaming endpoints typically set it during
+          stream consumption).
+        * **Error handling** — unhandled exceptions are caught, logged, and
+          converted to an error :class:`InvocationResponse`.
+        * **Metadata back-fill** — ``input_payload`` and ``input_prompt`` are
+          guaranteed to be set on the returned response (success or error),
+          using the prepared payload.
 
         Args:
-            payload (Dict): The input payload for the model.
+            payload: The prepared input payload for the model.
 
         Returns:
-            InvocationResponse: An object containing the model's response and associated metrics.
-
-        Raises:
-            NotImplementedError: If the method is not implemented by a subclass.
+            InvocationResponse: An object containing the model's response and
+                associated metrics.
         """
         raise NotImplementedError
+
+    @abstractmethod
+    def parse_response(self, raw_response: Any, start_t: float) -> InvocationResponse:
+        """Parse the raw API response into an :class:`InvocationResponse`.
+
+        Subclasses implement this to extract the generated text, token counts,
+        timing information, and any other provider-specific metadata from the
+        raw object returned by the API client.
+
+        This method is called from :meth:`invoke` after the API call.
+        Exceptions raised here will be caught by the base-class ``invoke``
+        wrapper and converted to an error response automatically.
+
+        Non-streaming endpoints can ignore ``start_t`` — the wrapper
+        back-fills ``time_to_last_token`` automatically.  Streaming endpoints
+        use it to compute ``time_to_first_token`` and ``time_to_last_token``
+        during stream consumption.
+
+        Args:
+            raw_response: The raw response object from the provider's API
+                client.  The type varies by provider (e.g. ``ChatCompletion``,
+                ``dict``, a streaming iterator).
+            start_t: The :func:`time.perf_counter` timestamp captured
+                immediately before the API call (also available as
+                ``self._start_t``).
+
+        Returns:
+            InvocationResponse: Parsed response with at least
+                ``response_text`` populated.
+        """
+        raise NotImplementedError
+
+    def prepare_payload(self, payload: dict, **kwargs: Any) -> dict:
+        """Prepare the payload before sending it to the API.
+
+        This method is called by the ``invoke`` wrapper before the actual
+        invocation.  Subclasses can override it to merge ``**kwargs``, inject
+        provider-specific fields (``model``, ``modelId``, streaming options,
+        etc.), or apply any other transformation.
+
+        The default implementation returns *payload* unchanged (ignoring
+        ``**kwargs``).
+
+        Args:
+            payload: The raw input payload from the caller.
+            **kwargs: Additional keyword arguments from the caller.
+
+        Returns:
+            dict: The final payload to send to the API.
+        """
+        return payload
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+
+        # Wrap the subclass invoke (if it defines one) with prepare_payload,
+        # error handling, and metadata back-fill.
+        if "invoke" not in cls.__dict__:
+            return
+
+        inner = cls.__dict__["invoke"]
+
+        if not callable(inner) or isinstance(inner, (classmethod, staticmethod)):
+            return
+
+        def invoke(self: "Endpoint", payload: dict, **kw: Any) -> InvocationResponse:
+            prepared = self.prepare_payload(payload, **kw)
+            self._last_payload = prepared
+            self._start_t = time.perf_counter()
+            try:
+                response = inner(self, prepared)
+            except Exception as e:
+                logger.exception("Endpoint invocation failed: %s", e)
+                response = InvocationResponse.error_output(
+                    input_payload=prepared,
+                    id=uuid4().hex,
+                    error=str(e),
+                )
+
+            # Back-fill time_to_last_token if the subclass didn't set it
+            # (streaming endpoints typically set it during stream consumption).
+            if response.time_to_last_token is None and response.error is None:
+                response.time_to_last_token = time.perf_counter() - self._start_t
+
+            if response.input_payload is None:
+                response.input_payload = prepared
+            if response.input_prompt is None:
+                try:
+                    response.input_prompt = self._parse_payload(prepared)
+                except Exception:
+                    logger.debug("_parse_payload failed; leaving input_prompt as None")
+            if response.id is None:
+                response.id = uuid4().hex
+
+            return response
+
+        invoke.__name__ = inner.__name__
+        invoke.__qualname__ = inner.__qualname__
+        invoke.__doc__ = inner.__doc__
+        invoke.__module__ = inner.__module__
+        cls.invoke = invoke  # type: ignore[attr-defined]
+
+    def _parse_payload(self, payload: dict) -> str | dict | None:
+        """Extract the user-facing input text from an API request payload.
+
+        The ``invoke`` wrapper calls this automatically to populate
+        :pyattr:`InvocationResponse.input_prompt`.  That field serves two
+        purposes:
+
+        * **Observability** — it records *what* was sent to the model in a
+          human-readable form, separate from the full API payload (which may
+          contain binary media, inference config, etc.).
+        * **Token counting fallback** — when the API response does not include
+          an input-token count, the :class:`~llmeter.runner.Runner` tokenizes
+          ``input_prompt`` to estimate it.
+
+        Subclasses should override this to navigate their provider-specific
+        payload structure and return the concatenated message text.  The
+        default implementation returns ``None`` (no prompt extracted).
+
+        Args:
+            payload: The prepared request payload (after :meth:`prepare_payload`).
+
+        Returns:
+            The extracted prompt text, or ``None`` if extraction is not
+            possible.
+        """
+        return None
 
     @staticmethod
     def create_payload(*args: Any, **kwargs: Any) -> Any:

--- a/llmeter/endpoints/bedrock.py
+++ b/llmeter/endpoints/bedrock.py
@@ -13,11 +13,9 @@ Alternatively, see:
 import logging
 import time
 from typing import Any
-from uuid import uuid4
 
 import boto3
 from botocore.config import Config
-from botocore.exceptions import ClientError
 
 from ..prompt_utils import (
     AudioContent,
@@ -30,6 +28,20 @@ from ..prompt_utils import (
 from .base import Endpoint, InvocationResponse
 
 logger = logging.getLogger(__name__)
+
+# Error event types that can appear in Bedrock streaming responses.
+# Shared by both ConverseStream and InvokeModelWithResponseStream APIs.
+# See: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ResponseStream.html
+BEDROCK_STREAM_ERROR_TYPES = frozenset(
+    {
+        "internalServerException",
+        "modelStreamErrorException",
+        "modelTimeoutException",
+        "serviceUnavailableException",
+        "throttlingException",
+        "validationException",
+    }
+)
 
 
 def _mime_to_format(mime_type: str) -> str | None:
@@ -274,211 +286,110 @@ class BedrockBase(Endpoint):
 
 
 class BedrockConverse(BedrockBase):
-    def _parse_converse_response(self, response: dict) -> InvocationResponse:
-        """
-        Parse the response from a Bedrock converse API call.
+    def parse_response(self, response: dict, start_t: float) -> InvocationResponse:
+        """Parse the response from a Bedrock converse API call.
 
         Args:
-            response (dict): Raw response from the Bedrock API containing output text and metadata
+            response: Raw response from the Bedrock API.
+            start_t: The timestamp when the request was initiated.
 
         Returns:
-            InvocationResponse: Parsed response containing the generated text and metadata
-
-        Raises:
-            KeyError: If required fields are missing from the response
-            TypeError: If response fields have unexpected types
+            InvocationResponse with the generated text and metadata.
         """
-        try:
-            # Direct dictionary access and single-level assignment for better performance
-            output = response["output"]["message"]["content"][0]["text"]
-            if not isinstance(output, str):
-                raise TypeError("Expected string for output text")
+        output = response["output"]["message"]["content"][0]["text"]
+        if not isinstance(output, str):
+            raise TypeError("Expected string for output text")
 
-            usage = response.get("usage", {})
-            retries = response["ResponseMetadata"]["RetryAttempts"]
+        usage = response.get("usage") or {}
+        retries = response["ResponseMetadata"]["RetryAttempts"]
 
-            return InvocationResponse(
-                id=uuid4().hex,
-                response_text=output,
-                num_tokens_input=usage.get("inputTokens"),
-                num_tokens_output=usage.get("outputTokens"),
-                retries=retries,
-            )
+        return InvocationResponse(
+            id=response["ResponseMetadata"].get("RequestId"),
+            response_text=output,
+            num_tokens_input=usage.get("inputTokens")
+            if isinstance(usage, dict)
+            else None,
+            num_tokens_output=usage.get("outputTokens")
+            if isinstance(usage, dict)
+            else None,
+            num_tokens_input_cached=usage.get("cacheReadInputTokens")
+            if isinstance(usage, dict)
+            else None,
+            retries=retries,
+        )
 
-        except KeyError as e:
-            logger.error(f"Missing required field in response: {e}")
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Missing required field: {e}",
-            )
+    def invoke(self, payload: dict) -> InvocationResponse:
+        """Invoke the Bedrock converse API with the given payload."""
+        client_response = self._bedrock_client.converse(**payload)  # type: ignore
+        return self.parse_response(client_response, self._start_t)  # type: ignore
 
-        except TypeError as e:
-            logger.error(f"Unexpected type in response: {e}")
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Type error in response: {e}",
-            )
-
-        except Exception as e:
-            logger.error(f"Error parsing converse response: {e}")
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Response parsing error: {e}",
-            )
-
-    def invoke(self, payload: dict, **kwargs: Any) -> InvocationResponse:
-        """
-        Invoke the Bedrock converse API with the given payload.
-
-        Args:
-            payload (dict): The payload containing the request parameters
-            **kwargs: Additional keyword arguments to include in the payload
-
-        Returns:
-            InvocationResponse: Response object containing generated text and metadata
-
-        Raises:
-            ClientError: If there is an error calling the Bedrock API
-            ValueError: If payload is invalid
-            TypeError: If payload is not a dictionary
-        """
-        if not isinstance(payload, dict):
-            raise TypeError("Payload must be a dictionary")
-
-        try:
-            payload = {**kwargs, **payload}
-            if payload.get("inferenceConfig") is None:
-                payload["inferenceConfig"] = self._inference_config or {}
-
-            payload["modelId"] = self.model_id
-            try:
-                start_t = time.perf_counter()
-                client_response = self._bedrock_client.converse(**payload)  # type: ignore
-                time_to_last_token = time.perf_counter() - start_t
-            except ClientError as e:
-                logger.error(f"Bedrock API error: {e}")
-                return InvocationResponse.error_output(
-                    input_payload=payload, id=uuid4().hex, error=str(e)
-                )
-            except Exception as e:
-                logger.error(f"Unexpected error during API call: {e}")
-                return InvocationResponse.error_output(
-                    input_payload=payload, id=uuid4().hex, error=str(e)
-                )
-
-            response = self._parse_converse_response(client_response)  # type: ignore
-            response.input_payload = payload
-            response.input_prompt = self._parse_payload(payload)
-            response.time_to_last_token = time_to_last_token
-            return response
-
-        except Exception as e:
-            logger.error(f"Error in invoke method: {e}")
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-
-
-class BedrockConverseStream(BedrockConverse):
-    def invoke(self, payload: dict, **kwargs: Any) -> InvocationResponse:
+    def prepare_payload(self, payload, **kwargs):
         payload = {**kwargs, **payload}
         if payload.get("inferenceConfig") is None:
             payload["inferenceConfig"] = self._inference_config or {}
-
         payload["modelId"] = self.model_id
-        start_t = time.perf_counter()
-        try:
-            client_response = self._bedrock_client.converse_stream(**payload)  # type: ignore
-        except (ClientError, Exception) as e:
-            logger.error(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-        response = self._parse_conversation_stream(client_response, start_t)
-        response.input_payload = payload
-        response.input_prompt = self._parse_payload(payload)
-        return response
+        return payload
 
-    def _parse_conversation_stream(
-        self, client_response, start_t: float
-    ) -> InvocationResponse:
-        """
-        Parse the streaming response from Bedrock conversation API.
+
+class BedrockConverseStream(BedrockConverse):
+    def invoke(self, payload: dict) -> InvocationResponse:
+        client_response = self._bedrock_client.converse_stream(**payload)  # type: ignore
+        return self.parse_response(client_response, self._start_t)
+
+    def parse_response(self, client_response, start_t: float) -> InvocationResponse:
+        """Parse the streaming response from Bedrock conversation API.
 
         Args:
-            client_response (dict): The raw response from the Bedrock API
-            start_t (float): The timestamp when the request was initiated
+            client_response: The raw response from the Bedrock API.
+            start_t: The timestamp when the request was initiated.
 
         Returns:
-            InvocationResponse: Parsed response containing the generated text and metadata
-
-        Raises:
-            KeyError: If required fields are missing from the response
-            TypeError: If response fields have unexpected types
+            InvocationResponse with the generated text and metadata.
         """
         time_flag = True
         time_to_first_token = None
         time_to_last_token = None
         output_text = ""
         metadata = None
+        error = None
 
-        try:
-            for chunk in client_response["stream"]:
-                if "contentBlockDelta" in chunk:
-                    delta_text = chunk["contentBlockDelta"]["delta"].get("text", "")
-                    if not isinstance(delta_text, str):
-                        raise TypeError("Expected string for delta text")
-                    output_text += delta_text or ""
-                    if time_flag:
-                        time_to_first_token = time.perf_counter() - start_t
-                        time_flag = False
+        for chunk in client_response["stream"]:
+            if "contentBlockDelta" in chunk:
+                delta_text = chunk["contentBlockDelta"]["delta"].get("text", "")
+                if not isinstance(delta_text, str):
+                    raise TypeError("Expected string for delta text")
+                output_text += delta_text or ""
+                if time_flag:
+                    time_to_first_token = time.perf_counter() - start_t
+                    time_flag = False
 
-                if "contentBlockStop" in chunk:
-                    time_to_last_token = time.perf_counter() - start_t
+            if "contentBlockStop" in chunk:
+                time_to_last_token = time.perf_counter() - start_t
 
-                if "metadata" in chunk:
-                    metadata = chunk["metadata"]
+            if "metadata" in chunk:
+                metadata = chunk["metadata"]
 
-            response = InvocationResponse(
-                id=uuid4().hex,
-                response_text=output_text,
-                time_to_last_token=time_to_last_token,
-                time_to_first_token=time_to_first_token,
-            )
+            # Detect Bedrock stream error events
+            for error_type in BEDROCK_STREAM_ERROR_TYPES:
+                if error_type in chunk:
+                    error = f"Bedrock {error_type}: {chunk[error_type]['message']}"
+                    logger.error(error)
+                    break
 
-            if metadata:
-                # The latency provided by Bedrock is at the service endpoint time, not client side
-                # time_to_last_token = metadata.get("metrics", {}).get("latencyMs")
-                try:
-                    usage = metadata.get("usage", {})
-                    response.num_tokens_input = usage.get("inputTokens")
-                    response.num_tokens_output = usage.get("outputTokens")
-                except Exception as e:
-                    logger.error(f"Error parsing metadata: {e}")
-                    return InvocationResponse.error_output(
-                        id=uuid4().hex,
-                        error=f"Metadata parsing error: {e}",
-                    )
+        response = InvocationResponse(
+            id=client_response["ResponseMetadata"].get("RequestId"),
+            response_text=output_text,
+            time_to_last_token=time_to_last_token,
+            time_to_first_token=time_to_first_token,
+            error=error,
+        )
 
-            response.retries = client_response["ResponseMetadata"]["RetryAttempts"]
+        if metadata:
+            usage = metadata.get("usage", {})
+            response.num_tokens_input = usage.get("inputTokens")
+            response.num_tokens_output = usage.get("outputTokens")
+            response.num_tokens_input_cached = usage.get("cacheReadInputTokens")
 
-            return response
+        response.retries = client_response["ResponseMetadata"]["RetryAttempts"]
 
-        except KeyError as e:
-            logger.error(f"Missing required field in response: {e}")
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Missing required field: {e}",
-            )
-        except TypeError as e:
-            logger.error(f"Unexpected type in response: {e}")
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Type error in response: {e}",
-            )
-        except Exception as e:
-            logger.error(f"Error parsing conversation stream: {e}")
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Stream parsing error: {e}",
-            )
+        return response

--- a/llmeter/endpoints/bedrock_invoke.py
+++ b/llmeter/endpoints/bedrock_invoke.py
@@ -5,14 +5,13 @@ import json
 import logging
 import time
 from typing import Any
-from uuid import uuid4
 
 import boto3
 import jmespath
 from botocore.config import Config
-from botocore.exceptions import ClientError
 
 from .base import Endpoint, InvocationResponse
+from .bedrock import BEDROCK_STREAM_ERROR_TYPES
 
 logger = logging.getLogger(__name__)
 
@@ -169,132 +168,59 @@ class BedrockInvoke(Endpoint):
             logger.exception("Failed to create InvokeModel payload")
             raise RuntimeError(f"Failed to create payload: {str(e)}") from e
 
-    def _parse_response(self, response: dict) -> InvocationResponse:
-        """
-        Parse the response from a Bedrock InvokeModel API call.
+    def parse_response(self, response: dict, start_t: float) -> InvocationResponse:
+        """Parse the response from a Bedrock InvokeModel API call.
 
         Args:
-            response (dict): Raw response from the Bedrock API containing output text and metadata
+            response: Raw response from the Bedrock API.
+            start_t: The timestamp when the request was initiated.
 
         Returns:
-            InvocationResponse: Parsed response containing the generated text and metadata
-
-        Raises:
-            KeyError: If required fields are missing from the response
-            TypeError: If response fields have unexpected types
+            InvocationResponse with the generated text and metadata.
         """
-        try:
-            response_body_json = response["body"].read().decode("utf-8")
-            response_body = json.loads(response_body_json)
-        except json.JSONDecodeError as e:
-            logger.exception(
-                "Error parsing response as JSON. Accept header='%s'",
-                response.get("accept"),
-            )
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Failed to parse endpoint response as JSON: {e}",
-            )
+        response_body_json = response["body"].read().decode("utf-8")
+        response_body = json.loads(response_body_json)
 
-        try:
-            response_text = jmespath.search(self.generated_text_jmespath, response_body)
-            if isinstance(response_text, list):
-                response_text = "\n".join(response_text)
+        response_text = jmespath.search(self.generated_text_jmespath, response_body)
+        if isinstance(response_text, list):
+            response_text = "\n".join(response_text)
 
-            id = response_body.get("id", uuid4().hex)
-            retries = response.get("ResponseMetadata", {}).get("RetryAttempts")
-            num_tokens_input = (
-                jmespath.search(self.input_token_count_jmespath, response_body)
-                if self.input_token_count_jmespath
-                else None
-            )
-            num_tokens_output = (
-                jmespath.search(self.generated_token_count_jmespath, response_body)
-                if self.generated_token_count_jmespath
-                else None
-            )
+        id = response_body.get("id") or response.get("ResponseMetadata", {}).get(
+            "RequestId"
+        )
+        retries = response.get("ResponseMetadata", {}).get("RetryAttempts")
+        num_tokens_input = (
+            jmespath.search(self.input_token_count_jmespath, response_body)
+            if self.input_token_count_jmespath
+            else None
+        )
+        num_tokens_output = (
+            jmespath.search(self.generated_token_count_jmespath, response_body)
+            if self.generated_token_count_jmespath
+            else None
+        )
 
-            return InvocationResponse(
-                id=id,
-                response_text=response_text,
-                num_tokens_input=num_tokens_input,
-                num_tokens_output=num_tokens_output,
-                retries=retries,
-            )
-
-        except KeyError as e:
-            logger.exception(f"Missing required field in response: {e}")
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Missing required field: {e}",
-            )
-
-        except TypeError as e:
-            logger.exception(f"Unexpected type in response: {e}")
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Type error in response: {e}",
-            )
-
-        except Exception as e:
-            logger.exception(f"Error parsing InvokeModel response: {e}")
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Response parsing error: {e}",
-            )
+        return InvocationResponse(
+            id=id,
+            response_text=response_text,
+            num_tokens_input=num_tokens_input,
+            num_tokens_output=num_tokens_output,
+            retries=retries,
+        )
 
     def invoke(self, payload: dict) -> InvocationResponse:
-        """Invoke the Bedrock InvokeModel API with the given payload.
+        """Invoke the Bedrock InvokeModel API with the given payload."""
+        req_body = json.dumps(payload).encode("utf-8")
 
-        Args:
-            payload (dict): The payload containing the request parameters
-
-        Returns:
-            InvocationResponse: Response object containing generated text and metadata
-
-        Raises:
-            ClientError: If there is an error calling the Bedrock API
-            ValueError: If payload is invalid
-            TypeError: If payload is not a dictionary
-        """
-        if not isinstance(payload, dict):
-            raise TypeError("Payload must be a dictionary")
-
-        try:
-            req_body = json.dumps(payload).encode("utf-8")
-            try:
-                start_t = time.perf_counter()
-                client_response = self._bedrock_client.invoke_model(  # type: ignore
-                    accept="application/json",
-                    body=req_body,
-                    contentType="application/json",
-                    modelId=self.model_id,
-                    # TODO: Provide config for other optional arguments
-                    # trace, guardrailIdentifier/Version, performanceConfigLatency, serviceTier
-                )
-                time_to_last_token = time.perf_counter() - start_t
-            except ClientError as e:
-                logger.error(f"Bedrock API error: {e}")
-                return InvocationResponse.error_output(
-                    input_payload=payload, id=uuid4().hex, error=str(e)
-                )
-            except Exception as e:
-                logger.error(f"Unexpected error during API call: {e}")
-                return InvocationResponse.error_output(
-                    input_payload=payload, id=uuid4().hex, error=str(e)
-                )
-
-            response = self._parse_response(client_response)  # type: ignore
-            response.input_payload = payload
-            response.input_prompt = self._parse_payload(payload)
-            response.time_to_last_token = time_to_last_token
-            return response
-
-        except Exception as e:
-            logger.error(f"Error in invoke method: {e}")
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
+        client_response = self._bedrock_client.invoke_model(  # type: ignore
+            accept="application/json",
+            body=req_body,
+            contentType="application/json",
+            modelId=self.model_id,
+            # TODO: Provide config for other optional arguments
+            # trace, guardrailIdentifier/Version, performanceConfigLatency, serviceTier
+        )
+        return self.parse_response(client_response, self._start_t)  # type: ignore
 
 
 class BedrockInvokeStream(BedrockInvoke):
@@ -354,138 +280,86 @@ class BedrockInvokeStream(BedrockInvoke):
 
     def invoke(self, payload: dict) -> InvocationResponse:
         req_body = json.dumps(payload).encode("utf-8")
-        try:
-            start_t = time.perf_counter()
-            client_response = self._bedrock_client.invoke_model_with_response_stream(  # type: ignore
-                accept="application/json",
-                body=req_body,
-                contentType="application/json",
-                modelId=self.model_id,
-                # TODO: Provide config for other optional arguments
-                # trace, guardrailIdentifier/Version, performanceConfigLatency, serviceTier
-            )
-        except (ClientError, Exception) as e:
-            logger.error(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-        response = self._parse_response_stream(client_response, start_t)
-        response.input_payload = payload
-        response.input_prompt = self._parse_payload(payload)
-        return response
 
-    def _parse_response_stream(
-        self, client_response, start_t: float
-    ) -> InvocationResponse:
-        """Parse the streaming response from Bedrock InovkeModel API.
+        client_response = self._bedrock_client.invoke_model_with_response_stream(  # type: ignore
+            accept="application/json",
+            body=req_body,
+            contentType="application/json",
+            modelId=self.model_id,
+            # TODO: Provide config for other optional arguments
+            # trace, guardrailIdentifier/Version, performanceConfigLatency, serviceTier
+        )
+        return self.parse_response(client_response, self._start_t)
+
+    def parse_response(self, client_response, start_t: float) -> InvocationResponse:
+        """Parse the streaming response from Bedrock InvokeModel API.
 
         Args:
-            client_response (dict): The raw response from the Bedrock API
-            start_t (float): The timestamp when the request was initiated
+            client_response: The raw response from the Bedrock API.
+            start_t: The timestamp when the request was initiated.
 
         Returns:
-            InvocationResponse: Parsed response containing the generated text and metadata
-
-        Raises:
-            KeyError: If required fields are missing from the response
-            TypeError: If response fields have unexpected types
+            InvocationResponse with the generated text and metadata.
         """
         output_text = ""
         chunks = []
         time_to_first_token = None
         time_to_last_token = None
+        error = None
 
-        try:
-            for event in client_response["body"]:
-                if "chunk" in event:
-                    chunk_bytes = event["chunk"]["bytes"]
-                    chunk_data = json.loads(chunk_bytes)
-                    chunk_text = jmespath.search(
-                        self.generated_text_jmespath, chunk_data
-                    )
-                    if isinstance(chunk_text, list):
-                        chunk_text = "".join(chunk_text)
-                    if chunk_text:
-                        now = time.perf_counter()
-                        if time_to_first_token is None:
-                            time_to_first_token = now - start_t
-                        time_to_last_token = now - start_t
-                        output_text += chunk_text
-                    chunks.append(chunk_data)
-                else:
-                    for etype in (
-                        "internalServerException",
-                        "modelStreamErrorException",
-                        "validationException",
-                        "throttlingException",
-                        "modelTimeoutException",
-                        "serviceUnavailableException",
-                    ):
-                        if etype in event:
-                            msg = f"Bedrock {etype}: {event[etype]['message']}"
-                            logger.error(msg)
-                            return InvocationResponse.error_output(
-                                id=uuid4().hex,
-                                error=msg,
-                            )
-                    # Unknown event type - probably an error
-                    return InvocationResponse.error_output(
-                        id=uuid4().hex,
-                        error=f"Unknown event type in response stream: {event}",
-                    )
+        for event in client_response["body"]:
+            if "chunk" in event:
+                chunk_bytes = event["chunk"]["bytes"]
+                chunk_data = json.loads(chunk_bytes)
+                chunk_text = jmespath.search(self.generated_text_jmespath, chunk_data)
+                if isinstance(chunk_text, list):
+                    chunk_text = "".join(chunk_text)
+                if chunk_text:
+                    now = time.perf_counter()
+                    if time_to_first_token is None:
+                        time_to_first_token = now - start_t
+                    time_to_last_token = now - start_t
+                    output_text += chunk_text
+                chunks.append(chunk_data)
+            else:
+                # Non-chunk events: check for Bedrock error events, skip
+                # everything else (e.g. messageStart, contentBlockStart).
+                for error_type in BEDROCK_STREAM_ERROR_TYPES:
+                    if error_type in event:
+                        error = f"Bedrock {error_type}: {event[error_type]['message']}"
+                        logger.error(error)
+                        break
 
-            # Post-process additional data from chunks:
-            # (Which we do after performance timing, to avoid counting JMESPath overhead)
-            num_tokens_input = None
-            num_tokens_output = None
-            resp_id = None
-            for chunk in chunks:
-                if "id" in chunk:
-                    resp_id = chunk["id"]
-                # Usage counts should only appear once in the stream. We'll overwrite if duplicated:
-                chk_tokens_input = (
-                    jmespath.search(self.input_token_count_jmespath, chunk)
-                    if self.input_token_count_jmespath
-                    else None
-                )
-                if chk_tokens_input is not None:
-                    num_tokens_input = chk_tokens_input
-                chk_tokens_output = (
-                    jmespath.search(self.generated_token_count_jmespath, chunk)
-                    if self.generated_token_count_jmespath
-                    else None
-                )
-                if chk_tokens_output is not None:
-                    num_tokens_output = chk_tokens_output
+        # Post-process additional data from chunks
+        # (after performance timing, to avoid counting JMESPath overhead)
+        num_tokens_input = None
+        num_tokens_output = None
+        resp_id = None
+        for chunk in chunks:
+            if "id" in chunk:
+                resp_id = chunk["id"]
+            chk_tokens_input = (
+                jmespath.search(self.input_token_count_jmespath, chunk)
+                if self.input_token_count_jmespath
+                else None
+            )
+            if chk_tokens_input is not None:
+                num_tokens_input = chk_tokens_input
+            chk_tokens_output = (
+                jmespath.search(self.generated_token_count_jmespath, chunk)
+                if self.generated_token_count_jmespath
+                else None
+            )
+            if chk_tokens_output is not None:
+                num_tokens_output = chk_tokens_output
 
-            response = InvocationResponse(
-                id=resp_id or uuid4().hex,
-                response_text=output_text,
-                time_to_first_token=time_to_first_token,
-                time_to_last_token=time_to_last_token,
-                num_tokens_input=num_tokens_input,
-                num_tokens_output=num_tokens_output,
-                retries=client_response.get("ResponseMetadata", {}).get(
-                    "RetryAttempts"
-                ),
-            )
-            return response
-
-        except KeyError as e:
-            logger.error(f"Missing required field in response: {e}")
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Missing required field: {e}",
-            )
-        except TypeError as e:
-            logger.error(f"Unexpected type in response: {e}")
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Type error in response: {e}",
-            )
-        except Exception as e:
-            logger.error(f"Error parsing response stream: {e}")
-            return InvocationResponse.error_output(
-                id=uuid4().hex,
-                error=f"Stream parsing error: {e}",
-            )
+        return InvocationResponse(
+            id=resp_id or client_response.get("ResponseMetadata", {}).get("RequestId"),
+            response_text=output_text,
+            time_to_first_token=time_to_first_token,
+            time_to_last_token=time_to_last_token,
+            num_tokens_input=num_tokens_input,
+            num_tokens_output=num_tokens_output,
+            error=error,
+            retries=client_response.get("ResponseMetadata", {}).get("RetryAttempts"),
+        )

--- a/llmeter/endpoints/litellm.py
+++ b/llmeter/endpoints/litellm.py
@@ -6,7 +6,6 @@ import logging
 import os
 import time
 from typing import Any, Sequence
-from uuid import uuid4
 
 import litellm
 from litellm import CustomStreamWrapper, completion
@@ -44,6 +43,11 @@ class LiteLLMBase(Endpoint):
     def _parse_payload(self, payload):
         return json.dumps(payload.get("messages"))
 
+    def prepare_payload(self, payload, **kwargs):
+        if kwargs:
+            payload = {**payload, **kwargs}
+        return payload
+
     @staticmethod
     def create_payload(
         user_message: str | Sequence[str],
@@ -76,25 +80,14 @@ class LiteLLMBase(Endpoint):
 
 
 class LiteLLM(LiteLLMBase):
-    def invoke(self, payload, **kwargs):
-        try:
-            response = completion(model=self.litellm_model, **payload, **kwargs)
-            if not isinstance(response, ModelResponse):
-                raise ValueError(f"Expected ModelResponse, got {type(response)}")
-            response = self._parse_converse_response(response)
-            response.input_prompt = self._parse_payload(payload)
-            return response
+    def invoke(self, payload):
+        response = completion(model=self.litellm_model, **payload)
+        if not isinstance(response, ModelResponse):
+            raise ValueError(f"Expected ModelResponse, got {type(response)}")
+        return self.parse_response(response, self._start_t)
 
-        except Exception as e:
-            logger.exception(e)
-            response = InvocationResponse.error_output(
-                input_payload=payload, error=str(e), id=uuid4().hex
-            )
-            response.input_prompt = self._parse_payload(payload)
-            return response
-
-    def _parse_converse_response(
-        self, client_response: ModelResponse
+    def parse_response(
+        self, client_response: ModelResponse, start_t: float
     ) -> InvocationResponse:
         response = InvocationResponse(
             id=client_response.id,
@@ -111,15 +104,21 @@ class LiteLLM(LiteLLMBase):
 
 
 class LiteLLMStreaming(LiteLLMBase):
-    def invoke(self, payload, **kwargs):
+    def invoke(self, payload):
+        response = completion(model=self.litellm_model, **payload)
+
+        if not isinstance(response, CustomStreamWrapper):
+            raise ValueError(f"Expected CustomStreamWrapper, got {type(response)}")
+        return self.parse_response(response, self._start_t)
+
+    def prepare_payload(self, payload, **kwargs):
         # Make a copy of payload to avoid modifying the original
         payload_copy = payload.copy()
 
-        # Create a clean kwargs dict without conflicting parameters
-        clean_kwargs = {}
+        # Merge kwargs, excluding stream-related keys (we control those)
         for key, value in kwargs.items():
             if key not in ["stream", "stream_options"]:
-                clean_kwargs[key] = value
+                payload_copy[key] = value
 
         # Ensure streaming is enabled
         payload_copy["stream"] = True
@@ -131,30 +130,12 @@ class LiteLLMStreaming(LiteLLMBase):
         elif "stream_options" not in payload_copy:
             payload_copy["stream_options"] = {"include_usage": True}
         else:
-            # Merge with existing stream_options in payload if present
             existing_options = payload_copy.get("stream_options", {})
             payload_copy["stream_options"] = {**existing_options, "include_usage": True}
 
-        try:
-            start_t = time.perf_counter()
-            response = completion(
-                model=self.litellm_model, **payload_copy, **clean_kwargs
-            )
-        except Exception as e:
-            logger.exception(e)
-            response = InvocationResponse.error_output(
-                input_payload=payload, error=str(e), id=uuid4().hex
-            )
-            response.input_prompt = self._parse_payload(payload)
-            return response
+        return payload_copy
 
-        if not isinstance(response, CustomStreamWrapper):
-            raise ValueError(f"Expected CustomStreamWrapper, got {type(response)}")
-        response = self._parse_stream(response, start_t)
-        response.input_prompt = self._parse_payload(payload)
-        return response
-
-    def _parse_stream(
+    def parse_response(
         self, client_response: CustomStreamWrapper, start_t: float
     ) -> InvocationResponse:
         usage = None

--- a/llmeter/endpoints/openai.py
+++ b/llmeter/endpoints/openai.py
@@ -6,10 +6,9 @@ import base64
 import logging
 import os
 import time
-from typing import Any, cast, Literal
-from uuid import uuid4
+from typing import Any, Literal, cast
 
-from openai import APIConnectionError, OpenAI
+from openai import OpenAI
 from openai.types.chat import (
     ChatCompletion,
     ChatCompletionChunk,
@@ -225,86 +224,49 @@ class OpenAIEndpoint(Endpoint):
 class OpenAICompletionEndpoint(OpenAIEndpoint):
     """Endpoint for OpenAI-compatible Chat Completion APIs (non-streaming mode)"""
 
-    def invoke(
-        self, payload: CompletionCreateParams, **kwargs: Any
-    ) -> InvocationResponse:
-        """Invoke the OpenAI chat completion API.
+    def invoke(self, payload: CompletionCreateParams) -> InvocationResponse:
+        """Invoke the OpenAI chat completion API."""
+        client_response: ChatCompletion = self._client.chat.completions.create(
+            **payload
+        )
+        return self.parse_response(client_response, self._start_t)
 
-        Args:
-            payload (CompletionCreateParams): Request payload
-            **kwargs (Any): Additional parameters for the request
-
-        Returns:
-            InvocationResponse: Response from the API
-        """
+    def prepare_payload(self, payload, **kwargs):
         payload = {**kwargs, **payload}
         payload["model"] = self.model_id
+        return payload
 
-        start_t = time.perf_counter()
-        try:
-            client_response: ChatCompletion = self._client.chat.completions.create(
-                **payload
-            )
-        except (APIConnectionError, Exception) as e:
-            logger.error(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-
-        response = self._parse_converse_response(client_response, start_t)
-        response.input_payload = payload
-        response.input_prompt = self._parse_payload(payload)
-        return response
-
-    def _parse_converse_response(self, client_response: ChatCompletion, start_t: float):
+    def parse_response(self, client_response: ChatCompletion, start_t: float):
         usage = client_response.usage
+        cached_tokens = None
+        if usage and usage.prompt_tokens_details:
+            cached_tokens = getattr(usage.prompt_tokens_details, "cached_tokens", None)
         return InvocationResponse(
             id=client_response.id,
             response_text=client_response.choices[0].message.content,
             num_tokens_input=usage and usage.prompt_tokens,
             num_tokens_output=usage and usage.completion_tokens,
-            time_to_last_token=time.perf_counter() - start_t,
+            num_tokens_input_cached=cached_tokens,
         )
 
 
 class OpenAICompletionStreamEndpoint(OpenAIEndpoint):
     """Endpoint for OpenAI-compatible Chat Completion APIs (streaming mode)"""
 
-    def invoke(
-        self, payload: CompletionCreateParams, **kwargs: Any
-    ) -> InvocationResponse:
-        """Invoke the OpenAI streaming chat completion API.
+    def invoke(self, payload: CompletionCreateParams) -> InvocationResponse:
+        """Invoke the OpenAI streaming chat completion API."""
+        client_response = self._client.chat.completions.create(**payload)
+        return self.parse_response(client_response, self._start_t)
 
-        Args:
-            payload (CompletionCreateParams): Request payload
-            **kwargs (Any): Additional parameters for the request
-
-        Returns:
-            InvocationResponse: Response from the API
-        """
+    def prepare_payload(self, payload, **kwargs):
         payload = {**kwargs, **payload}
         payload["model"] = self.model_id
-
         if not payload.get("stream"):
             payload["stream"] = True
             payload["stream_options"] = {"include_usage": True}
+        return payload
 
-        try:
-            start_t = time.perf_counter()
-            client_response = self._client.chat.completions.create(**payload)
-        except (APIConnectionError, Exception) as e:
-            logger.error(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-        response = self._parse_converse_stream_response(client_response, start_t)
-        response.input_payload = payload
-        response.input_prompt = self._parse_payload(payload)
-        return response
-
-    def _parse_converse_stream_response(
-        self, client_response, start_t: float
-    ) -> InvocationResponse:
+    def parse_response(self, client_response, start_t: float) -> InvocationResponse:
         """Parse the streaming API response from OpenAI chat completion API.
 
         Args:
@@ -316,6 +278,7 @@ class OpenAICompletionStreamEndpoint(OpenAIEndpoint):
         """
         prompt_tokens = None
         completion_tokens = None
+        cached_tokens = None
         response_text = ""
         response_id = None
         time_to_first_token = None
@@ -335,6 +298,10 @@ class OpenAICompletionStreamEndpoint(OpenAIEndpoint):
             if chunk.usage is not None:
                 prompt_tokens = chunk.usage.prompt_tokens
                 completion_tokens = chunk.usage.completion_tokens
+                if chunk.usage.prompt_tokens_details:
+                    cached_tokens = getattr(
+                        chunk.usage.prompt_tokens_details, "cached_tokens", None
+                    )
 
         time_to_last_token = time.perf_counter() - start_t
 
@@ -346,6 +313,7 @@ class OpenAICompletionStreamEndpoint(OpenAIEndpoint):
             response_text=response_text,
             num_tokens_input=prompt_tokens,
             num_tokens_output=completion_tokens,
+            num_tokens_input_cached=cached_tokens,
             time_to_first_token=time_to_first_token,
             time_to_last_token=time_to_last_token,
         )

--- a/llmeter/endpoints/openai_response.py
+++ b/llmeter/endpoints/openai_response.py
@@ -4,20 +4,14 @@
 import logging
 import time
 from collections.abc import Sequence
-from typing import cast, Any
-from uuid import uuid4
+from typing import Any, cast
 
 from openai import (
-    APIConnectionError,
-    AuthenticationError,
-    BadRequestError,
     OpenAI,
-    RateLimitError,
 )
 from openai.types.responses import Response, ResponseCreateParams
 from openai.types.responses.response_create_params import (
     ResponseCreateParamsNonStreaming,
-    ResponseCreateParamsStreaming,
 )
 
 from .base import Endpoint, InvocationResponse
@@ -53,60 +47,17 @@ class OpenAIResponseEndpoint(Endpoint):
         super().__init__(endpoint_name, model_id, provider=provider)
         self._client = OpenAI(api_key=api_key, **kwargs)
 
-    def invoke(
-        self, payload: ResponseCreateParamsNonStreaming, **kwargs
-    ) -> InvocationResponse:
-        """Invoke the Responses API.
+    def invoke(self, payload: ResponseCreateParamsNonStreaming) -> InvocationResponse:
+        """Invoke the Responses API."""
+        client_response = self._client.responses.create(**payload)
+        return self.parse_response(client_response, self._start_t)
 
-        Args:
-            payload: Request payload typed as
-                ``openai.types.responses.ResponseCreateParams``. You can build
-                this yourself using the OpenAI SDK types, or use the
-                ``create_payload`` convenience helper.
-            **kwargs: Additional parameters to merge with payload
-
-        Returns:
-            InvocationResponse with response text, timing, and token counts
-        """
-        # Merge kwargs with payload and add model_id
+    def prepare_payload(self, payload, **kwargs):
         payload = {**kwargs, **payload}  # type: ignore
         payload["model"] = self.model_id
+        return payload
 
-        start_t = time.perf_counter()
-        try:
-            client_response = self._client.responses.create(**payload)
-        except APIConnectionError as e:
-            logger.exception(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-        except AuthenticationError as e:
-            logger.exception(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-        except RateLimitError as e:
-            logger.exception(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-        except BadRequestError as e:
-            logger.exception(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-        except Exception as e:
-            logger.exception(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-
-        response = self._parse_response(client_response, start_t)
-        response.input_payload = payload
-        response.input_prompt = self._parse_payload(payload)
-        return response
-
-    def _parse_response(
+    def parse_response(
         self, client_response: Response, start_t: float
     ) -> InvocationResponse:
         """Parse Response API output into InvocationResponse.
@@ -122,16 +73,20 @@ class OpenAIResponseEndpoint(Endpoint):
 
         input_tokens = None
         output_tokens = None
+        cached_tokens = None
         if usage is not None:
             input_tokens = usage.input_tokens
             output_tokens = usage.output_tokens
+            details = getattr(usage, "input_tokens_details", None)
+            if details:
+                cached_tokens = getattr(details, "cached_tokens", None)
 
         return InvocationResponse(
             id=client_response.id,
             response_text=client_response.output_text,
             num_tokens_input=input_tokens,
             num_tokens_output=output_tokens,
-            time_to_last_token=time.perf_counter() - start_t,
+            num_tokens_input_cached=cached_tokens,
         )
 
     @staticmethod
@@ -236,63 +191,20 @@ class OpenAIResponseStreamEndpoint(OpenAIResponseEndpoint):
             **kwargs,
         )
 
-    def invoke(self, payload: ResponseCreateParams, **kwargs) -> InvocationResponse:
-        """Invoke the Responses API with streaming.
+    def invoke(self, payload: ResponseCreateParams) -> InvocationResponse:
+        """Invoke the Responses API with streaming."""
+        client_response = self._client.responses.create(**payload)
+        return self.parse_response(client_response, self._start_t)
 
-        Args:
-            payload: Request payload typed as
-                ``openai.types.responses.ResponseCreateParams``.
-            **kwargs: Additional parameters to merge with payload
-
-        Returns:
-            InvocationResponse with response text, timing (TTFT, TTLT), and token counts
-        """
-        # Merge kwargs with payload and add model_id
+    def prepare_payload(self, payload, **kwargs):
         payload = {**kwargs, **payload}
         payload["model"] = self.model_id
-
-        # Set streaming parameters
         if not payload.get("stream"):
             payload["stream"] = True
             payload["stream_options"] = {"include_usage": True}
+        return payload
 
-        try:
-            start_t = time.perf_counter()
-            client_response = self._client.responses.create(**payload)
-        except APIConnectionError as e:
-            logger.exception(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-        except AuthenticationError as e:
-            logger.exception(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-        except RateLimitError as e:
-            logger.exception(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-        except BadRequestError as e:
-            logger.exception(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-        except Exception as e:
-            logger.exception(e)
-            return InvocationResponse.error_output(
-                input_payload=payload, id=uuid4().hex, error=str(e)
-            )
-
-        response = self._parse_stream_response(client_response, start_t)
-        response.input_payload = payload
-        response.input_prompt = self._parse_payload(payload)
-        return response
-
-    def _parse_stream_response(
-        self, client_response, start_t: float
-    ) -> InvocationResponse:
+    def parse_response(self, client_response, start_t: float) -> InvocationResponse:
         """Parse streaming Response API output into InvocationResponse.
 
         Processes typed events from the stream:
@@ -309,6 +221,7 @@ class OpenAIResponseStreamEndpoint(OpenAIResponseEndpoint):
         """
         input_tokens = None
         output_tokens = None
+        cached_tokens = None
         response_text = ""
         response_id = None
         time_to_first_token = None
@@ -327,6 +240,9 @@ class OpenAIResponseStreamEndpoint(OpenAIResponseEndpoint):
                 if usage is not None:
                     input_tokens = usage.input_tokens
                     output_tokens = usage.output_tokens
+                    details = getattr(usage, "input_tokens_details", None)
+                    if details:
+                        cached_tokens = getattr(details, "cached_tokens", None)
 
         time_to_last_token = time.perf_counter() - start_t
 
@@ -338,6 +254,7 @@ class OpenAIResponseStreamEndpoint(OpenAIResponseEndpoint):
             response_text=response_text,
             num_tokens_input=input_tokens,
             num_tokens_output=output_tokens,
+            num_tokens_input_cached=cached_tokens,
             time_to_first_token=time_to_first_token,
             time_to_last_token=time_to_last_token,
         )

--- a/llmeter/endpoints/sagemaker.py
+++ b/llmeter/endpoints/sagemaker.py
@@ -6,13 +6,10 @@ import json
 import logging
 import time
 import warnings
-from uuid import uuid4
 
 import boto3
 import jmespath
-from botocore.exceptions import ClientError
 
-from .base import Endpoint, InvocationResponse
 from ..prompt_utils import (
     AudioContent,
     ContentItem,
@@ -21,6 +18,7 @@ from ..prompt_utils import (
     MediaContent,
     VideoContent,
 )
+from .base import Endpoint, InvocationResponse
 
 logger = logging.getLogger(__name__)
 
@@ -174,85 +172,48 @@ class SageMakerEndpoint(SageMakerBase):
     a SageMaker endpoint and parsing its response.
     """
 
-    def _parse_client_response(self, client_response: dict | None) -> dict | None:
-        """
-        Parse the response from the SageMaker endpoint.
-
-        This method processes the raw response from the SageMaker endpoint,
-        extracting the generated text and token count if available.
+    def parse_response(self, client_response, start_t: float) -> InvocationResponse:
+        """Parse the response from the SageMaker endpoint.
 
         Args:
-            client_response (Dict | None): The raw response from the SageMaker endpoint.
+            client_response: The raw response from the SageMaker endpoint.
+            start_t: The timestamp when the request was initiated.
 
         Returns:
-            Dict | None: A dictionary containing the parsed response, or None if the input is None.
+            InvocationResponse with the generated text and metadata.
         """
-
         if client_response is None:
-            return None
+            return InvocationResponse(response_text=None)
+
         client_response_body_json = client_response["Body"].read().decode("utf-8")
         client_response_body = json.loads(client_response_body_json)
-        ret_dict = {
-            "output_text": jmespath.search(
-                self.generated_text_jmespath, client_response_body
-            )
-        }
+
+        response_text = jmespath.search(
+            self.generated_text_jmespath, client_response_body
+        )
+        num_tokens_output = None
         if self.token_count_jmespath:
-            ret_dict["num_tokens_output"] = jmespath.search(
+            num_tokens_output = jmespath.search(
                 self.token_count_jmespath, client_response_body
             )
-        return ret_dict
-
-    def invoke(self, payload: dict) -> InvocationResponse:
-        """
-        Invoke the SageMaker endpoint with the given payload.
-
-        This method sends a request to the SageMaker endpoint, processes the response,
-        and returns an InvocationResponse object with the results.
-
-        Args:
-            payload (Dict): The input payload for the model.
-
-        Returns:
-            InvocationResponse: An object containing the model's response and associated metrics.
-
-        Raises:
-            ClientError: If there's an error during the invocation of the SageMaker endpoint.
-            Exception: If there's any other error during the invocation or parsing of the response.
-        """
-
-        json_payload = json.dumps(payload)
-        input_prompt = self._parse_input(payload)
-
-        start_t = time.perf_counter()
-        try:
-            client_response = self._sagemaker_runtime.invoke_endpoint(
-                EndpointName=self.endpoint_name,
-                ContentType="application/json",
-                Body=bytes(json_payload, "utf-8"),
-            )
-        except (ClientError, Exception) as e:
-            logger.error(e)
-            return InvocationResponse.error_output(
-                input_payload=payload,
-                id=uuid4().hex,
-                error=str(e),
-            )
-
-        time_to_last_token = time.perf_counter() - start_t
-        parsed_response = self._parse_client_response(client_response)
-        if parsed_response:
-            response_text = parsed_response.get("output_text", "")
-            num_tokens_output = parsed_response.get("num_tokens_output", None)
 
         return InvocationResponse(
-            input_payload=payload,
-            id=uuid4().hex,
-            response_text=response_text,
-            time_to_last_token=time_to_last_token,
-            input_prompt=input_prompt,
+            id=client_response.get("ResponseMetadata", {}).get("RequestId"),
+            response_text=response_text or "",
             num_tokens_output=num_tokens_output if num_tokens_output else None,
+            retries=client_response.get("ResponseMetadata", {}).get("RetryAttempts"),
         )
+
+    def invoke(self, payload: dict) -> InvocationResponse:
+        """Invoke the SageMaker endpoint with the given payload."""
+        json_payload = json.dumps(payload)
+
+        client_response = self._sagemaker_runtime.invoke_endpoint(
+            EndpointName=self.endpoint_name,
+            ContentType="application/json",
+            Body=bytes(json_payload, "utf-8"),
+        )
+        return self.parse_response(client_response, self._start_t)
 
 
 class SageMakerStreamEndpoint(SageMakerBase):
@@ -263,9 +224,7 @@ class SageMakerStreamEndpoint(SageMakerBase):
     streaming responses from a SageMaker endpoint.
     """
 
-    def _parse_client_response(
-        self, client_response, start_t: float
-    ) -> InvocationResponse:
+    def parse_response(self, client_response, start_t: float) -> InvocationResponse:
         """
         Parse the streaming response from the SageMaker endpoint.
 
@@ -288,60 +247,32 @@ class SageMakerStreamEndpoint(SageMakerBase):
         num_tokens_output = len(response_text_tokens)
 
         return InvocationResponse(
-            id=uuid4().hex,
+            id=client_response.get("ResponseMetadata", {}).get("RequestId"),
             response_text="".join(response_text_tokens),
             time_to_first_token=time_to_first_token,
             time_to_last_token=time_to_last_token,
             num_tokens_output=num_tokens_output,
+            retries=client_response.get("ResponseMetadata", {}).get("RetryAttempts"),
         )
 
     def invoke(self, payload: dict) -> InvocationResponse:
-        """
-        Invoke a SageMaker endpoint with the given payload.
+        """Invoke a SageMaker streaming endpoint with the given payload."""
+        json_payload = json.dumps(payload)
 
-        This method sends a request to the SageMaker endpoint and handles
-        the streaming response.
+        client_response = self._sagemaker_runtime.invoke_endpoint_with_response_stream(
+            EndpointName=self.endpoint_name,
+            Body=json_payload,
+            ContentType="application/json",
+        )
+        return self.parse_response(client_response, self._start_t)
 
-        Args:
-            payload (Dict): The input payload for the model.
-
-        Returns:
-            InvocationResponse: An object containing the model's response and metrics.
-
-        Raises:
-            Exception: If there's an error during the invocation or parsing of the response.
-        """
-
-        _payload = payload
-        if "parameters" in _payload:
-            _payload["parameters"].pop("decoder_input_details", None)
-        if "stream" not in _payload:
+    def prepare_payload(self, payload, **kwargs):
+        if "parameters" in payload:
+            payload["parameters"].pop("decoder_input_details", None)
+        if "stream" not in payload:
             warnings.warn("stream not specified in payload, defaulting to True")
-            _payload["stream"] = True
-
-        json_payload = json.dumps(_payload)
-        input_prompt = self._parse_input(_payload)
-
-        start_t = time.perf_counter()
-        try:
-            client_response = (
-                self._sagemaker_runtime.invoke_endpoint_with_response_stream(
-                    EndpointName=self.endpoint_name,
-                    Body=json_payload,
-                    ContentType="application/json",
-                )
-            )
-        except Exception as e:
-            logger.error(e)
-            return InvocationResponse.error_output(input_payload=payload, error=str(e))
-
-        try:
-            response = self._parse_client_response(client_response, start_t)
-            response.input_payload = payload
-            response.input_prompt = input_prompt
-            return response
-        except Exception as e:
-            return InvocationResponse.error_output(input_payload=payload, error=str(e))
+            payload["stream"] = True
+        return payload
 
     @staticmethod
     def create_payload(

--- a/llmeter/plotting/__init__.py
+++ b/llmeter/plotting/__init__.py
@@ -8,11 +8,11 @@ or via the `llmeter[plotting]` extra.
 
 from .plotting import (
     boxplot_by_dimension,
-    plot_heatmap,
-    scatter_histogram_2d,
-    plot_load_test_results,
-    histogram_by_dimension,
     color_sequences,
+    histogram_by_dimension,
+    plot_heatmap,
+    plot_load_test_results,
+    scatter_histogram_2d,
 )
 
 __all__ = [

--- a/llmeter/prompt_utils.py
+++ b/llmeter/prompt_utils.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Iterator
 from upath import UPath as Path
 from upath.types import ReadablePathLike, WritablePathLike
 
-from .json_utils import llmeter_default_serializer, llmeter_bytes_decoder
+from .json_utils import llmeter_bytes_decoder, llmeter_default_serializer
 from .tokenizers import DummyTokenizer, Tokenizer
 from .utils import DeferredError, ensure_path
 

--- a/llmeter/results.py
+++ b/llmeter/results.py
@@ -281,6 +281,7 @@ class Result:
             "time_to_first_token",
             "num_tokens_output",
             "num_tokens_input",
+            "num_tokens_input_cached",
         ]
 
         results_stats = _get_stats_from_results(
@@ -442,6 +443,9 @@ def _get_run_stats(results: Result):
     )
     stats["total_output_tokens"] = sum(
         jmespath.search("[:].num_tokens_output", data=data)
+    )
+    stats["total_cached_input_tokens"] = sum(
+        v for v in jmespath.search("[:].num_tokens_input_cached", data=data) if v
     )
     stats["average_input_tokens_per_minute"] = (
         results.total_test_time

--- a/llmeter/tokenizers.py
+++ b/llmeter/tokenizers.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
+
+import json
 from abc import ABC, abstractmethod
 from typing import Any
 
 from upath import UPath
 from upath.types import ReadablePathLike, WritablePathLike
-import json
 
 from .utils import ensure_path
 

--- a/tests/integ/conftest.py
+++ b/tests/integ/conftest.py
@@ -148,6 +148,7 @@ def test_image_bytes():
         tuple: (image1_bytes, image2_bytes) - Two JPEG images as bytes
     """
     import io
+
     from PIL import Image
 
     # 32x32 red square JPEG - binary format

--- a/tests/integ/test_bedrock_converse.py
+++ b/tests/integ/test_bedrock_converse.py
@@ -84,8 +84,11 @@ def test_bedrock_converse_non_streaming(
         f"Response should not contain errors: {response.error}"
     )
 
-    # Verify response has an ID
+    # Verify response has an ID from the Bedrock API (AWS RequestId format)
     assert response.id is not None, "Response should have an ID"
+    assert "-" in response.id, (
+        f"Response ID should be an AWS RequestId (UUID with hyphens), got: {response.id}"
+    )
 
 
 @pytest.mark.integ
@@ -161,8 +164,11 @@ def test_bedrock_converse_streaming(
         f"Response should not contain errors: {response.error}"
     )
 
-    # Verify response has an ID
+    # Verify response has an ID from the Bedrock API (AWS RequestId format)
     assert response.id is not None, "Response should have an ID"
+    assert "-" in response.id, (
+        f"Response ID should be an AWS RequestId (UUID with hyphens), got: {response.id}"
+    )
 
 
 @pytest.mark.integ
@@ -235,8 +241,11 @@ def test_bedrock_converse_with_image(
         f"Response should not contain errors: {response.error}"
     )
 
-    # Verify response has an ID
+    # Verify response has an ID from the Bedrock API (AWS RequestId format)
     assert response.id is not None, "Response should have an ID"
+    assert "-" in response.id, (
+        f"Response ID should be an AWS RequestId (UUID with hyphens), got: {response.id}"
+    )
 
 
 @pytest.mark.integ
@@ -286,6 +295,12 @@ def test_bedrock_converse_streaming_with_image(
         f"Response should not contain errors: {response.error}"
     )
 
+    # Verify response has an ID from the Bedrock API (AWS RequestId format)
+    assert response.id is not None, "Response should have an ID"
+    assert "-" in response.id, (
+        f"Response ID should be an AWS RequestId (UUID with hyphens), got: {response.id}"
+    )
+
 
 def test_save_load_payload_with_image(test_payload_with_image, tmp_path):
     """
@@ -303,7 +318,7 @@ def test_save_load_payload_with_image(test_payload_with_image, tmp_path):
         test_payload_with_image: Test payload with image content (from fixture).
         tmp_path: Temporary directory for test files (from pytest).
     """
-    from llmeter.prompt_utils import save_payloads, load_payloads
+    from llmeter.prompt_utils import load_payloads, save_payloads
 
     # Save payload with image
     output_file = save_payloads(test_payload_with_image, tmp_path, "test_image.jsonl")
@@ -346,7 +361,7 @@ def test_save_load_payload_with_video(tmp_path):
     Args:
         tmp_path: Temporary directory for test files (from pytest).
     """
-    from llmeter.prompt_utils import save_payloads, load_payloads
+    from llmeter.prompt_utils import load_payloads, save_payloads
 
     # Create a test payload with video content (simulated video bytes)
     video_payload = {
@@ -408,7 +423,7 @@ def test_save_load_multiple_images(tmp_path):
     Args:
         tmp_path: Temporary directory for test files (from pytest).
     """
-    from llmeter.prompt_utils import save_payloads, load_payloads
+    from llmeter.prompt_utils import load_payloads, save_payloads
 
     # Create a test payload with multiple images
     multi_image_payload = {
@@ -500,8 +515,8 @@ def test_round_trip_bedrock_converse_structure(
         aws_credentials: Boto3 session with valid AWS credentials (from fixture).
         aws_region: AWS region for testing (from fixture).
     """
-    from llmeter.prompt_utils import save_payloads, load_payloads
     from llmeter.endpoints.bedrock import BedrockConverse
+    from llmeter.prompt_utils import load_payloads, save_payloads
 
     # Create a complete Bedrock Converse payload with all typical fields
     complete_payload = {

--- a/tests/integ/test_bedrock_converse.py
+++ b/tests/integ/test_bedrock_converse.py
@@ -302,6 +302,101 @@ def test_bedrock_converse_streaming_with_image(
     )
 
 
+@pytest.mark.integ
+def test_bedrock_converse_streaming_prompt_caching(
+    aws_credentials, aws_region, bedrock_test_model
+):
+    """Test that BedrockConverseStream captures prompt caching metrics.
+
+    This test validates that:
+    - A request with a cachePoint in the system prompt succeeds
+    - ``num_tokens_input_cached`` is populated on the response
+    - A second request with the same prefix reads from cache
+
+    Prompt caching requires a minimum of 1024 tokens in the cached prefix
+    for Nova models. We use a long system prompt to meet this threshold.
+
+    Args:
+        aws_credentials: Boto3 session with valid AWS credentials.
+        aws_region: AWS region for testing.
+        bedrock_test_model: Model ID for testing.
+
+    AWS Permissions Required:
+        - bedrock:InvokeModelWithResponseStream
+
+    Estimated Cost:
+        ~$0.0003 per test run (two streaming calls with ~2K cached input tokens)
+    """
+    import time
+    from uuid import uuid4
+
+    from llmeter.endpoints.bedrock import BedrockConverseStream
+
+    endpoint = BedrockConverseStream(model_id=bedrock_test_model, region=aws_region)
+
+    # Unique prefix per test run to avoid accidental cache hits from previous runs.
+    run_id = uuid4().hex
+
+    # Build a system prompt long enough to meet the 1024-token minimum for
+    # Nova prompt caching.  Each "rule" line is ~25 tokens, so 80 lines ≈ 2000.
+    long_system_text = (
+        f"You are a helpful assistant (session {run_id}). Follow these rules:\n"
+        + "\n".join(
+            f"Rule {i}: Always be concise, accurate, and helpful in your responses. "
+            "This is an important guideline that must be followed at all times."
+            for i in range(1, 81)
+        )
+    )
+
+    payload = {
+        "system": [
+            {"text": long_system_text},
+            {"cachePoint": {"type": "default"}},
+        ],
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"text": "Say hello in one word."}],
+            }
+        ],
+        "inferenceConfig": {"maxTokens": 10},
+    }
+
+    # First call: writes the system prompt to cache
+    response1 = endpoint.invoke(payload)
+    assert response1.error is None, f"First call should not error: {response1.error}"
+    assert response1.response_text, "First call should return text"
+
+    # num_tokens_input_cached should be present (may be 0 on cache write)
+    assert response1.num_tokens_input_cached is not None, (
+        "Response should include num_tokens_input_cached field"
+    )
+
+    # Brief pause to allow cache propagation
+    time.sleep(1)
+
+    # Second call with same system prefix: should read from cache
+    payload_2 = {
+        **payload,
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"text": "Say goodbye in one word."}],
+            }
+        ],
+    }
+    response2 = endpoint.invoke(payload_2)
+    assert response2.error is None, f"Second call should not error: {response2.error}"
+    assert response2.response_text, "Second call should return text"
+
+    assert response2.num_tokens_input_cached is not None, (
+        "Second call should report num_tokens_input_cached"
+    )
+    assert response2.num_tokens_input_cached > 0, (
+        f"Expected cached tokens > 0 on cache hit, got {response2.num_tokens_input_cached}"
+    )
+
+
 def test_save_load_payload_with_image(test_payload_with_image, tmp_path):
     """
     Test saving and loading payload with image content using serialization.

--- a/tests/integ/test_bedrock_invoke.py
+++ b/tests/integ/test_bedrock_invoke.py
@@ -109,8 +109,11 @@ def test_bedrock_invoke_non_streaming(aws_credentials, aws_region, bedrock_test_
         f"Response should not contain errors: {response.error}"
     )
 
-    # Verify response has an ID
+    # Verify response has an ID from the Bedrock API
     assert response.id is not None, "Response should have an ID"
+    assert "-" in response.id, (
+        f"Response ID should be an AWS RequestId (UUID with hyphens), got: {response.id}"
+    )
 
 
 @pytest.mark.integ
@@ -195,6 +198,12 @@ def test_bedrock_invoke_with_image(aws_credentials, aws_region, bedrock_test_mod
     assert "red" in response_lower or "blue" in response_lower, (
         "Model should identify at least one color (red/blue) from the split image, got: "
         f"{response.response_text[:200]}"
+    )
+
+    # Verify response has an ID from the Bedrock API
+    assert response.id is not None, "Response should have an ID"
+    assert "-" in response.id, (
+        f"Response ID should be an AWS RequestId (UUID with hyphens), got: {response.id}"
     )
 
 
@@ -299,8 +308,11 @@ def test_bedrock_invoke_streaming(aws_credentials, aws_region, bedrock_test_mode
         f"Response should not contain errors: {response.error}"
     )
 
-    # Verify response has an ID
+    # Verify response has an ID from the Bedrock API
     assert response.id is not None, "Response should have an ID"
+    assert "-" in response.id, (
+        f"Response ID should be an AWS RequestId (UUID with hyphens), got: {response.id}"
+    )
 
 
 def test_save_load_invoke_payload_with_image(tmp_path):
@@ -319,9 +331,11 @@ def test_save_load_invoke_payload_with_image(tmp_path):
     Args:
         tmp_path: Temporary directory for test files (from pytest).
     """
-    from llmeter.prompt_utils import save_payloads, load_payloads
     import io
+
     from PIL import Image
+
+    from llmeter.prompt_utils import load_payloads, save_payloads
 
     # Create a simple test image
     img = Image.new("RGB", (50, 50), color="blue")
@@ -403,7 +417,7 @@ def test_round_trip_invoke_structure(
         aws_region: AWS region for testing (from fixture).
         bedrock_test_model: Model ID for testing (from fixture).
     """
-    from llmeter.prompt_utils import save_payloads, load_payloads
+    from llmeter.prompt_utils import load_payloads, save_payloads
 
     # Create a complete Bedrock Invoke payload with provider-specific structure
     # This mimics the actual Anthropic Claude Messages API format used by InvokeModel

--- a/tests/integ/test_openai_bedrock.py
+++ b/tests/integ/test_openai_bedrock.py
@@ -248,8 +248,9 @@ def test_save_load_openai_payload_with_image_url(tmp_path):
     Args:
         tmp_path: Temporary directory for test files (from pytest).
     """
-    from llmeter.prompt_utils import save_payloads, load_payloads
     import base64
+
+    from llmeter.prompt_utils import load_payloads, save_payloads
 
     # Create a small test image (1x1 red pixel PNG)
     test_image_bytes = base64.b64decode(
@@ -335,8 +336,9 @@ def test_save_load_openai_complete_structure(
     Estimated Cost:
         ~$0.0002 per test run (using Qwen3-VL with minimal tokens)
     """
-    from llmeter.prompt_utils import save_payloads, load_payloads
     import base64
+
+    from llmeter.prompt_utils import load_payloads, save_payloads
 
     # Get test images as binary data
     image1_binary, image2_binary = test_image_bytes

--- a/tests/unit/endpoints/test_bedrock.py
+++ b/tests/unit/endpoints/test_bedrock.py
@@ -46,7 +46,7 @@ class TestBedrock:
 
         # Call the method under test
         start_time = time.perf_counter()
-        result = bedrock_stream._parse_conversation_stream(client_response, start_time)
+        result = bedrock_stream.parse_response(client_response, start_time)
 
         # Assert the result is an InvocationResponse object
         assert isinstance(result, InvocationResponse)
@@ -93,9 +93,7 @@ class TestBedrock:
             mock_perf_counter.side_effect = [start_t + 0.1, start_t + 0.2]
 
             bedrock_stream = BedrockConverseStream(model_id="test_model")
-            result = bedrock_stream._parse_conversation_stream(
-                mock_client_response, start_t
-            )
+            result = bedrock_stream.parse_response(mock_client_response, start_t)
 
         assert isinstance(result, InvocationResponse)
         assert result.response_text == "Hello world!"
@@ -131,11 +129,11 @@ class TestBedrock:
         }
 
         # Call the method
-        result = bedrock_stream._parse_conversation_stream(client_response, start_t)
+        result = bedrock_stream.parse_response(client_response, start_t)
 
         # Assertions
         assert isinstance(result, InvocationResponse)
-        assert result.id
+        # id is back-filled by the invoke wrapper, not by parse_response
         assert result.response_text == ""
         assert result.time_to_last_token is not None
         assert result.time_to_first_token is None
@@ -169,7 +167,7 @@ class TestBedrock:
         start_t = time.perf_counter()
 
         # Call the method
-        response = bedrock_stream._parse_conversation_stream(client_response, start_t)
+        response = bedrock_stream.parse_response(client_response, start_t)
 
         # Assertions
         assert isinstance(response, InvocationResponse)
@@ -216,7 +214,7 @@ class TestBedrock:
         start_t = time.perf_counter()
 
         # Call the method under test
-        result = bedrock_stream._parse_conversation_stream(mock_response, start_t)
+        result = bedrock_stream.parse_response(mock_response, start_t)
 
         # Assertions
         assert isinstance(result, InvocationResponse)
@@ -253,13 +251,13 @@ class TestBedrock:
         start_t = time.perf_counter()
 
         # Call the method under test
-        response = bedrock_stream._parse_conversation_stream(client_response, start_t)
+        response = bedrock_stream.parse_response(client_response, start_t)
 
         # Assert the response is an InvocationResponse
         assert isinstance(response, InvocationResponse)
 
         # Assert the response contains expected values
-        assert response.id is not None
+        # id is back-filled by the invoke wrapper, not by parse_response
         assert response.response_text == "Hello"
         assert response.time_to_last_token is not None
         assert response.time_to_first_token is not None
@@ -276,7 +274,7 @@ class TestBedrock:
         empty_response = {"stream": [], "ResponseMetadata": {"RetryAttempts": 0}}
         start_t = 0.0
 
-        result = bedrock._parse_conversation_stream(empty_response, start_t)
+        result = bedrock.parse_response(empty_response, start_t)
 
         assert isinstance(result, InvocationResponse)
         assert result.response_text == ""
@@ -286,17 +284,15 @@ class TestBedrock:
     def test__parse_conversation_stream_incorrect_type(self):
         """
         Test _parse_conversation_stream with incorrect input type.
+        Parsing methods are internal — they raise on bad input, and the
+        base invoke wrapper converts the exception to an error response.
         """
         bedrock = BedrockConverseStream(model_id="test_model")
         incorrect_type_response = "Not a dictionary"
         start_t = 0.0
 
-        result = bedrock._parse_conversation_stream(incorrect_type_response, start_t)
-
-        assert isinstance(result, InvocationResponse)
-        assert result.response_text is None
-        assert result.time_to_first_token is None
-        assert result.time_to_last_token is None
+        with pytest.raises(TypeError):
+            bedrock.parse_response(incorrect_type_response, start_t)
 
     def test__parse_conversation_stream_invalid_input(self):
         """
@@ -309,12 +305,8 @@ class TestBedrock:
         }
         start_t = 0.0
 
-        result = bedrock._parse_conversation_stream(invalid_response, start_t)
-
-        assert isinstance(result, InvocationResponse)
-        assert result.response_text is None
-        assert result.time_to_first_token is None
-        assert result.time_to_last_token is None
+        with pytest.raises(KeyError):
+            bedrock.parse_response(invalid_response, start_t)
 
     def test__parse_conversation_stream_missing_metadata(self):
         """
@@ -330,7 +322,7 @@ class TestBedrock:
         }
         start_t = 0.0
 
-        result = bedrock._parse_conversation_stream(response_without_metadata, start_t)
+        result = bedrock.parse_response(response_without_metadata, start_t)
 
         assert isinstance(result, InvocationResponse)
         assert result.response_text == "Hello"
@@ -340,17 +332,16 @@ class TestBedrock:
     def test__parse_converse_response_invalid_output_structure(self):
         """
         Test _parse_converse_response with an invalid 'output' structure.
-        This should return an InvocationResponse with error details.
+        Parsing methods raise on bad input; the base invoke wrapper converts
+        exceptions to error responses.
         """
         bedrock_converse = BedrockConverse(model_id="test_model")
         invalid_response = {
             "output": {"invalid_key": "value"},
             "ResponseMetadata": {"RetryAttempts": 0},
         }
-        result = bedrock_converse._parse_converse_response(invalid_response)
-        assert isinstance(result, InvocationResponse)
-        assert result.error is not None
-        assert "missing required field" in str(result.error).lower()
+        with pytest.raises(KeyError):
+            bedrock_converse.parse_response(invalid_response, 0.0)
 
     def test__parse_converse_response_invalid_usage_type(self):
         """
@@ -363,7 +354,7 @@ class TestBedrock:
             "usage": "invalid_usage",
             "ResponseMetadata": {"RetryAttempts": 0},
         }
-        result = bedrock_converse._parse_converse_response(response)
+        result = bedrock_converse.parse_response(response, 0.0)
         assert isinstance(result, InvocationResponse)
         assert result.num_tokens_input is None
         assert result.num_tokens_output is None
@@ -371,28 +362,22 @@ class TestBedrock:
     def test__parse_converse_response_missing_output(self):
         """
         Test _parse_converse_response with a dictionary missing the 'output' key.
-        This should return an InvocationResponse with an error.
         """
         bedrock_converse = BedrockConverse(model_id="test_model")
         invalid_response = {"ResponseMetadata": {"RetryAttempts": 0}}
-        result = bedrock_converse._parse_converse_response(invalid_response)
-        assert isinstance(result, InvocationResponse)
-        assert result.error is not None
-        assert "output" in str(result.error).lower()
+        with pytest.raises(KeyError):
+            bedrock_converse.parse_response(invalid_response, 0.0)
 
     def test__parse_converse_response_missing_response_metadata(self):
         """
         Test _parse_converse_response with a dictionary missing the 'ResponseMetadata' key.
-        This should return an InvocationResponse with an error.
         """
         bedrock_converse = BedrockConverse(model_id="test_model")
         invalid_response = {
             "output": {"message": {"content": [{"text": "Test output"}]}}
         }
-        result = bedrock_converse._parse_converse_response(invalid_response)
-        assert isinstance(result, InvocationResponse)
-        assert result.error is not None
-        assert "responsemetadata" in str(result.error).lower()
+        with pytest.raises(KeyError):
+            bedrock_converse.parse_response(invalid_response, 0.0)
 
     def test__parse_payload_1(self):
         """
@@ -685,14 +670,10 @@ class TestBedrock:
         payload = {"messages": [{"role": "user", "content": [{"text": "Hello"}]}]}
 
         # Act
-        with patch(
-            "llmeter.endpoints.bedrock.uuid4", return_value=Mock(hex="mock_uuid")
-        ):
-            result = bedrock_converse.invoke(payload)
+        result = bedrock_converse.invoke(payload)
 
         # Assert
         assert isinstance(result, InvocationResponse)
-        assert result.id == "mock_uuid"
         assert result.error == "API error"
         assert result.input_payload == {
             "messages": [{"role": "user", "content": [{"text": "Hello"}]}],
@@ -801,7 +782,6 @@ class TestBedrock:
         # Assert the response is an error InvocationResponse
         assert isinstance(response, InvocationResponse)
         assert response.error == "API Error"
-        # assert response.id == "mock_uuid"
         assert response.input_payload == {
             "messages": [{"role": "user", "content": "Hello"}],
             "inferenceConfig": {},
@@ -830,7 +810,7 @@ class TestBedrock:
 
         # Act
         with patch("uuid.uuid4", return_value=Mock(hex="mock_uuid")):
-            result = bedrock_converse._parse_converse_response(mock_response)
+            result = bedrock_converse.parse_response(mock_response, 0.0)
 
         # Assert
         assert isinstance(result, InvocationResponse)

--- a/tests/unit/endpoints/test_bedrock.py
+++ b/tests/unit/endpoints/test_bedrock.py
@@ -819,3 +819,53 @@ class TestBedrock:
         assert result.num_tokens_input == 10
         assert result.num_tokens_output == 20
         assert result.retries == 1
+
+    def test_invoke_stream_mid_stream_timeout(self):
+        """Verify that a timeout during stream consumption is caught by the
+        invoke wrapper and returned as an error InvocationResponse — not raised."""
+        bedrock_stream = BedrockConverseStream(model_id="test_model")
+        bedrock_stream._bedrock_client = Mock()
+
+        # converse_stream returns immediately, but iterating the stream raises
+        def exploding_stream():
+            yield {"contentBlockDelta": {"delta": {"text": "Hello"}}}
+            raise TimeoutError("Connection timed out during streaming")
+
+        bedrock_stream._bedrock_client.converse_stream.return_value = {
+            "stream": exploding_stream(),
+            "ResponseMetadata": {"RetryAttempts": 0, "RequestId": "req-123"},
+        }
+
+        response = bedrock_stream.invoke(
+            {"messages": [{"role": "user", "content": [{"text": "Hi"}]}]}
+        )
+
+        assert isinstance(response, InvocationResponse)
+        assert response.error is not None
+        assert "timed out" in response.error.lower()
+        assert response.input_payload is not None
+
+    def test_invoke_stream_connection_drop(self):
+        """Verify that a connection error mid-stream is caught and returns
+        partial data where possible."""
+        bedrock_stream = BedrockConverseStream(model_id="test_model")
+        bedrock_stream._bedrock_client = Mock()
+
+        def dropping_stream():
+            yield {"contentBlockDelta": {"delta": {"text": "Partial"}}}
+            yield {"contentBlockDelta": {"delta": {"text": " data"}}}
+            raise ConnectionError("Connection reset by peer")
+
+        bedrock_stream._bedrock_client.converse_stream.return_value = {
+            "stream": dropping_stream(),
+            "ResponseMetadata": {"RetryAttempts": 0, "RequestId": "req-456"},
+        }
+
+        response = bedrock_stream.invoke(
+            {"messages": [{"role": "user", "content": [{"text": "Hi"}]}]}
+        )
+
+        assert isinstance(response, InvocationResponse)
+        assert response.error is not None
+        assert "connection" in response.error.lower()
+        assert response.input_payload is not None

--- a/tests/unit/endpoints/test_bedrock_invoke.py
+++ b/tests/unit/endpoints/test_bedrock_invoke.py
@@ -605,3 +605,62 @@ class TestBedrockInvokeStream:
         assert isinstance(response, InvocationResponse)
         assert response.error is not None
         assert "test error" in str(response.error).lower()
+
+    def test_invoke_stream_mid_stream_timeout(self):
+        """Verify that a timeout during stream body iteration is caught by
+        the invoke wrapper and returned as an error InvocationResponse."""
+        endpoint = BedrockInvokeStream(model_id="test_model")
+        endpoint._bedrock_client = MagicMock()
+
+        def exploding_body():
+            yield {
+                "chunk": {
+                    "bytes": json.dumps(
+                        {"choices": [{"delta": {"content": "Hello"}}]}
+                    ).encode()
+                }
+            }
+            raise TimeoutError("Read timed out during streaming")
+
+        endpoint._bedrock_client.invoke_model_with_response_stream.return_value = {
+            "body": exploding_body(),
+            "ResponseMetadata": {"RetryAttempts": 0, "RequestId": "req-789"},
+        }
+
+        response = endpoint.invoke(
+            {"messages": [{"role": "user", "content": [{"text": "Hi"}]}]}
+        )
+
+        assert isinstance(response, InvocationResponse)
+        assert response.error is not None
+        assert "timed out" in response.error.lower()
+        assert response.input_payload is not None
+
+    def test_invoke_stream_connection_drop(self):
+        """Verify that a connection error mid-stream is caught by the wrapper."""
+        endpoint = BedrockInvokeStream(model_id="test_model")
+        endpoint._bedrock_client = MagicMock()
+
+        def dropping_body():
+            yield {
+                "chunk": {
+                    "bytes": json.dumps(
+                        {"choices": [{"delta": {"content": "Partial"}}]}
+                    ).encode()
+                }
+            }
+            raise ConnectionError("Connection reset by peer")
+
+        endpoint._bedrock_client.invoke_model_with_response_stream.return_value = {
+            "body": dropping_body(),
+            "ResponseMetadata": {"RetryAttempts": 0, "RequestId": "req-abc"},
+        }
+
+        response = endpoint.invoke(
+            {"messages": [{"role": "user", "content": [{"text": "Hi"}]}]}
+        )
+
+        assert isinstance(response, InvocationResponse)
+        assert response.error is not None
+        assert "connection" in response.error.lower()
+        assert response.input_payload is not None

--- a/tests/unit/endpoints/test_bedrock_invoke.py
+++ b/tests/unit/endpoints/test_bedrock_invoke.py
@@ -1,11 +1,11 @@
-from contextlib import contextmanager
-from io import BytesIO
 import json
 import time
+from contextlib import contextmanager
+from io import BytesIO
 
+import pytest
 from botocore.exceptions import ClientError
 from mock import MagicMock
-import pytest
 
 from llmeter.endpoints.bedrock_invoke import (
     BedrockInvoke,
@@ -125,7 +125,7 @@ class TestBedrockInvoke:
             retries=1,
         ) as mock_response:
             # Act
-            result = endpoint._parse_response(mock_response)
+            result = endpoint.parse_response(mock_response, 0.0)
 
         # Assert
         assert isinstance(result, InvocationResponse)
@@ -141,10 +141,10 @@ class TestBedrockInvoke:
         """
         endpoint = BedrockInvoke(model_id="test_model")
         with _mock_invoke_model_response({"wrong_key": "wrong_value"}) as mock_resp:
-            result = endpoint._parse_response(mock_resp)
+            result = endpoint.parse_response(mock_resp, 0.0)
         assert isinstance(result, InvocationResponse)
         assert result.error is None
-        assert isinstance(result.id, str)
+        # id is back-filled by the invoke wrapper, not by parse_response
         assert result.input_prompt is None
         assert result.num_tokens_input is None
         assert result.num_tokens_output is None
@@ -152,15 +152,13 @@ class TestBedrockInvoke:
 
     def test__parse_response_invalid_json(self):
         """
-        If response is invalid JSON, result is an error:
+        If response is invalid JSON, _parse_response raises JSONDecodeError.
+        The base invoke wrapper converts this to an error response.
         """
         endpoint = BedrockInvoke(model_id="test_model")
         with BytesIO('{"Oops": '.encode("utf-8")) as invalid_body:
-            result = endpoint._parse_response({"body": invalid_body})
-        assert isinstance(result, InvocationResponse)
-        assert result.error is not None
-        assert "json" in str(result.error).lower()
-        assert isinstance(result.id, str)
+            with pytest.raises(json.JSONDecodeError):
+                endpoint.parse_response({"body": invalid_body}, 0.0)
 
     def test__parse_response_custom_jmespaths(self):
         """
@@ -185,7 +183,7 @@ class TestBedrockInvoke:
             },
         ) as mock_response:
             # Act
-            result = endpoint._parse_response(mock_response)
+            result = endpoint.parse_response(mock_response, 0.0)
 
         # Assert
         assert isinstance(result, InvocationResponse)
@@ -278,7 +276,8 @@ class TestBedrockInvoke:
 
     def test_invoke_payload_no_text(self):
         """
-        When text cannot be extracted from the input payload, an error should be returned
+        When text cannot be extracted from the input payload, the invocation
+        should still succeed — _parse_payload failure is not an invocation error.
         """
         endpoint = BedrockInvoke(model_id="test_model")
         endpoint._bedrock_client = MagicMock()
@@ -288,8 +287,9 @@ class TestBedrockInvoke:
             )
             response = endpoint.invoke({})
         assert isinstance(response, InvocationResponse)
-        assert response.error is not None
-        assert "failed to extract input text" in str(response.error).lower()
+        assert response.error is None
+        # input_prompt falls back to None when _parse_payload can't extract text
+        assert response.input_prompt is None
 
     def test_invoke_generic_exception(self):
         """
@@ -407,7 +407,7 @@ class TestBedrockInvokeStream:
 
         # Call the method under test
         start_time = time.perf_counter()
-        result = endpoint._parse_response_stream(client_response, start_time)
+        result = endpoint.parse_response(client_response, start_time)
 
         # Assert the result is an InvocationResponse object
         assert isinstance(result, InvocationResponse)
@@ -462,7 +462,7 @@ class TestBedrockInvokeStream:
 
         # Call the method under test
         start_time = time.perf_counter()
-        result = endpoint._parse_response_stream(client_response, start_time)
+        result = endpoint.parse_response(client_response, start_time)
 
         # Assert the result is an InvocationResponse object
         assert isinstance(result, InvocationResponse)
@@ -478,51 +478,98 @@ class TestBedrockInvokeStream:
 
     def test__parse_response_stream_known_error(self):
         """
-        Test _parse_response_stream detects and returns known errors in the stream
+        Test parse_response records known Bedrock stream errors and returns partial data.
         """
         endpoint = BedrockInvokeStream(model_id="test_model")
         client_response = {
             "body": [
                 {"throttlingException": {"message": "Test error"}},
-                MagicMock(
-                    side_effect=RuntimeError("Shouldn't try to access this chunk")
-                ),
             ],
             "ResponseMetadata": {"RetryAttempts": 0},
         }
 
-        # Call the method under test
         start_time = time.perf_counter()
-        result = endpoint._parse_response_stream(client_response, start_time)
+        result = endpoint.parse_response(client_response, start_time)
 
-        # Check result:
         assert isinstance(result, InvocationResponse)
         assert result.error is not None
-        assert "test error" in str(result.error).lower()
+        assert "test error" in result.error.lower()
 
-    def test__parse_response_stream_unknown_error(self):
+    def test__parse_response_stream_known_error_with_partial_data(self):
         """
-        Test _parse_response_stream detects and returns unknown errors in the stream
+        Test that partial data collected before a stream error is preserved.
         """
-        endpoint = BedrockInvokeStream(model_id="test_model")
+        endpoint = BedrockInvokeStream(
+            model_id="test_model",
+            generated_text_jmespath="choices[0].delta.content",
+        )
         client_response = {
             "body": [
-                {"myUnexpectedChunkType": {"hello": "world"}},
-                MagicMock(
-                    side_effect=RuntimeError("Shouldn't try to access this chunk")
-                ),
+                {
+                    "chunk": {
+                        "bytes": json.dumps(
+                            {"choices": [{"delta": {"content": "Hello"}}]}
+                        ).encode()
+                    }
+                },
+                {
+                    "chunk": {
+                        "bytes": json.dumps(
+                            {"choices": [{"delta": {"content": " world"}}]}
+                        ).encode()
+                    }
+                },
+                {"throttlingException": {"message": "Rate exceeded"}},
             ],
             "ResponseMetadata": {"RetryAttempts": 0},
         }
 
-        # Call the method under test
         start_time = time.perf_counter()
-        result = endpoint._parse_response_stream(client_response, start_time)
+        result = endpoint.parse_response(client_response, start_time)
 
-        # Check result:
         assert isinstance(result, InvocationResponse)
         assert result.error is not None
-        assert "unknown event" in str(result.error).lower()
+        assert "rate exceeded" in result.error.lower()
+        # Partial data is preserved
+        assert result.response_text == "Hello world"
+        assert result.time_to_first_token is not None
+
+    def test__parse_response_stream_unknown_event(self):
+        """
+        Test parse_response skips unknown event types without aborting.
+        """
+        endpoint = BedrockInvokeStream(
+            model_id="test_model",
+            generated_text_jmespath="choices[0].delta.content",
+        )
+        client_response = {
+            "body": [
+                {
+                    "chunk": {
+                        "bytes": json.dumps(
+                            {"choices": [{"delta": {"content": "Hi"}}]}
+                        ).encode()
+                    }
+                },
+                {"myUnexpectedChunkType": {"hello": "world"}},
+                {
+                    "chunk": {
+                        "bytes": json.dumps(
+                            {"choices": [{"delta": {"content": "!"}}]}
+                        ).encode()
+                    }
+                },
+            ],
+            "ResponseMetadata": {"RetryAttempts": 0},
+        }
+
+        start_time = time.perf_counter()
+        result = endpoint.parse_response(client_response, start_time)
+
+        assert isinstance(result, InvocationResponse)
+        # Unknown events are skipped, not errors
+        assert result.error is None
+        assert result.response_text == "Hi!"
 
     def test__parse_response_stream_empty_input(self):
         """
@@ -531,7 +578,7 @@ class TestBedrockInvokeStream:
         endpoint = BedrockInvokeStream(model_id="test_model")
         empty_response = {"body": [], "ResponseMetadata": {"RetryAttempts": 0}}
         start_time = time.perf_counter()
-        result = endpoint._parse_response_stream(empty_response, start_time)
+        result = endpoint.parse_response(empty_response, start_time)
 
         assert isinstance(result, InvocationResponse)
         assert result.response_text == ""

--- a/tests/unit/endpoints/test_bedrock_multimodal.py
+++ b/tests/unit/endpoints/test_bedrock_multimodal.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from llmeter.endpoints.bedrock import BedrockBase
-from llmeter.prompt_utils import ImageContent, DocumentContent
+from llmeter.prompt_utils import DocumentContent, ImageContent
 
 
 class TestBedrockMultiModal:

--- a/tests/unit/endpoints/test_endpoints.py
+++ b/tests/unit/endpoints/test_endpoints.py
@@ -74,10 +74,13 @@ class ConcreteEndpoint(Endpoint):
         )
 
     def invoke(self, payload: dict) -> InvocationResponse:
+        return self.parse_response(payload, 0.0)
+
+    def parse_response(self, raw_response, start_t: float) -> InvocationResponse:
         return InvocationResponse(
             id="test_id",
-            response_text=f"Invoked with payload: {payload}",
-            input_prompt=payload.get("prompt", ""),
+            response_text=f"Invoked with payload: {raw_response}",
+            input_prompt=raw_response.get("prompt", ""),
         )
 
     @classmethod

--- a/tests/unit/endpoints/test_litellm.py
+++ b/tests/unit/endpoints/test_litellm.py
@@ -242,7 +242,7 @@ class TestLiteLLM:
         usage_mock.completion_tokens = 8
         mock_response.usage = usage_mock
 
-        result = self.endpoint._parse_converse_response(mock_response)
+        result = self.endpoint.parse_response(mock_response, 0.0)
 
         assert isinstance(result, InvocationResponse)
         assert result.id == "response-id"
@@ -259,7 +259,7 @@ class TestLiteLLM:
         # Remove usage attribute to simulate AttributeError
         del mock_response.usage
 
-        result = self.endpoint._parse_converse_response(mock_response)
+        result = self.endpoint.parse_response(mock_response, 0.0)
 
         assert isinstance(result, InvocationResponse)
         assert result.id == "response-id"
@@ -412,7 +412,7 @@ class TestLiteLLMStreaming:
         mock_stream = MagicMock()
         mock_stream.__iter__ = lambda self: iter([chunk1, chunk2])
 
-        result = self.endpoint._parse_stream(mock_stream, start_t)  # type: ignore
+        result = self.endpoint.parse_response(mock_stream, start_t)  # type: ignore
 
         assert isinstance(result, InvocationResponse)
         assert result.id == "test-id"
@@ -440,7 +440,7 @@ class TestLiteLLMStreaming:
         mock_stream = MagicMock()
         mock_stream.__iter__ = lambda self: iter([chunk])
 
-        result = self.endpoint._parse_stream(mock_stream, start_t)  # type: ignore
+        result = self.endpoint.parse_response(mock_stream, start_t)  # type: ignore
 
         assert result.num_tokens_input is None
         assert result.num_tokens_output is None
@@ -468,7 +468,7 @@ class TestLiteLLMStreaming:
         mock_stream = MagicMock()
         mock_stream.__iter__ = lambda self: iter([chunk1, chunk2])
 
-        result = self.endpoint._parse_stream(mock_stream, start_t)  # type: ignore
+        result = self.endpoint.parse_response(mock_stream, start_t)  # type: ignore
 
         assert result.response_text == "Real content"
 
@@ -489,7 +489,7 @@ class TestLiteLLMStreaming:
         mock_stream = MagicMock()
         mock_stream.__iter__ = lambda self: iter([chunk])
 
-        result = self.endpoint._parse_stream(mock_stream, start_t)  # type: ignore
+        result = self.endpoint.parse_response(mock_stream, start_t)  # type: ignore
 
         # With 1 token, (num_tokens_output - 1) = 0, so time_per_output_token should be None
         assert result.time_per_output_token is None

--- a/tests/unit/endpoints/test_multimodal_properties.py
+++ b/tests/unit/endpoints/test_multimodal_properties.py
@@ -17,11 +17,11 @@ from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
 from llmeter.endpoints.bedrock import BedrockBase
-from llmeter.json_utils import llmeter_default_serializer, llmeter_bytes_decoder
+from llmeter.json_utils import llmeter_bytes_decoder, llmeter_default_serializer
 from llmeter.prompt_utils import (
-    ImageContent,
-    DocumentContent,
     AudioContent,
+    DocumentContent,
+    ImageContent,
     VideoContent,
     load_payloads,
     save_payloads,

--- a/tests/unit/endpoints/test_multimodal_serialization.py
+++ b/tests/unit/endpoints/test_multimodal_serialization.py
@@ -4,12 +4,16 @@
 import tempfile
 from pathlib import Path
 
-
 from llmeter.endpoints.bedrock import BedrockBase
 from llmeter.endpoints.openai import OpenAIEndpoint
 from llmeter.endpoints.sagemaker import SageMakerBase
-from llmeter.prompt_utils import ImageContent, DocumentContent
-from llmeter.prompt_utils import save_payloads, load_payloads, load_prompts
+from llmeter.prompt_utils import (
+    DocumentContent,
+    ImageContent,
+    load_payloads,
+    load_prompts,
+    save_payloads,
+)
 
 
 class TestMultiModalSerialization:

--- a/tests/unit/endpoints/test_multimodal_utilities.py
+++ b/tests/unit/endpoints/test_multimodal_utilities.py
@@ -8,10 +8,10 @@ from unittest.mock import patch
 import pytest
 
 from llmeter.prompt_utils import (
-    read_file,
-    detect_format_from_extension,
     detect_format_from_bytes,
+    detect_format_from_extension,
     detect_format_from_file,
+    read_file,
 )
 
 

--- a/tests/unit/endpoints/test_openai.py
+++ b/tests/unit/endpoints/test_openai.py
@@ -269,17 +269,20 @@ class TestOpenAICompletionEndpoint:
             assert response.response_text is None
 
     def test_parse_converse_response(self, endpoint, mock_chat_completion):
-        """Test _parse_converse_response method."""
+        """Test parse_response method.
+
+        Note: time_to_last_token is back-filled by the base invoke wrapper,
+        not by parse_response itself for non-streaming endpoints.
+        """
         start_time = time.perf_counter()
 
-        response = endpoint._parse_converse_response(mock_chat_completion, start_time)
+        response = endpoint.parse_response(mock_chat_completion, start_time)
 
         assert isinstance(response, InvocationResponse)
         assert response.id == "chatcmpl-test123"
         assert response.response_text == "Hello! How can I help you today?"
         assert response.num_tokens_input == 10
         assert response.num_tokens_output == 8
-        assert response.time_to_last_token is not None
 
     def test_parse_converse_response_no_usage(self, endpoint):
         """Test _parse_converse_response with no usage information."""
@@ -299,7 +302,7 @@ class TestOpenAICompletionEndpoint:
         )
 
         start_time = time.perf_counter()
-        response = endpoint._parse_converse_response(completion, start_time)
+        response = endpoint.parse_response(completion, start_time)
 
         assert response.num_tokens_input is None
         assert response.num_tokens_output is None
@@ -447,9 +450,7 @@ class TestOpenAICompletionStreamEndpoint:
         """Test _parse_converse_stream_response method."""
         start_time = time.perf_counter()
 
-        response = endpoint._parse_converse_stream_response(
-            iter(mock_stream_response), start_time
-        )
+        response = endpoint.parse_response(iter(mock_stream_response), start_time)
 
         assert isinstance(response, InvocationResponse)
         assert response.id == "chatcmpl-test123"
@@ -463,7 +464,7 @@ class TestOpenAICompletionStreamEndpoint:
         """Test _parse_converse_stream_response with empty stream."""
         start_time = time.perf_counter()
 
-        response = endpoint._parse_converse_stream_response(iter([]), start_time)
+        response = endpoint.parse_response(iter([]), start_time)
 
         assert response.response_text == ""
         assert response.num_tokens_input is None
@@ -484,9 +485,7 @@ class TestOpenAICompletionStreamEndpoint:
         chunk2.usage = None
 
         start_time = time.perf_counter()
-        response = endpoint._parse_converse_stream_response(
-            iter([chunk1, chunk2]), start_time
-        )
+        response = endpoint.parse_response(iter([chunk1, chunk2]), start_time)
 
         assert response.response_text == "Hello"
         assert response.num_tokens_input is None
@@ -505,9 +504,7 @@ class TestOpenAICompletionStreamEndpoint:
         chunk2.choices[0].delta.content = "Hello"
 
         start_time = time.perf_counter()
-        response = endpoint._parse_converse_stream_response(
-            iter([chunk1, chunk2]), start_time
-        )
+        response = endpoint.parse_response(iter([chunk1, chunk2]), start_time)
 
         assert response.response_text == "Hello"
 
@@ -664,9 +661,12 @@ class TestOpenAIEndpointEdgeCases:
 
             payload = {"messages": [{"role": "user", "content": "Hello"}]}
 
-            # This should raise AttributeError when trying to access choices
-            with pytest.raises(AttributeError):
-                endpoint.invoke(payload)
+            # Malformed chunks are caught by the base invoke wrapper and
+            # returned as an error InvocationResponse instead of propagating.
+            response = endpoint.invoke(payload)
+            assert isinstance(response, InvocationResponse)
+            assert response.error is not None
+            assert response.input_payload is not None
 
     def test_response_timing_accuracy(self):
         """Test that response timing measurements are accurate."""

--- a/tests/unit/endpoints/test_openai.py
+++ b/tests/unit/endpoints/test_openai.py
@@ -772,3 +772,59 @@ class TestOpenAIEndpointEdgeCases:
             assert response.response_text == "Hello world"
             assert response.num_tokens_input is None
             assert response.num_tokens_output is None
+
+
+class TestStreamMidStreamErrors:
+    """Verify that errors during stream consumption are caught by the invoke wrapper."""
+
+    def test_timeout_during_stream_consumption(self):
+        """A timeout while iterating chunks should be caught, not raised."""
+        endpoint = OpenAICompletionStreamEndpoint(
+            model_id="gpt-3.5-turbo", api_key="test_key"
+        )
+
+        def exploding_stream():
+            chunk = MagicMock()
+            chunk.id = "test-id"
+            chunk.choices = [MagicMock()]
+            chunk.choices[0].delta.content = "Hello"
+            chunk.usage = None
+            yield chunk
+            raise TimeoutError("Read timed out")
+
+        with patch.object(endpoint._client.chat.completions, "create") as mock_create:
+            mock_create.return_value = exploding_stream()
+            response = endpoint.invoke(
+                {"messages": [{"role": "user", "content": "Hi"}]}
+            )
+
+        assert isinstance(response, InvocationResponse)
+        assert response.error is not None
+        assert "timed out" in response.error.lower()
+        assert response.input_payload is not None
+
+    def test_connection_error_during_stream_consumption(self):
+        """A connection drop mid-stream should be caught, not raised."""
+        endpoint = OpenAICompletionStreamEndpoint(
+            model_id="gpt-3.5-turbo", api_key="test_key"
+        )
+
+        def dropping_stream():
+            chunk = MagicMock()
+            chunk.id = "test-id"
+            chunk.choices = [MagicMock()]
+            chunk.choices[0].delta.content = "Partial"
+            chunk.usage = None
+            yield chunk
+            raise ConnectionError("Connection reset")
+
+        with patch.object(endpoint._client.chat.completions, "create") as mock_create:
+            mock_create.return_value = dropping_stream()
+            response = endpoint.invoke(
+                {"messages": [{"role": "user", "content": "Hi"}]}
+            )
+
+        assert isinstance(response, InvocationResponse)
+        assert response.error is not None
+        assert "connection" in response.error.lower()
+        assert response.input_payload is not None

--- a/tests/unit/endpoints/test_openai_response_format.py
+++ b/tests/unit/endpoints/test_openai_response_format.py
@@ -10,7 +10,6 @@ correctly and that structured outputs are parsed properly.
 
 from unittest.mock import Mock, patch
 
-
 from llmeter.endpoints.openai_response import (
     OpenAIResponseEndpoint,
     OpenAIResponseStreamEndpoint,

--- a/tests/unit/endpoints/test_openai_response_properties.py
+++ b/tests/unit/endpoints/test_openai_response_properties.py
@@ -13,7 +13,8 @@ Feature: openai-response-api
 
 from unittest.mock import Mock, patch
 
-from hypothesis import given, settings, strategies as st
+from hypothesis import given, settings
+from hypothesis import strategies as st
 
 from llmeter.endpoints.base import InvocationResponse
 from llmeter.endpoints.openai_response import (

--- a/tests/unit/endpoints/test_openai_response_serialization.py
+++ b/tests/unit/endpoints/test_openai_response_serialization.py
@@ -430,6 +430,7 @@ class TestInvocationResponseTypeConsistency:
         **Validates: Requirements 10.1**
         """
         from openai import APIConnectionError
+
         from llmeter.endpoints.base import InvocationResponse
 
         # Setup mock
@@ -458,6 +459,7 @@ class TestInvocationResponseTypeConsistency:
         **Validates: Requirements 10.1**
         """
         from openai import APIConnectionError
+
         from llmeter.endpoints.base import InvocationResponse
 
         # Setup mock

--- a/tests/unit/endpoints/test_sagemaker.py
+++ b/tests/unit/endpoints/test_sagemaker.py
@@ -2,9 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-from typing import Dict
 from unittest.mock import patch
-from uuid import UUID
 
 import pytest
 import requests
@@ -20,7 +18,10 @@ from llmeter.endpoints.sagemaker import (
 
 
 class ConcreteClass(SageMakerBase):
-    def invoke(self, payload: Dict) -> InvocationResponse:
+    def invoke(self, payload) -> InvocationResponse:
+        return self.parse_response(None, 0.0)
+
+    def parse_response(self, raw_response, start_t: float) -> InvocationResponse:
         return InvocationResponse(response_text="test response")
 
 
@@ -114,7 +115,7 @@ def test_sagemaker_endpoint_invoke(sagemaker_endpoint: SageMakerEndpoint):
     assert response.response_text == "Test output"
     assert response.num_tokens_output == 10
     assert isinstance(response.id, str)
-    assert UUID(response.id, version=4)
+    assert len(response.id) > 0
 
 
 # @patch("boto3.client")

--- a/tests/unit/endpoints/test_sagemaker_multimodal.py
+++ b/tests/unit/endpoints/test_sagemaker_multimodal.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from llmeter.endpoints.sagemaker import SageMakerBase
-from llmeter.prompt_utils import ImageContent, DocumentContent
+from llmeter.prompt_utils import DocumentContent, ImageContent
 
 
 class TestSageMakerMultiModal:

--- a/tests/unit/test_lazy_load.py
+++ b/tests/unit/test_lazy_load.py
@@ -1,12 +1,12 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 from upath import UPath
 
 from llmeter.endpoints.base import InvocationResponse
-from unittest.mock import MagicMock, patch
-
 from llmeter.experiments import LoadTestResult
 from llmeter.results import Result
 

--- a/tests/unit/test_prompt_utils.py
+++ b/tests/unit/test_prompt_utils.py
@@ -11,13 +11,13 @@ import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+from llmeter.json_utils import llmeter_bytes_decoder, llmeter_default_serializer
 from llmeter.prompt_utils import (
     CreatePromptCollection,
     load_payloads,
     load_prompts,
     save_payloads,
 )
-from llmeter.json_utils import llmeter_default_serializer, llmeter_bytes_decoder
 from llmeter.tokenizers import DummyTokenizer
 
 

--- a/tests/unit/test_property_save_load.py
+++ b/tests/unit/test_property_save_load.py
@@ -9,16 +9,16 @@ from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
-
-from hypothesis import given, strategies as st, settings
+from hypothesis import given, settings
+from hypothesis import strategies as st
 from hypothesis.strategies import composite
 
-from llmeter.tokenizers import DummyTokenizer, Tokenizer, save_tokenizer
-from llmeter.prompt_utils import save_payloads, load_payloads
 from llmeter.endpoints.base import Endpoint, InvocationResponse
 from llmeter.endpoints.openai import OpenAICompletionEndpoint
+from llmeter.prompt_utils import load_payloads, save_payloads
 from llmeter.results import Result
 from llmeter.runner import _RunConfig
+from llmeter.tokenizers import DummyTokenizer, Tokenizer, save_tokenizer
 
 
 # Custom strategies

--- a/tests/unit/test_serialization_properties.py
+++ b/tests/unit/test_serialization_properties.py
@@ -20,7 +20,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 from hypothesis.strategies import composite
 
-from llmeter.json_utils import llmeter_default_serializer, llmeter_bytes_decoder
+from llmeter.json_utils import llmeter_bytes_decoder, llmeter_default_serializer
 
 # Test infrastructure is set up and ready for property test implementation
 # This file will contain property-based tests for:


### PR DESCRIPTION
## Summary

Refactors the `Endpoint` base class to eliminate duplicated error handling, timing, and metadata boilerplate across all 12 endpoint implementations.

Closes #60

## What changed

### Base class (`base.py`)

The `Endpoint` class now provides a structured invoke lifecycle via `__init_subclass__` wrapping. Subclasses define three methods:

| Method | Required | Purpose |
|--------|----------|---------|
| `invoke(payload)` | Yes | API call + `parse_response()` |
| `parse_response(raw_response, start_t)` | Yes | Extract text, tokens, metadata |
| `prepare_payload(payload, **kwargs)` | No | Merge kwargs, inject model_id, etc. |

The wrapper automatically handles:
- **Error handling** — exceptions → error `InvocationResponse` with payload attached
- **Timing** — `time_to_last_token` back-filled for non-streaming endpoints
- **Metadata** — `input_payload`, `input_prompt`, `id` always populated
- **`_parse_payload`** — extracts human-readable prompt for observability and token counting fallback

### `InvocationResponse` new field

- **`num_tokens_input_cached`** — input tokens served from prompt cache. Populated by Bedrock (`cacheReadInputTokens`) and OpenAI (`cached_tokens`).

### Endpoint improvements

- **All Bedrock + SageMaker endpoints** now extract `ResponseMetadata.RequestId` as the response ID
- **SageMaker** now captures `RetryAttempts` (Bedrock already had this)
- **Bedrock streaming** preserves partial data on mid-stream errors instead of discarding it
- **`BEDROCK_STREAM_ERROR_TYPES`** defined as a shared `frozenset` constant, used by both Converse and InvokeModel stream parsers
- **Unknown stream events** are skipped gracefully (forward-compatible with new Bedrock event types)
- All redundant try/except blocks removed from `_parse_response` methods

### Before/after (e.g. `OpenAIResponseEndpoint.invoke`)

**Before** (27 lines with 5 duplicate except handlers):
```python
def invoke(self, payload, **kwargs):
    payload = {**kwargs, **payload}
    payload["model"] = self.model_id
    start_t = time.perf_counter()
    try:
        client_response = self._client.responses.create(**payload)
    except APIConnectionError as e:
        logger.exception(e)
        return InvocationResponse.error_output(...)
    except AuthenticationError as e:
        ...  # 4 more identical except blocks
    response = self._parse_response(client_response, start_t)
    response.input_payload = payload
    response.input_prompt = self._parse_payload(payload)
    return response
```

**After** (3 lines):
```python
def invoke(self, payload):
    client_response = self._client.responses.create(**payload)
    return self.parse_response(client_response, self._start_t)
```

## Documentation

- **`metrics.md`** — Per-request fields table expanded from 6 to 12 fields
- **`key_concepts.md`** — Endpoint description explains the invoke lifecycle
- **`connect_endpoints.md`** — Added custom endpoint example with the new abstract methods

## Testing

- 666 unit tests pass
- Integration tests updated with stronger ID assertions (AWS RequestId format)
- New test for partial data preservation on streaming errors
- Import sorting and formatting applied via ruff
