### PR TITLE
feat: add Anthropic Messages API endpoint

### DIFF
--- a/docs/reference/endpoints/anthropic_messages.md
+++ b/docs/reference/endpoints/anthropic_messages.md
@@ -1,0 +1,1 @@
+::: llmeter.endpoints.anthropic_messages

--- a/examples/Compare TTFT - Converse vs Anthropic Messages API on Amazon Bedrock.ipynb
+++ b/examples/Compare TTFT - Converse vs Anthropic Messages API on Amazon Bedrock.ipynb
@@ -1,0 +1,462 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Amazon Bedrock TTFT: Converse vs Anthropic Messages API\n",
+    "\n",
+    "This notebook compares **time-to-first-token (TTFT)** for Claude Opus 4.7 across\n",
+    "two Amazon Bedrock streaming API paths:\n",
+    "\n",
+    "| API | Endpoint class | Protocol | Bedrock endpoint |\n",
+    "|-----|---------------|----------|------------------|\n",
+    "| **Converse** | `BedrockConverseStream` | AWS event-stream | `bedrock-runtime` |\n",
+    "| **Anthropic Messages** | `AnthropicMessagesStream` | SSE (server-sent events) | `bedrock-mantle` |\n",
+    "\n",
+    "Both hit the same Opus 4.7 model in the same region, but the transport layer\n",
+    "differs. We use LLMeter's `Runner` to send identical prompts through each path\n",
+    "and compare the resulting TTFT distributions.\n",
+    "\n",
+    "A `NoCacheCallback` appends a unique suffix to each request to defeat any\n",
+    "prompt-level caching on the Mantle endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install \"llmeter[anthropic-bedrock,plotting]<1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Anti-caching callback\n",
+    "\n",
+    "Appends a unique suffix like `[req-0001-a3f2b]` to each request's user\n",
+    "message before it's sent. This keeps prompt length consistent while\n",
+    "preventing cache hits from skewing TTFT.\n",
+    "\n",
+    "Handles both payload formats:\n",
+    "- **Converse**: `messages[].content[].text` (text block in a list)\n",
+    "- **Messages API**: `messages[].content` (plain string)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import uuid\n",
+    "from llmeter.callbacks import Callback\n",
+    "\n",
+    "\n",
+    "class NoCacheCallback(Callback):\n",
+    "    \"\"\"Append a unique suffix to each request to defeat prompt caching.\"\"\"\n",
+    "\n",
+    "    def __init__(self):\n",
+    "        self._counter = 0\n",
+    "\n",
+    "    async def before_invoke(self, payload: dict) -> None:\n",
+    "        self._counter += 1\n",
+    "        tag = f\" [req-{self._counter:04d}-{uuid.uuid4().hex[:5]}]\"\n",
+    "\n",
+    "        messages = payload.get(\"messages\", [])\n",
+    "        if not messages:\n",
+    "            return\n",
+    "\n",
+    "        last_msg = messages[-1]\n",
+    "        content = last_msg.get(\"content\")\n",
+    "\n",
+    "        # Messages API format: content is a plain string\n",
+    "        if isinstance(content, str):\n",
+    "            last_msg[\"content\"] = content + tag\n",
+    "            return\n",
+    "\n",
+    "        # Converse format: content is a list of blocks\n",
+    "        if isinstance(content, list):\n",
+    "            for block in reversed(content):\n",
+    "                if isinstance(block, dict) and \"text\" in block:\n",
+    "                    block[\"text\"] = block[\"text\"] + tag\n",
+    "                    return"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure endpoints\n",
+    "\n",
+    "Both endpoints target Opus 4.7 in `us-east-1`:\n",
+    "\n",
+    "- **Converse** uses `bedrock-runtime` via boto3 with `global.anthropic.claude-opus-4-7`\n",
+    "- **Messages API** uses `bedrock-mantle` via the `anthropic` SDK with `anthropic.claude-opus-4-7`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llmeter.endpoints.bedrock import BedrockConverseStream\n",
+    "from llmeter.endpoints.anthropic_messages import AnthropicMessagesStream\n",
+    "\n",
+    "REGION = \"us-east-1\"\n",
+    "\n",
+    "# --- Converse API (bedrock-runtime) ---\n",
+    "converse_endpoint = BedrockConverseStream(\n",
+    "    model_id=\"global.anthropic.claude-opus-4-7\",\n",
+    "    region=REGION,\n",
+    "    endpoint_name=\"converse\",\n",
+    ")\n",
+    "\n",
+    "# --- Anthropic Messages API (bedrock-mantle) ---\n",
+    "messages_endpoint = AnthropicMessagesStream(\n",
+    "    model_id=\"anthropic.claude-opus-4-7\",\n",
+    "    provider=\"bedrock-mantle\",\n",
+    "    aws_region=REGION,\n",
+    "    endpoint_name=\"messages-api\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build payloads\n",
+    "\n",
+    "Each API has its own payload format. We use the `create_payload` helpers to\n",
+    "build equivalent requests with the same prompt and `max_tokens`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llmeter.endpoints.bedrock import BedrockBase\n",
+    "from llmeter.endpoints.anthropic_messages import AnthropicMessagesEndpoint\n",
+    "\n",
+    "PROMPT = (\n",
+    "    \"Explain the key differences between REST and GraphQL APIs. \"\n",
+    "    \"Cover query flexibility, over-fetching, versioning, and caching.\"\n",
+    ")\n",
+    "MAX_TOKENS = 512\n",
+    "\n",
+    "converse_payload = BedrockBase.create_payload(PROMPT, max_tokens=MAX_TOKENS)\n",
+    "messages_payload = AnthropicMessagesEndpoint.create_payload(PROMPT, max_tokens=MAX_TOKENS)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Verify both endpoints"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for name, ep, payload in [\n",
+    "    (\"Converse\", converse_endpoint, converse_payload),\n",
+    "    (\"Messages API\", messages_endpoint, messages_payload),\n",
+    "]:\n",
+    "    r = ep.invoke(payload)\n",
+    "    assert r.error is None, f\"{name} error: {r.error}\"\n",
+    "    print(\n",
+    "        f\"{name:>12}  \"\n",
+    "        f\"TTFT={r.time_to_first_token:.3f}s  \"\n",
+    "        f\"TTLT={r.time_to_last_token:.3f}s  \"\n",
+    "        f\"in={r.num_tokens_input} out={r.num_tokens_output}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run the comparison\n",
+    "\n",
+    "Single client, same prompt, same model, same region. The only variable is\n",
+    "the API path and transport protocol."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llmeter.runner import Runner\n",
+    "\n",
+    "N_REQUESTS = 10\n",
+    "OUTPUT_PATH = \"outputs/opus-4.7-ttft-comparison\"\n",
+    "\n",
+    "# --- Converse ---\n",
+    "converse_runner = Runner(\n",
+    "    endpoint=converse_endpoint,\n",
+    "    output_path=OUTPUT_PATH,\n",
+    "    callbacks=[NoCacheCallback()],\n",
+    ")\n",
+    "converse_result = await converse_runner.run(\n",
+    "    payload=converse_payload,\n",
+    "    n_requests=N_REQUESTS,\n",
+    "    clients=1,\n",
+    "    run_name=\"converse\",\n",
+    ")\n",
+    "\n",
+    "print(f\"Converse: {converse_result.total_requests} requests\")\n",
+    "print(f\"  p50 TTFT: {converse_result.stats['time_to_first_token-p50']:.3f}s\")\n",
+    "print(f\"  p90 TTFT: {converse_result.stats['time_to_first_token-p90']:.3f}s\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# --- Messages API ---\n",
+    "messages_runner = Runner(\n",
+    "    endpoint=messages_endpoint,\n",
+    "    output_path=OUTPUT_PATH,\n",
+    "    callbacks=[NoCacheCallback()],\n",
+    ")\n",
+    "messages_result = await messages_runner.run(\n",
+    "    payload=messages_payload,\n",
+    "    n_requests=N_REQUESTS,\n",
+    "    clients=1,\n",
+    "    run_name=\"messages-api\",\n",
+    ")\n",
+    "\n",
+    "print(f\"Messages API: {messages_result.total_requests} requests\")\n",
+    "print(f\"  p50 TTFT: {messages_result.stats['time_to_first_token-p50']:.3f}s\")\n",
+    "print(f\"  p90 TTFT: {messages_result.stats['time_to_first_token-p90']:.3f}s\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compare results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "summary = pd.DataFrame(\n",
+    "    {\n",
+    "        \"Converse\": {\n",
+    "            \"p50 TTFT (s)\": converse_result.stats[\"time_to_first_token-p50\"],\n",
+    "            \"p90 TTFT (s)\": converse_result.stats[\"time_to_first_token-p90\"],\n",
+    "            \"p50 TTLT (s)\": converse_result.stats[\"time_to_last_token-p50\"],\n",
+    "            \"p90 TTLT (s)\": converse_result.stats[\"time_to_last_token-p90\"],\n",
+    "            \"Avg output tokens\": converse_result.stats.get(\"num_tokens_output-mean\", \"N/A\"),\n",
+    "            \"Requests\": converse_result.total_requests,\n",
+    "            \"Errors\": converse_result.stats.get(\"errors\", 0),\n",
+    "        },\n",
+    "        \"Messages API\": {\n",
+    "            \"p50 TTFT (s)\": messages_result.stats[\"time_to_first_token-p50\"],\n",
+    "            \"p90 TTFT (s)\": messages_result.stats[\"time_to_first_token-p90\"],\n",
+    "            \"p50 TTLT (s)\": messages_result.stats[\"time_to_last_token-p50\"],\n",
+    "            \"p90 TTLT (s)\": messages_result.stats[\"time_to_last_token-p90\"],\n",
+    "            \"Avg output tokens\": messages_result.stats.get(\"num_tokens_output-mean\", \"N/A\"),\n",
+    "            \"Requests\": messages_result.total_requests,\n",
+    "            \"Errors\": messages_result.stats.get(\"errors\", 0),\n",
+    "        },\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot TTFT distributions\n",
+    "\n",
+    "Using LLMeter's built-in `histogram_by_dimension` and `boxplot_by_dimension`\n",
+    "plotting primitives."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import plotly.graph_objects as go\n",
+    "from llmeter.plotting import histogram_by_dimension, boxplot_by_dimension\n",
+    "\n",
+    "# --- TTFT Histogram ---\n",
+    "fig_hist = go.Figure()\n",
+    "fig_hist.add_trace(\n",
+    "    histogram_by_dimension(\n",
+    "        converse_result,\n",
+    "        \"time_to_first_token\",\n",
+    "        name=\"Converse API\",\n",
+    "        opacity=0.7,\n",
+    "        marker_color=\"#2196F3\",\n",
+    "    )\n",
+    ")\n",
+    "fig_hist.add_trace(\n",
+    "    histogram_by_dimension(\n",
+    "        messages_result,\n",
+    "        \"time_to_first_token\",\n",
+    "        name=\"Messages API\",\n",
+    "        opacity=0.7,\n",
+    "        marker_color=\"#FF9800\",\n",
+    "    )\n",
+    ")\n",
+    "fig_hist.update_layout(\n",
+    "    title=\"TTFT Distribution: Converse vs Messages API\",\n",
+    "    xaxis_title=\"Time to First Token (seconds)\",\n",
+    "    yaxis_title=\"Probability\",\n",
+    "    barmode=\"overlay\",\n",
+    "    height=400,\n",
+    "    template=\"plotly_white\",\n",
+    ")\n",
+    "fig_hist.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# --- TTFT Box plot ---\n",
+    "fig_box = go.Figure()\n",
+    "fig_box.add_trace(\n",
+    "    boxplot_by_dimension(\n",
+    "        converse_result,\n",
+    "        \"time_to_first_token\",\n",
+    "        name=\"Converse API\",\n",
+    "        marker=dict(color=\"#2196F3\"),\n",
+    "        boxpoints=\"all\",\n",
+    "        jitter=0.3,\n",
+    "    )\n",
+    ")\n",
+    "fig_box.add_trace(\n",
+    "    boxplot_by_dimension(\n",
+    "        messages_result,\n",
+    "        \"time_to_first_token\",\n",
+    "        name=\"Messages API\",\n",
+    "        marker=dict(color=\"#FF9800\"),\n",
+    "        boxpoints=\"all\",\n",
+    "        jitter=0.3,\n",
+    "    )\n",
+    ")\n",
+    "fig_box.update_layout(\n",
+    "    title=\"TTFT: Converse vs Messages API (Bedrock, us-east-1)\",\n",
+    "    xaxis_title=\"Time to First Token (seconds)\",\n",
+    "    showlegend=False,\n",
+    "    height=400,\n",
+    "    template=\"plotly_white\",\n",
+    ")\n",
+    "fig_box.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# --- TTLT Histogram ---\n",
+    "fig_ttlt = go.Figure()\n",
+    "fig_ttlt.add_trace(\n",
+    "    histogram_by_dimension(\n",
+    "        converse_result,\n",
+    "        \"time_to_last_token\",\n",
+    "        name=\"Converse API\",\n",
+    "        opacity=0.7,\n",
+    "        marker_color=\"#2196F3\",\n",
+    "    )\n",
+    ")\n",
+    "fig_ttlt.add_trace(\n",
+    "    histogram_by_dimension(\n",
+    "        messages_result,\n",
+    "        \"time_to_last_token\",\n",
+    "        name=\"Messages API\",\n",
+    "        opacity=0.7,\n",
+    "        marker_color=\"#FF9800\",\n",
+    "    )\n",
+    ")\n",
+    "fig_ttlt.update_layout(\n",
+    "    title=\"TTLT Distribution: Converse vs Messages API\",\n",
+    "    xaxis_title=\"Time to Last Token (seconds)\",\n",
+    "    yaxis_title=\"Probability\",\n",
+    "    barmode=\"overlay\",\n",
+    "    height=400,\n",
+    "    template=\"plotly_white\",\n",
+    ")\n",
+    "fig_ttlt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Observations\n",
+    "\n",
+    "Same model (Opus 4.7), same region (`us-east-1`), same prompt — the only\n",
+    "variable is the API path:\n",
+    "\n",
+    "- **Converse** uses AWS event-stream encoding over HTTP/1.1 via boto3\n",
+    "  (`bedrock-runtime`)\n",
+    "- **Messages API** uses standard SSE over HTTP/2 via the `anthropic` SDK\n",
+    "  (`bedrock-mantle`)\n",
+    "\n",
+    "Differences in TTFT may come from:\n",
+    "- Connection setup and TLS negotiation overhead\n",
+    "- Request routing through different Bedrock infrastructure paths\n",
+    "- SDK-level overhead (boto3 SigV4 signing vs anthropic SDK SigV4 signing)\n",
+    "- HTTP/1.1 event-stream vs HTTP/2 SSE framing\n",
+    "\n",
+    "To get more statistically significant results, increase `N_REQUESTS` above\n",
+    "or use `run_duration` for time-bound runs."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/Compare TTFT - Converse vs Anthropic Messages API on Amazon Bedrock.ipynb
+++ b/examples/Compare TTFT - Converse vs Anthropic Messages API on Amazon Bedrock.ipynb
@@ -6,20 +6,16 @@
    "source": [
     "# Amazon Bedrock TTFT: Converse vs Anthropic Messages API\n",
     "\n",
-    "This notebook compares **time-to-first-token (TTFT)** for Claude Opus 4.7 across\n",
-    "two Amazon Bedrock streaming API paths:\n",
+    "This notebook compares **time-to-first-token (TTFT)** for Claude Opus 4.7 across two different streaming APIs offered by Amazon Bedrock:\n",
     "\n",
     "| API | Endpoint class | Protocol | Bedrock endpoint |\n",
     "|-----|---------------|----------|------------------|\n",
-    "| **Converse** | `BedrockConverseStream` | AWS event-stream | `bedrock-runtime` |\n",
-    "| **Anthropic Messages** | `AnthropicMessagesStream` | SSE (server-sent events) | `bedrock-mantle` |\n",
+    "| **[ConverseStream](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html)** | `BedrockConverseStream` | AWS event-stream | `bedrock-runtime` |\n",
+    "| **[Anthropic Messages](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages.html)** | `AnthropicMessagesStream` | SSE (server-sent events) | `bedrock-mantle` |\n",
     "\n",
-    "Both hit the same Opus 4.7 model in the same region, but the transport layer\n",
-    "differs. We use LLMeter's `Runner` to send identical prompts through each path\n",
-    "and compare the resulting TTFT distributions.\n",
+    "Both hit the same Opus 4.7 model in the same AWS Region, but the transport layer differs. We use LLMeter's `Runner` to send identical prompts through each path and compare the resulting TTFT distributions.\n",
     "\n",
-    "A `NoCacheCallback` appends a unique suffix to each request to defeat any\n",
-    "prompt-level caching on the Mantle endpoint."
+    "A `NoCacheCallback` appends a unique prefix to each request to defeat any prompt-level caching on the Mantle endpoint."
    ]
   },
   {
@@ -48,9 +44,7 @@
    "source": [
     "## Anti-caching callback\n",
     "\n",
-    "Appends a unique suffix like `[req-0001-a3f2b]` to each request's user\n",
-    "message before it's sent. This keeps prompt length consistent while\n",
-    "preventing cache hits from skewing TTFT.\n",
+    "Adds a unique prefix like `[req-00001-a3f2b]` to the start of the first message in each request before it's sent. This keeps prompt length consistent while preventing cache hits from skewing TTFT metrics.\n",
     "\n",
     "Handles both payload formats:\n",
     "- **Converse**: `messages[].content[].text` (text block in a list)\n",
@@ -75,25 +69,25 @@
     "\n",
     "    async def before_invoke(self, payload: dict) -> None:\n",
     "        self._counter += 1\n",
-    "        tag = f\" [req-{self._counter:04d}-{uuid.uuid4().hex[:5]}]\"\n",
+    "        tag = f\"[req-{self._counter:05d}-{uuid.uuid4().hex[:5]}] \"\n",
     "\n",
     "        messages = payload.get(\"messages\", [])\n",
     "        if not messages:\n",
     "            return\n",
     "\n",
-    "        last_msg = messages[-1]\n",
-    "        content = last_msg.get(\"content\")\n",
+    "        first_msg = messages[0]\n",
+    "        content = first_msg.get(\"content\")\n",
     "\n",
     "        # Messages API format: content is a plain string\n",
     "        if isinstance(content, str):\n",
-    "            last_msg[\"content\"] = content + tag\n",
+    "            first_msg[\"content\"] = tag + content\n",
     "            return\n",
     "\n",
     "        # Converse format: content is a list of blocks\n",
     "        if isinstance(content, list):\n",
-    "            for block in reversed(content):\n",
+    "            for block in content:\n",
     "                if isinstance(block, dict) and \"text\" in block:\n",
-    "                    block[\"text\"] = block[\"text\"] + tag\n",
+    "                    block[\"text\"] = tag + block[\"text\"]\n",
     "                    return"
    ]
   },
@@ -448,13 +442,17 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
+    "display_name": "Python 3",
+    "language": "python",
+    "name": "python3"
   },
   "language_info": {
-   "name": "python",
-   "version": "3.12.0"
+    "name": "python",
+    "version": "3.12.0",
+    "file_extension": ".py",
+    "mimetype": "text/x-python",
+    "nbconvert_exporter": "python",
+    "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/Compare TTFT - Converse vs Anthropic Messages API on Amazon Bedrock.ipynb
+++ b/examples/Compare TTFT - Converse vs Anthropic Messages API on Amazon Bedrock.ipynb
@@ -24,7 +24,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install \"llmeter[anthropic-bedrock,plotting]<1\""
+    "# %pip install \"llmeter[anthropic,plotting]<1\""
    ]
   },
   {

--- a/examples/Compare TTFT - Converse vs Anthropic Messages API on Amazon Bedrock.ipynb
+++ b/examples/Compare TTFT - Converse vs Anthropic Messages API on Amazon Bedrock.ipynb
@@ -62,7 +62,7 @@
     "\n",
     "\n",
     "class NoCacheCallback(Callback):\n",
-    "    \"\"\"Append a unique suffix to each request to defeat prompt caching.\"\"\"\n",
+    "    \"\"\"Add a unique prefix to each request to defeat prompt caching.\"\"\"\n",
     "\n",
     "    def __init__(self):\n",
     "        self._counter = 0\n",
@@ -442,17 +442,17 @@
  ],
  "metadata": {
   "kernelspec": {
-    "display_name": "Python 3",
-    "language": "python",
-    "name": "python3"
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
   },
   "language_info": {
-    "name": "python",
-    "version": "3.12.0",
-    "file_extension": ".py",
-    "mimetype": "text/x-python",
-    "nbconvert_exporter": "python",
-    "pygments_lexer": "ipython3"
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
   }
  },
  "nbformat": 4,

--- a/examples/Extended thinking latency.ipynb
+++ b/examples/Extended thinking latency.ipynb
@@ -1,0 +1,4698 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Extended Thinking Latency: Claude Opus 4.7\n",
+    "\n",
+    "This notebook measures the impact of **extended thinking** on latency for\n",
+    "Claude Opus 4.7 across two Amazon Bedrock streaming API paths:\n",
+    "\n",
+    "| API | Endpoint class | Protocol | Bedrock endpoint |\n",
+    "|-----|---------------|----------|------------------|\n",
+    "| **Converse** | `BedrockConverseStream` | AWS event-stream | `bedrock-runtime` |\n",
+    "| **Anthropic Messages** | `AnthropicMessagesStream` | SSE (server-sent events) | `bedrock-mantle` |\n",
+    "\n",
+    "For each API path we compare three configurations:\n",
+    "\n",
+    "1. **No thinking** — `thinking: {\"type\": \"disabled\"}` (baseline)\n",
+    "2. **Adaptive thinking** — `thinking: {\"type\": \"adaptive\"}` (recommended for Opus 4.7)\n",
+    "3. **Adaptive thinking, display omitted** — same as above with `display: \"omitted\"`\n",
+    "   (skips streaming thinking tokens, reducing time-to-first-visible-text)\n",
+    "\n",
+    "We measure two TTFT variants:\n",
+    "\n",
+    "- **TTFT (visible)** — time to first *visible text* token (`ttft_visible_tokens_only=True`)\n",
+    "- **TTFT (any)** — time to first token of *any* kind, including thinking deltas\n",
+    "  (`ttft_visible_tokens_only=False`)\n",
+    "\n",
+    "### Key expectations\n",
+    "\n",
+    "- Thinking adds latency to TTFT (visible) because the model reasons before producing text\n",
+    "- `display: \"omitted\"` should reduce TTFT (visible) compared to `display: \"summarized\"`\n",
+    "  because no thinking tokens are streamed\n",
+    "- TTLT increases with thinking because more output tokens are generated\n",
+    "- TTFT (any) captures when the model first starts producing output, which is earlier\n",
+    "  than TTFT (visible) when thinking is enabled"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install \"llmeter[anthropic,plotting]<1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Anti-caching callback\n",
+    "\n",
+    "Prepends a unique prefix to each request to defeat prompt-level caching."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import uuid\n",
+    "from llmeter.callbacks import Callback\n",
+    "\n",
+    "\n",
+    "class NoCacheCallback(Callback):\n",
+    "    \"\"\"Prepend a unique prefix to each request to defeat prompt caching.\"\"\"\n",
+    "\n",
+    "    def __init__(self):\n",
+    "        self._counter = 0\n",
+    "\n",
+    "    async def before_invoke(self, payload: dict) -> None:\n",
+    "        self._counter += 1\n",
+    "        tag = f\" [req-{self._counter:04d}-{uuid.uuid4().hex[:5]}]\"\n",
+    "\n",
+    "        messages = payload.get(\"messages\", [])\n",
+    "        if not messages:\n",
+    "            return\n",
+    "\n",
+    "        last_msg = messages[-1]\n",
+    "        content = last_msg.get(\"content\")\n",
+    "\n",
+    "        # Messages API format: content is a plain string\n",
+    "        if isinstance(content, str):\n",
+    "            last_msg[\"content\"] = tag + content\n",
+    "            return\n",
+    "\n",
+    "        # Converse format: content is a list of blocks\n",
+    "        if isinstance(content, list):\n",
+    "            for block in content:\n",
+    "                if isinstance(block, dict) and \"text\" in block:\n",
+    "                    block[\"text\"] = tag + block[\"text\"]\n",
+    "                    return"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "REGION = \"us-east-1\"\n",
+    "N_REQUESTS = 10\n",
+    "OUTPUT_PATH = \"outputs/opus-4.7-extended-thinking\"\n",
+    "\n",
+    "# A prompt that benefits from reasoning\n",
+    "PROMPT = (\n",
+    "    \"A farmer has 3 fields. The first field produces 40% more wheat than the second. \"\n",
+    "    \"The third field produces 25% less than the first. Together they produce 8,200 kg. \"\n",
+    "    \"How much does each field produce? Show your work step by step.\"\n",
+    ")\n",
+    "MAX_TOKENS = 4096"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure endpoints\n",
+    "\n",
+    "We create **four** streaming endpoints — two per API path, one measuring\n",
+    "TTFT to visible text only (default) and one measuring TTFT to any token\n",
+    "including thinking."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llmeter.endpoints.bedrock import BedrockConverseStream\n",
+    "from llmeter.endpoints.anthropic_messages import AnthropicMessagesStream\n",
+    "\n",
+    "# --- Converse API (bedrock-runtime) ---\n",
+    "converse_visible = BedrockConverseStream(\n",
+    "    model_id=\"global.anthropic.claude-opus-4-7\",\n",
+    "    region=REGION,\n",
+    "    endpoint_name=\"converse (visible TTFT)\",\n",
+    "    ttft_visible_tokens_only=True,\n",
+    ")\n",
+    "\n",
+    "converse_any = BedrockConverseStream(\n",
+    "    model_id=\"global.anthropic.claude-opus-4-7\",\n",
+    "    region=REGION,\n",
+    "    endpoint_name=\"converse (any TTFT)\",\n",
+    "    ttft_visible_tokens_only=False,\n",
+    ")\n",
+    "\n",
+    "# --- Anthropic Messages API (bedrock-mantle) ---\n",
+    "messages_visible = AnthropicMessagesStream(\n",
+    "    model_id=\"anthropic.claude-opus-4-7\",\n",
+    "    provider=\"bedrock-mantle\",\n",
+    "    aws_region=REGION,\n",
+    "    endpoint_name=\"messages (visible TTFT)\",\n",
+    "    ttft_visible_tokens_only=True,\n",
+    ")\n",
+    "\n",
+    "messages_any = AnthropicMessagesStream(\n",
+    "    model_id=\"anthropic.claude-opus-4-7\",\n",
+    "    provider=\"bedrock-mantle\",\n",
+    "    aws_region=REGION,\n",
+    "    endpoint_name=\"messages (any TTFT)\",\n",
+    "    ttft_visible_tokens_only=False,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build payloads\n",
+    "\n",
+    "Three thinking configurations per API path.\n",
+    "\n",
+    "Note: Opus 4.7 only supports adaptive thinking (`type: \"adaptive\"`).\n",
+    "Manual `type: \"enabled\"` with `budget_tokens` returns a 400 error on this model.\n",
+    "The `display` field defaults to `\"omitted\"` on Opus 4.7, so we set\n",
+    "`\"summarized\"` explicitly for the summarized variant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llmeter.endpoints.bedrock import BedrockBase\n",
+    "from llmeter.endpoints.anthropic_messages import AnthropicMessagesEndpoint\n",
+    "\n",
+    "# --- Converse payloads ---\n",
+    "# Thinking config goes in additionalModelRequestFields for Converse\n",
+    "converse_no_thinking = BedrockBase.create_payload(\n",
+    "    PROMPT,\n",
+    "    max_tokens=MAX_TOKENS,\n",
+    "    additionalModelRequestFields={\"thinking\": {\"type\": \"disabled\"}},\n",
+    ")\n",
+    "\n",
+    "converse_thinking_summarized = BedrockBase.create_payload(\n",
+    "    PROMPT,\n",
+    "    max_tokens=MAX_TOKENS,\n",
+    "    additionalModelRequestFields={\n",
+    "        \"thinking\": {\"type\": \"adaptive\", \"display\": \"summarized\"}\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "converse_thinking_omitted = BedrockBase.create_payload(\n",
+    "    PROMPT,\n",
+    "    max_tokens=MAX_TOKENS,\n",
+    "    additionalModelRequestFields={\n",
+    "        \"thinking\": {\"type\": \"adaptive\", \"display\": \"omitted\"}\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "# --- Messages API payloads ---\n",
+    "messages_no_thinking = AnthropicMessagesEndpoint.create_payload(\n",
+    "    PROMPT,\n",
+    "    max_tokens=MAX_TOKENS,\n",
+    "    thinking={\"type\": \"disabled\"},\n",
+    ")\n",
+    "\n",
+    "messages_thinking_summarized = AnthropicMessagesEndpoint.create_payload(\n",
+    "    PROMPT,\n",
+    "    max_tokens=MAX_TOKENS,\n",
+    "    thinking={\"type\": \"adaptive\", \"display\": \"summarized\"},\n",
+    ")\n",
+    "\n",
+    "messages_thinking_omitted = AnthropicMessagesEndpoint.create_payload(\n",
+    "    PROMPT,\n",
+    "    max_tokens=MAX_TOKENS,\n",
+    "    thinking={\"type\": \"adaptive\", \"display\": \"omitted\"},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Verify endpoints\n",
+    "\n",
+    "Quick smoke test — one request per configuration to confirm everything works."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                  Converse / no thinking  TTFT=1.689s  TTLT=6.068s  out=622\n",
+      "        Converse / adaptive (summarized)  TTFT=4.324s  TTLT=6.692s  out=777\n",
+      "           Converse / adaptive (omitted)  TTFT=26.235s  TTLT=29.358s  out=737\n",
+      "                  Messages / no thinking  TTFT=2.021s  TTLT=7.027s  out=629\n",
+      "        Messages / adaptive (summarized)  TTFT=3.379s  TTLT=6.212s  out=801\n",
+      "           Messages / adaptive (omitted)  TTFT=2.415s  TTLT=5.759s  out=730\n"
+     ]
+    }
+   ],
+   "source": [
+    "test_cases = [\n",
+    "    (\"Converse / no thinking\", converse_visible, converse_no_thinking),\n",
+    "    (\"Converse / adaptive (summarized)\", converse_visible, converse_thinking_summarized),\n",
+    "    (\"Converse / adaptive (omitted)\", converse_visible, converse_thinking_omitted),\n",
+    "    (\"Messages / no thinking\", messages_visible, messages_no_thinking),\n",
+    "    (\"Messages / adaptive (summarized)\", messages_visible, messages_thinking_summarized),\n",
+    "    (\"Messages / adaptive (omitted)\", messages_visible, messages_thinking_omitted),\n",
+    "]\n",
+    "\n",
+    "for name, ep, payload in test_cases:\n",
+    "    r = ep.invoke(payload)\n",
+    "    assert r.error is None, f\"{name} error: {r.error}\"\n",
+    "    print(\n",
+    "        f\"{name:>40}  \"\n",
+    "        f\"TTFT={r.time_to_first_token:.3f}s  \"\n",
+    "        f\"TTLT={r.time_to_last_token:.3f}s  \"\n",
+    "        f\"out={r.num_tokens_output}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run the benchmark\n",
+    "\n",
+    "We run each configuration through `Runner` to collect enough samples for\n",
+    "meaningful statistics. Each run uses a fresh `NoCacheCallback` to prevent\n",
+    "prompt caching."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "--- converse-no-thinking ---\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "57bba48b277c4441b5beeff9ce116b4e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Total requests:   0%|          | 0/10 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table style='border-collapse:collapse;margin:4px 0'><tr><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Throughput</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTFT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTLT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Tokens</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Errors</th></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>rpm</span>&nbsp;&nbsp;<span style='font-family:monospace'>6.7</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>1.971s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>7.738s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>input_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>909.0</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>fail</span>&nbsp;&nbsp;<span style='font-family:monospace'>0.0</span></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>65.9 tok/s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>20.364s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>25.973s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>6671.0</span></td><td></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>122.7 tok/s</span></td><td></td><td></td><td></td><td></td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  10 requests  p50 TTFT=1.971s  p50 TTLT=7.738s\n",
+      "\n",
+      "--- converse-thinking-summarized ---\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d4830dd435444ca6a295204ae3244060",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Total requests:   0%|          | 0/10 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table style='border-collapse:collapse;margin:4px 0'><tr><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Throughput</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTFT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTLT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Tokens</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Errors</th></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>rpm</span>&nbsp;&nbsp;<span style='font-family:monospace'>5.9</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>4.048s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>6.824s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>input_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>904.0</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>fail</span>&nbsp;&nbsp;<span style='font-family:monospace'>0.0</span></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>76.6 tok/s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>31.044s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>34.086s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>8323.0</span></td><td></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>290.0 tok/s</span></td><td></td><td></td><td></td><td></td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  10 requests  p50 TTFT=4.048s  p50 TTLT=6.824s\n",
+      "\n",
+      "--- converse-thinking-omitted ---\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "76d1838ced9341b98025c7d2c09e409a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Total requests:   0%|          | 0/10 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table style='border-collapse:collapse;margin:4px 0'><tr><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Throughput</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTFT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTLT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Tokens</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Errors</th></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>rpm</span>&nbsp;&nbsp;<span style='font-family:monospace'>4.7</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>3.600s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>7.531s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>input_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>904.0</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>fail</span>&nbsp;&nbsp;<span style='font-family:monospace'>0.0</span></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>64.4 tok/s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>25.766s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>28.689s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>8642.0</span></td><td></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>227.0 tok/s</span></td><td></td><td></td><td></td><td></td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  10 requests  p50 TTFT=3.600s  p50 TTLT=7.531s\n",
+      "\n",
+      "--- converse-thinking-any-ttft ---\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2c56e8d27ac54bd3a7b54567a6fcecad",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Total requests:   0%|          | 0/10 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table style='border-collapse:collapse;margin:4px 0'><tr><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Throughput</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTFT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTLT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Tokens</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Errors</th></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>rpm</span>&nbsp;&nbsp;<span style='font-family:monospace'>9.6</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>3.082s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>6.594s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>input_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>907.0</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>fail</span>&nbsp;&nbsp;<span style='font-family:monospace'>0.0</span></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>109.4 tok/s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>6.276s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>9.963s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>7918.0</span></td><td></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>225.0 tok/s</span></td><td></td><td></td><td></td><td></td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  10 requests  p50 TTFT=3.082s  p50 TTLT=6.594s\n",
+      "\n",
+      "--- messages-no-thinking ---\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "655ad5b33ce64e0fa4f958548d41a96d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Total requests:   0%|          | 0/10 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table style='border-collapse:collapse;margin:4px 0'><tr><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Throughput</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTFT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTLT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Tokens</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Errors</th></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>rpm</span>&nbsp;&nbsp;<span style='font-family:monospace'>6.1</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>1.109s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>5.697s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>input_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>902.0</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>fail</span>&nbsp;&nbsp;<span style='font-family:monospace'>0.0</span></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>63.2 tok/s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>24.495s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>30.082s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>6591.0</span></td><td></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>148.2 tok/s</span></td><td></td><td></td><td></td><td></td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  10 requests  p50 TTFT=1.109s  p50 TTLT=5.697s\n",
+      "\n",
+      "--- messages-thinking-summarized ---\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4f98ef4ff014452ca2dd9c449a492a66",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Total requests:   0%|          | 0/10 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table style='border-collapse:collapse;margin:4px 0'><tr><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Throughput</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTFT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTLT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Tokens</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Errors</th></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>rpm</span>&nbsp;&nbsp;<span style='font-family:monospace'>4.4</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>7.132s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>10.248s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>input_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>902.0</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>fail</span>&nbsp;&nbsp;<span style='font-family:monospace'>0.0</span></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>58.2 tok/s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>26.860s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>30.793s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>8272.0</span></td><td></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>304.9 tok/s</span></td><td></td><td></td><td></td><td></td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  10 requests  p50 TTFT=7.132s  p50 TTLT=10.248s\n",
+      "\n",
+      "--- messages-thinking-omitted ---\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "356b54b899a24fda9844724c0f617697",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Total requests:   0%|          | 0/10 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table style='border-collapse:collapse;margin:4px 0'><tr><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Throughput</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTFT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTLT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Tokens</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Errors</th></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>rpm</span>&nbsp;&nbsp;<span style='font-family:monospace'>6.1</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>3.077s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>6.734s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>input_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>905.0</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>fail</span>&nbsp;&nbsp;<span style='font-family:monospace'>0.0</span></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>66.8 tok/s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>22.238s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>24.422s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>8195.0</span></td><td></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>203.6 tok/s</span></td><td></td><td></td><td></td><td></td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  10 requests  p50 TTFT=3.077s  p50 TTLT=6.734s\n",
+      "\n",
+      "--- messages-thinking-any-ttft ---\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "64d0af91c27349b1b8ace4c89c14df59",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Total requests:   0%|          | 0/10 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table style='border-collapse:collapse;margin:4px 0'><tr><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Throughput</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTFT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>TTLT</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Tokens</th><th style='padding:2px 10px;font-size:11px;color:#888;border-bottom:1px solid #ddd;text-align:left'>Errors</th></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>rpm</span>&nbsp;&nbsp;<span style='font-family:monospace'>5.0</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>2.447s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>6.760s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>input_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>815.0</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>fail</span>&nbsp;&nbsp;<span style='font-family:monospace'>0.0</span></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>63.6 tok/s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttft</span>&nbsp;&nbsp;<span style='font-family:monospace'>29.852s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p90_ttlt</span>&nbsp;&nbsp;<span style='font-family:monospace'>36.524s</span></td><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>output_tokens</span>&nbsp;&nbsp;<span style='font-family:monospace'>7288.0</span></td><td></td></tr><tr><td style='padding:1px 10px;font-size:12px'><span style='color:#666'>p50_tps</span>&nbsp;&nbsp;<span style='font-family:monospace'>211.7 tok/s</span></td><td></td><td></td><td></td><td></td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Timeout waiting for response\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  9 requests  p50 TTFT=2.447s  p50 TTLT=6.760s\n"
+     ]
+    }
+   ],
+   "source": [
+    "from llmeter.runner import Runner\n",
+    "\n",
+    "results = {}\n",
+    "\n",
+    "runs = [\n",
+    "    # (label, endpoint, payload)\n",
+    "    (\"converse-no-thinking\", converse_visible, converse_no_thinking),\n",
+    "    (\"converse-thinking-summarized\", converse_visible, converse_thinking_summarized),\n",
+    "    (\"converse-thinking-omitted\", converse_visible, converse_thinking_omitted),\n",
+    "    (\"converse-thinking-any-ttft\", converse_any, converse_thinking_summarized),\n",
+    "    (\"messages-no-thinking\", messages_visible, messages_no_thinking),\n",
+    "    (\"messages-thinking-summarized\", messages_visible, messages_thinking_summarized),\n",
+    "    (\"messages-thinking-omitted\", messages_visible, messages_thinking_omitted),\n",
+    "    (\"messages-thinking-any-ttft\", messages_any, messages_thinking_summarized),\n",
+    "]\n",
+    "\n",
+    "for label, endpoint, payload in runs:\n",
+    "    print(f\"\\n--- {label} ---\")\n",
+    "    runner = Runner(\n",
+    "        endpoint=endpoint,\n",
+    "        output_path=OUTPUT_PATH,\n",
+    "        callbacks=[NoCacheCallback()],\n",
+    "    )\n",
+    "    result = await runner.run(\n",
+    "        payload=payload,\n",
+    "        n_requests=N_REQUESTS,\n",
+    "        clients=1,\n",
+    "        run_name=label,\n",
+    "    )\n",
+    "    results[label] = result\n",
+    "    print(\n",
+    "        f\"  {result.total_requests} requests  \"\n",
+    "        f\"p50 TTFT={result.stats['time_to_first_token-p50']:.3f}s  \"\n",
+    "        f\"p50 TTLT={result.stats['time_to_last_token-p50']:.3f}s\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>p50 TTFT (s)</th>\n",
+       "      <th>p90 TTFT (s)</th>\n",
+       "      <th>p50 TTLT (s)</th>\n",
+       "      <th>p90 TTLT (s)</th>\n",
+       "      <th>Avg output tokens</th>\n",
+       "      <th>Requests</th>\n",
+       "      <th>Errors</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Configuration</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>converse-no-thinking</th>\n",
+       "      <td>1.971</td>\n",
+       "      <td>20.364</td>\n",
+       "      <td>7.738</td>\n",
+       "      <td>25.973</td>\n",
+       "      <td>0</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>converse-thinking-summarized</th>\n",
+       "      <td>4.048</td>\n",
+       "      <td>31.044</td>\n",
+       "      <td>6.824</td>\n",
+       "      <td>34.086</td>\n",
+       "      <td>0</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>converse-thinking-omitted</th>\n",
+       "      <td>3.600</td>\n",
+       "      <td>25.766</td>\n",
+       "      <td>7.531</td>\n",
+       "      <td>28.689</td>\n",
+       "      <td>0</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>converse-thinking-any-ttft</th>\n",
+       "      <td>3.082</td>\n",
+       "      <td>6.276</td>\n",
+       "      <td>6.594</td>\n",
+       "      <td>9.963</td>\n",
+       "      <td>0</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>messages-no-thinking</th>\n",
+       "      <td>1.109</td>\n",
+       "      <td>24.495</td>\n",
+       "      <td>5.697</td>\n",
+       "      <td>30.082</td>\n",
+       "      <td>0</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>messages-thinking-summarized</th>\n",
+       "      <td>7.132</td>\n",
+       "      <td>26.860</td>\n",
+       "      <td>10.248</td>\n",
+       "      <td>30.793</td>\n",
+       "      <td>0</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>messages-thinking-omitted</th>\n",
+       "      <td>3.077</td>\n",
+       "      <td>22.238</td>\n",
+       "      <td>6.734</td>\n",
+       "      <td>24.422</td>\n",
+       "      <td>0</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>messages-thinking-any-ttft</th>\n",
+       "      <td>2.447</td>\n",
+       "      <td>29.852</td>\n",
+       "      <td>6.760</td>\n",
+       "      <td>36.524</td>\n",
+       "      <td>0</td>\n",
+       "      <td>9</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                              p50 TTFT (s)  p90 TTFT (s)  p50 TTLT (s)  \\\n",
+       "Configuration                                                            \n",
+       "converse-no-thinking                 1.971        20.364         7.738   \n",
+       "converse-thinking-summarized         4.048        31.044         6.824   \n",
+       "converse-thinking-omitted            3.600        25.766         7.531   \n",
+       "converse-thinking-any-ttft           3.082         6.276         6.594   \n",
+       "messages-no-thinking                 1.109        24.495         5.697   \n",
+       "messages-thinking-summarized         7.132        26.860        10.248   \n",
+       "messages-thinking-omitted            3.077        22.238         6.734   \n",
+       "messages-thinking-any-ttft           2.447        29.852         6.760   \n",
+       "\n",
+       "                              p90 TTLT (s)  Avg output tokens  Requests  \\\n",
+       "Configuration                                                             \n",
+       "converse-no-thinking                25.973                  0        10   \n",
+       "converse-thinking-summarized        34.086                  0        10   \n",
+       "converse-thinking-omitted           28.689                  0        10   \n",
+       "converse-thinking-any-ttft           9.963                  0        10   \n",
+       "messages-no-thinking                30.082                  0        10   \n",
+       "messages-thinking-summarized        30.793                  0        10   \n",
+       "messages-thinking-omitted           24.422                  0        10   \n",
+       "messages-thinking-any-ttft          36.524                  0         9   \n",
+       "\n",
+       "                              Errors  \n",
+       "Configuration                         \n",
+       "converse-no-thinking               0  \n",
+       "converse-thinking-summarized       0  \n",
+       "converse-thinking-omitted          0  \n",
+       "converse-thinking-any-ttft         0  \n",
+       "messages-no-thinking               0  \n",
+       "messages-thinking-summarized       0  \n",
+       "messages-thinking-omitted          0  \n",
+       "messages-thinking-any-ttft         0  "
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "rows = []\n",
+    "for label, result in results.items():\n",
+    "    s = result.stats\n",
+    "    rows.append({\n",
+    "        \"Configuration\": label,\n",
+    "        \"p50 TTFT (s)\": round(s[\"time_to_first_token-p50\"], 3),\n",
+    "        \"p90 TTFT (s)\": round(s[\"time_to_first_token-p90\"], 3),\n",
+    "        \"p50 TTLT (s)\": round(s[\"time_to_last_token-p50\"], 3),\n",
+    "        \"p90 TTLT (s)\": round(s[\"time_to_last_token-p90\"], 3),\n",
+    "        \"Avg output tokens\": round(s.get(\"num_tokens_output-mean\", 0)),\n",
+    "        \"Requests\": result.total_requests,\n",
+    "        \"Errors\": s.get(\"errors\", 0),\n",
+    "    })\n",
+    "\n",
+    "df = pd.DataFrame(rows).set_index(\"Configuration\")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot: TTFT by configuration\n",
+    "\n",
+    "Box plots showing the TTFT distribution for each configuration, grouped by\n",
+    "API path."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "boxpoints": "all",
+         "jitter": 0.3,
+         "marker": {
+          "color": "#4CAF50"
+         },
+         "name": "converse-no-thinking",
+         "type": "box",
+         "x": [
+          1.7869597500248346,
+          3.145613707980374,
+          5.754856167011894,
+          1.1514407499926165,
+          4.4281272499938495,
+          21.987767416983843,
+          0.9559530410042498,
+          1.0873009999922942,
+          1.1039884159981739,
+          2.1552712920238264
+         ]
+        },
+        {
+         "boxpoints": "all",
+         "jitter": 0.3,
+         "marker": {
+          "color": "#2196F3"
+         },
+         "name": "converse-thinking-summarized",
+         "type": "box",
+         "x": [
+          4.081663082994055,
+          7.824671208974905,
+          3.6653099170071073,
+          3.5641183749830816,
+          3.5467002500081435,
+          9.821974332997343,
+          4.774003333004657,
+          33.40186129201902,
+          4.014156707999064,
+          3.6799593750038184
+         ]
+        },
+        {
+         "boxpoints": "all",
+         "jitter": 0.3,
+         "marker": {
+          "color": "#FF9800"
+         },
+         "name": "converse-thinking-omitted",
+         "type": "box",
+         "x": [
+          23.075980958994478,
+          2.886183082999196,
+          2.292580832989188,
+          2.2727907090156805,
+          22.922610458976123,
+          2.443593249976402,
+          5.725463667011354,
+          3.5984454590070527,
+          26.064817208010936,
+          3.6023917089914903
+         ]
+        },
+        {
+         "boxpoints": "all",
+         "jitter": 0.3,
+         "marker": {
+          "color": "#9C27B0"
+         },
+         "name": "converse-thinking-any-ttft",
+         "type": "box",
+         "x": [
+          3.1041307499981485,
+          3.059847249998711,
+          3.7532062910031527,
+          4.348357042006683,
+          2.912970999983372,
+          5.295427292003296,
+          2.6249350830039475,
+          2.8283514169743285,
+          2.859767332993215,
+          6.385083125001984
+         ]
+        },
+        {
+         "boxpoints": "all",
+         "jitter": 0.3,
+         "marker": {
+          "color": "#4CAF50"
+         },
+         "name": "messages-no-thinking",
+         "type": "box",
+         "x": [
+          24.280539083993062,
+          1.0550471250026021,
+          1.1011859590071253,
+          1.1957160419842694,
+          24.51890454100794,
+          1.1176160000031814,
+          0.9301740000082646,
+          0.9050850420026109,
+          1.3896148749918211,
+          1.0888673750159796
+         ]
+        },
+        {
+         "boxpoints": "all",
+         "jitter": 0.3,
+         "marker": {
+          "color": "#2196F3"
+         },
+         "name": "messages-thinking-summarized",
+         "type": "box",
+         "x": [
+          3.524948250007583,
+          3.9881283750000875,
+          4.649804832995869,
+          5.674885957996594,
+          19.12323674999061,
+          18.11222650000127,
+          27.72002229100326,
+          18.511900916986633,
+          8.589993041998241,
+          5.404422583989799
+         ]
+        },
+        {
+         "boxpoints": "all",
+         "jitter": 0.3,
+         "marker": {
+          "color": "#FF9800"
+         },
+         "name": "messages-thinking-omitted",
+         "type": "box",
+         "x": [
+          2.480500417004805,
+          2.32936058298219,
+          2.4179350410122424,
+          10.131054583005607,
+          3.67383833398344,
+          17.103312749997713,
+          2.3223652500018943,
+          15.593774207984097,
+          2.3977655410126317,
+          22.808821083017392
+         ]
+        },
+        {
+         "boxpoints": "all",
+         "jitter": 0.3,
+         "marker": {
+          "color": "#9C27B0"
+         },
+         "name": "messages-thinking-any-ttft",
+         "type": "box",
+         "x": [
+          29.85229079099372,
+          27.776597249991028,
+          2.403857875004178,
+          2.4177865000092424,
+          2.366947957983939,
+          2.583363542013103,
+          2.4719927920086775,
+          2.4466450829932,
+          2.4383985410095192
+         ]
+        }
+       ],
+       "layout": {
+        "height": 500,
+        "showlegend": false,
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "TTFT by Thinking Configuration (Opus 4.7, us-east-1)"
+        },
+        "yaxis": {
+         "title": {
+          "text": "Time to First Token (seconds)"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import plotly.graph_objects as go\n",
+    "from llmeter.plotting import boxplot_by_dimension\n",
+    "\n",
+    "colors = {\n",
+    "    \"no-thinking\": \"#4CAF50\",\n",
+    "    \"thinking-summarized\": \"#2196F3\",\n",
+    "    \"thinking-omitted\": \"#FF9800\",\n",
+    "    \"thinking-any-ttft\": \"#9C27B0\",\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def color_for(label):\n",
+    "    for key, color in colors.items():\n",
+    "        if key in label:\n",
+    "            return color\n",
+    "    return \"#607D8B\"\n",
+    "\n",
+    "\n",
+    "fig = go.Figure()\n",
+    "for label, result in results.items():\n",
+    "    fig.add_trace(\n",
+    "        boxplot_by_dimension(\n",
+    "            result,\n",
+    "            \"time_to_first_token\",\n",
+    "            name=label,\n",
+    "            marker=dict(color=color_for(label)),\n",
+    "            boxpoints=\"all\",\n",
+    "            jitter=0.3,\n",
+    "        )\n",
+    "    )\n",
+    "\n",
+    "fig.update_layout(\n",
+    "    title=\"TTFT by Thinking Configuration (Opus 4.7, us-east-1)\",\n",
+    "    yaxis_title=\"Time to First Token (seconds)\",\n",
+    "    showlegend=False,\n",
+    "    height=500,\n",
+    "    template=\"plotly_white\",\n",
+    ")\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot: TTLT by configuration\n",
+    "\n",
+    "Total response time including all output tokens (thinking + text)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "boxpoints": "all",
+         "jitter": 0.3,
+         "marker": {
+          "color": "#4CAF50"
+         },
+         "name": "converse-no-thinking",
+         "type": "box",
+         "x": [
+          8.284159125003498,
+          11.935566957981791,
+          11.320494042010978,
+          6.780932499998016,
+          7.191645499988226,
+          27.533265125006437,
+          5.769811666017631,
+          5.467577333009103,
+          5.366933915996924,
+          11.516475917014759
+         ]
+        },
+        {
+         "boxpoints": "all",
+         "jitter": 0.3,
+         "marker": {
+          "color": "#2196F3"
+         },
+         "name": "converse-thinking-summarized",
+         "type": "box",
+         "x": [
+          8.162754666002002,
+          11.952275499992538,
+          6.472520417009946,
+          5.773663083004067,
+          6.324513416009722,
+          13.484650582977338,
+          6.5130376660090405,
+          36.37474866700359,
+          7.134789000003366,
+          6.355732500000158
+         ]
+        },
+        {
+         "boxpoints": "all",
+         "jitter": 0.3,
+         "marker": {
+          "color": "#FF9800"
+         },
+         "name": "converse-thinking-omitted",
+         "type": "box",
+         "x": [
+          27.01591779201408,
+          6.248818207997829,
+          6.44927979199565,
+          6.929151999996975,
+          26.689073416986503,
+          6.073572458000854,
+          10.885554084001342,
+          7.16528595899581,
+          28.87443433300359,
+          7.896123874990735
+         ]
+        },
+        {
+         "boxpoints": "all",
+         "jitter": 0.3,
+         "marker": {
+          "color": "#9C27B0"
+         },
+         "name": "converse-thinking-any-ttft",
+         "type": "box",
+         "x": [
+          6.372218292002799,
+          6.202841667021858,
+          6.635245625016978,
+          7.260089707997395,
+          6.687382542004343,
+          9.703164042002754,
+          6.409111415996449,
+          6.552905332995579,
+          6.481580499996198,
+          9.992215750011383
+         ]
+        },
+        {
+         "boxpoints": "all",
+         "jitter": 0.3,
+         "marker": {
+          "color": "#4CAF50"
+         },
+         "name": "messages-no-thinking",
+         "type": "box",
+         "x": [
+          30.266572334017837,
+          5.197585125017213,
+          5.339016417012317,
+          5.06713820900768,
+          28.418429832992842,
+          6.202777416008757,
+          5.476517958013574,
+          5.581687833997421,
+          6.054244666011073,
+          5.811719666002318
+         ]
+        },
+        {
+         "boxpoints": "all",
+         "jitter": 0.3,
+         "marker": {
+          "color": "#2196F3"
+         },
+         "name": "messages-thinking-summarized",
+         "type": "box",
+         "x": [
+          6.223801957996329,
+          6.868071166012669,
+          5.83141745798639,
+          8.880050833016867,
+          21.375141374999657,
+          21.43709266697988,
+          31.832206040999154,
+          20.607733166980324,
+          11.615932125016116,
+          6.459852959000273
+         ]
+        },
+        {
+         "boxpoints": "all",
+         "jitter": 0.3,
+         "marker": {
+          "color": "#FF9800"
+         },
+         "name": "messages-thinking-omitted",
+         "type": "box",
+         "x": [
+          6.539782375009963,
+          6.0905656249960884,
+          6.477202833018964,
+          15.432946916000219,
+          6.777441999991424,
+          22.664138666994404,
+          6.359750167001039,
+          20.000599082995905,
+          6.69086945799063,
+          24.617020250007045
+         ]
+        },
+        {
+         "boxpoints": "all",
+         "jitter": 0.3,
+         "marker": {
+          "color": "#9C27B0"
+         },
+         "name": "messages-thinking-any-ttft",
+         "type": "box",
+         "x": [
+          36.524465416005114,
+          30.7035252499918,
+          7.130062750016805,
+          6.416984792012954,
+          8.504490040999372,
+          6.759908250009175,
+          5.866771333006909,
+          6.234095249994425,
+          5.618105208006455
+         ]
+        }
+       ],
+       "layout": {
+        "height": 500,
+        "showlegend": false,
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "TTLT by Thinking Configuration (Opus 4.7, us-east-1)"
+        },
+        "yaxis": {
+         "title": {
+          "text": "Time to Last Token (seconds)"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig_ttlt = go.Figure()\n",
+    "for label, result in results.items():\n",
+    "    fig_ttlt.add_trace(\n",
+    "        boxplot_by_dimension(\n",
+    "            result,\n",
+    "            \"time_to_last_token\",\n",
+    "            name=label,\n",
+    "            marker=dict(color=color_for(label)),\n",
+    "            boxpoints=\"all\",\n",
+    "            jitter=0.3,\n",
+    "        )\n",
+    "    )\n",
+    "\n",
+    "fig_ttlt.update_layout(\n",
+    "    title=\"TTLT by Thinking Configuration (Opus 4.7, us-east-1)\",\n",
+    "    yaxis_title=\"Time to Last Token (seconds)\",\n",
+    "    showlegend=False,\n",
+    "    height=500,\n",
+    "    template=\"plotly_white\",\n",
+    ")\n",
+    "fig_ttlt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot: TTFT visible vs any (thinking enabled)\n",
+    "\n",
+    "Direct comparison of the two TTFT measurement modes for the same thinking\n",
+    "configuration. This shows the gap between when the model starts thinking\n",
+    "and when the user sees the first visible text."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "histnorm": "probability",
+         "marker": {
+          "color": "#9C27B0"
+         },
+         "name": "TTFT (any token)",
+         "opacity": 0.7,
+         "type": "histogram",
+         "x": [
+          3.1041307499981485,
+          3.059847249998711,
+          3.7532062910031527,
+          4.348357042006683,
+          2.912970999983372,
+          5.295427292003296,
+          2.6249350830039475,
+          2.8283514169743285,
+          2.859767332993215,
+          6.385083125001984
+         ]
+        },
+        {
+         "histnorm": "probability",
+         "marker": {
+          "color": "#2196F3"
+         },
+         "name": "TTFT (visible text)",
+         "opacity": 0.7,
+         "type": "histogram",
+         "x": [
+          4.081663082994055,
+          7.824671208974905,
+          3.6653099170071073,
+          3.5641183749830816,
+          3.5467002500081435,
+          9.821974332997343,
+          4.774003333004657,
+          33.40186129201902,
+          4.014156707999064,
+          3.6799593750038184
+         ]
+        }
+       ],
+       "layout": {
+        "barmode": "overlay",
+        "height": 400,
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "TTFT: Any Token vs Visible Text (Converse, adaptive thinking)"
+        },
+        "xaxis": {
+         "title": {
+          "text": "Time to First Token (seconds)"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "Probability"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "histnorm": "probability",
+         "marker": {
+          "color": "#9C27B0"
+         },
+         "name": "TTFT (any token)",
+         "opacity": 0.7,
+         "type": "histogram",
+         "x": [
+          29.85229079099372,
+          27.776597249991028,
+          2.403857875004178,
+          2.4177865000092424,
+          2.366947957983939,
+          2.583363542013103,
+          2.4719927920086775,
+          2.4466450829932,
+          2.4383985410095192
+         ]
+        },
+        {
+         "histnorm": "probability",
+         "marker": {
+          "color": "#2196F3"
+         },
+         "name": "TTFT (visible text)",
+         "opacity": 0.7,
+         "type": "histogram",
+         "x": [
+          3.524948250007583,
+          3.9881283750000875,
+          4.649804832995869,
+          5.674885957996594,
+          19.12323674999061,
+          18.11222650000127,
+          27.72002229100326,
+          18.511900916986633,
+          8.589993041998241,
+          5.404422583989799
+         ]
+        }
+       ],
+       "layout": {
+        "barmode": "overlay",
+        "height": 400,
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "TTFT: Any Token vs Visible Text (Messages, adaptive thinking)"
+        },
+        "xaxis": {
+         "title": {
+          "text": "Time to First Token (seconds)"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "Probability"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from llmeter.plotting import histogram_by_dimension\n",
+    "\n",
+    "for api in [\"converse\", \"messages\"]:\n",
+    "    visible_key = f\"{api}-thinking-summarized\"\n",
+    "    any_key = f\"{api}-thinking-any-ttft\"\n",
+    "\n",
+    "    if visible_key not in results or any_key not in results:\n",
+    "        continue\n",
+    "\n",
+    "    fig_cmp = go.Figure()\n",
+    "    fig_cmp.add_trace(\n",
+    "        histogram_by_dimension(\n",
+    "            results[any_key],\n",
+    "            \"time_to_first_token\",\n",
+    "            name=\"TTFT (any token)\",\n",
+    "            opacity=0.7,\n",
+    "            marker_color=\"#9C27B0\",\n",
+    "        )\n",
+    "    )\n",
+    "    fig_cmp.add_trace(\n",
+    "        histogram_by_dimension(\n",
+    "            results[visible_key],\n",
+    "            \"time_to_first_token\",\n",
+    "            name=\"TTFT (visible text)\",\n",
+    "            opacity=0.7,\n",
+    "            marker_color=\"#2196F3\",\n",
+    "        )\n",
+    "    )\n",
+    "    fig_cmp.update_layout(\n",
+    "        title=f\"TTFT: Any Token vs Visible Text ({api.title()}, adaptive thinking)\",\n",
+    "        xaxis_title=\"Time to First Token (seconds)\",\n",
+    "        yaxis_title=\"Probability\",\n",
+    "        barmode=\"overlay\",\n",
+    "        height=400,\n",
+    "        template=\"plotly_white\",\n",
+    "    )\n",
+    "    fig_cmp.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Observations\n",
+    "\n",
+    "Expected patterns:\n",
+    "\n",
+    "- **No thinking** has the lowest TTFT and TTLT — the model produces text immediately\n",
+    "- **Adaptive thinking (summarized)** increases TTFT (visible) because thinking\n",
+    "  tokens stream before the text. TTFT (any) is lower because it captures the\n",
+    "  first thinking delta\n",
+    "- **Adaptive thinking (omitted)** should have TTFT (visible) between the other\n",
+    "  two — no thinking tokens are streamed, so text starts sooner than summarized\n",
+    "  mode, but the model still reasons internally before producing text\n",
+    "- **TTLT** increases with thinking because `output_tokens` includes both\n",
+    "  thinking and text tokens\n",
+    "- The gap between TTFT (any) and TTFT (visible) represents the time the model\n",
+    "  spends reasoning before producing visible output\n",
+    "\n",
+    "### Token accounting note\n",
+    "\n",
+    "The Anthropic API reports a single `output_tokens` count that includes both\n",
+    "thinking and visible text tokens. There is no separate `reasoning_tokens`\n",
+    "field. This means `num_tokens_output` in the results reflects total billed\n",
+    "output, and `num_tokens_output_reasoning` is `None`.\n",
+    "\n",
+    "To get more statistically significant results, increase `N_REQUESTS` or use\n",
+    "`run_duration` for time-bound runs."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/llmeter/endpoints/__init__.py
+++ b/llmeter/endpoints/__init__.py
@@ -21,6 +21,13 @@ if spec:
         OpenAIResponseStreamEndpoint,
     )
 
+spec = importlib.util.find_spec("anthropic")
+if spec:
+    from .anthropic_messages import (  # noqa: F401
+        AnthropicMessages,
+        AnthropicMessagesStream,
+    )
+
 spec = importlib.util.find_spec("litellm")
 if spec:
     from .litellm import LiteLLM, LiteLLMStreaming  # noqa: F401

--- a/llmeter/endpoints/anthropic_messages.py
+++ b/llmeter/endpoints/anthropic_messages.py
@@ -5,17 +5,13 @@
 Supports any client provided by the `anthropic` Python SDK:
 
 * `"anthropic"` - Direct API at `api.anthropic.com`
-* `"bedrock-mantle"` - Amazon Bedrock Mantle (requires `anthropic[bedrock]`)
+* `"bedrock-mantle"` - Amazon Bedrock Mantle
 * `"vertex"` - Google Vertex AI (requires `anthropic[vertex]`)
 * `"foundry"` - Azure Foundry
 
-Install the base dependency::
+Install the dependency::
 
     pip install 'llmeter[anthropic]'
-
-For Bedrock Mantle support::
-
-    pip install 'llmeter[anthropic-bedrock]'
 
 ### Extended thinking
 

--- a/llmeter/endpoints/anthropic_messages.py
+++ b/llmeter/endpoints/anthropic_messages.py
@@ -1,97 +1,127 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""LLMeter targets for testing Anthropic Messages API endpoints
+"""LLMeter endpoints for the Anthropic Messages API.
 
-Supports the Anthropic Messages API via:
+Supports any client provided by the ``anthropic`` Python SDK:
 
-* **Direct Anthropic API** — using an API key against ``api.anthropic.com``
-* **Amazon Bedrock** — using ``AnthropicBedrock`` with AWS credentials and
-  ARN-versioned model IDs (``InvokeModel``-based integration)
-* **Amazon Bedrock Mantle** — using ``AnthropicBedrockMantle`` with the
-  ``/anthropic/v1/messages`` endpoint and SSE streaming
+* ``"anthropic"`` -- direct API at ``api.anthropic.com``
+* ``"bedrock-mantle"`` -- Amazon Bedrock Mantle (requires ``anthropic[bedrock]``)
+* ``"vertex"`` -- Google Vertex AI (requires ``anthropic[vertex]``)
+* ``"foundry"`` -- Azure Foundry
 
-All three paths use the same ``anthropic`` Python SDK and the same Messages API
-shape, so a single pair of endpoint classes covers them.
-
-Requires the ``anthropic`` optional dependency::
+Install the base dependency::
 
     pip install 'llmeter[anthropic]'
 
-For Bedrock support, install the bedrock extra instead::
+For Bedrock Mantle support::
 
     pip install 'llmeter[anthropic-bedrock]'
+
+Extended thinking
+-----------------
+
+Claude models can perform internal reasoning ("thinking") before producing a
+visible answer.  The thinking configuration is controlled via the ``thinking``
+parameter on
+:meth:`~AnthropicMessagesEndpoint.create_payload` or passed directly in the
+request payload.
+
+Token accounting
+~~~~~~~~~~~~~~~~
+
+The Anthropic API reports a single ``output_tokens`` count that **includes**
+both thinking and visible text tokens.  There is no separate
+``reasoning_tokens`` field.  As a result:
+
+* :attr:`~llmeter.endpoints.base.InvocationResponse.num_tokens_output` reflects
+  the total billed output tokens (thinking + text).
+* :attr:`~llmeter.endpoints.base.InvocationResponse.num_tokens_output_reasoning`
+  is always ``None`` for Anthropic endpoints because the API does not provide a
+  breakdown.
+
+This differs from OpenAI, which reports ``reasoning_tokens`` separately.  When
+comparing across providers, keep in mind that ``num_tokens_output`` is
+semantically consistent (total billed output) but the reasoning breakdown is
+only available where the provider exposes it.
+
+Time to first token (TTFT) and the ``display`` setting
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``display`` field on the thinking configuration controls whether thinking
+content is streamed back:
+
+* ``"summarized"`` (default on most models) -- ``thinking_delta`` events stream
+  before the visible text.
+* ``"omitted"`` (default on Claude Opus 4.7 and Mythos) -- no
+  ``thinking_delta`` events are emitted; only a ``signature_delta`` signals
+  that the thinking block completed.
+
+The ``ttft_visible_tokens_only`` parameter on
+:class:`AnthropicMessagesStream` controls how
+:attr:`~llmeter.endpoints.base.InvocationResponse.time_to_first_token` is
+measured:
+
+* ``True`` (default) -- TTFT records the first **visible** ``text_delta``.
+  Thinking events (``thinking_delta``, ``signature_delta``) are ignored.  This
+  measures the latency the end user experiences before seeing output.
+* ``False`` -- TTFT records the first token of **any** kind, including
+  ``thinking_delta`` (summarized mode) or ``signature_delta`` (omitted mode).
+  This measures when the model first started producing output.
+
+Because ``display: "omitted"`` suppresses ``thinking_delta`` events entirely,
+the ``signature_delta`` is the earliest signal available.  With
+``ttft_visible_tokens_only=False``, the measured TTFT will therefore differ
+between summarized and omitted modes for the same model and prompt:
+summarized mode captures the first thinking token, while omitted mode captures
+the signature that arrives after all thinking is complete.
 """
 
 import logging
 import time
-from typing import Any
+from typing import Any, Generic, Iterable, TypeVar
 
-from ..utils import DeferredError
-from .base import Endpoint, InvocationResponse, llmeter_invoke
+import anthropic
+from anthropic.types import (
+    Message,
+    MessageCreateParams,
+    RawMessageStreamEvent,
+)
+
+from .base import Endpoint, InvocationResponse
 
 logger = logging.getLogger(__name__)
 
-try:
-    import anthropic
-except ImportError as e:
-    logger.debug(
-        "anthropic not available. Install with: pip install 'llmeter[anthropic]' "
-        "or pip install 'llmeter[anthropic-bedrock]' for Bedrock support"
-    )
-    anthropic = DeferredError(e)
+TAnthropicResponseBase = TypeVar(
+    "TAnthropicResponseBase",
+    bound=Message | Iterable[RawMessageStreamEvent],
+)
+
+_ANTHROPIC_CLIENTS: dict[str, type] = {
+    "anthropic": anthropic.Anthropic,
+    "bedrock-mantle": anthropic.AnthropicBedrockMantle,
+    "vertex": anthropic.AnthropicVertex,
+    "foundry": anthropic.AnthropicFoundry,
+}
 
 
-def _build_anthropic_client(
-    provider: str,
-    api_key: str | None = None,
-    aws_region: str | None = None,
-    **kwargs: Any,
+class AnthropicMessagesEndpoint(
+    Endpoint[TAnthropicResponseBase], Generic[TAnthropicResponseBase]
 ):
-    """Build the appropriate Anthropic client based on provider.
-
-    Args:
-        provider: One of ``"anthropic"``, ``"bedrock"``, or ``"bedrock-mantle"``.
-        api_key: API key for direct Anthropic API access.
-        aws_region: AWS region for Bedrock providers.
-        **kwargs: Additional keyword arguments passed to the client constructor.
-
-    Returns:
-        An Anthropic client instance.
-
-    Raises:
-        ValueError: If provider is not recognized.
-    """
-    if provider == "anthropic":
-        return anthropic.Anthropic(api_key=api_key, **kwargs)
-    elif provider == "bedrock":
-        return anthropic.AnthropicBedrock(aws_region=aws_region, **kwargs)
-    elif provider == "bedrock-mantle":
-        return anthropic.AnthropicBedrockMantle(aws_region=aws_region, **kwargs)
-    else:
-        raise ValueError(
-            f"Unknown provider '{provider}'. "
-            "Use 'anthropic', 'bedrock', or 'bedrock-mantle'."
-        )
-
-
-class AnthropicMessagesEndpoint(Endpoint):
     """Base class for Anthropic Messages API endpoints.
 
-    Works with the direct Anthropic API, Amazon Bedrock, and Amazon Bedrock
-    Mantle.  The ``provider`` argument selects which client to instantiate.
+    Works with any client provided by the ``anthropic`` SDK.  The ``provider``
+    argument selects which client to instantiate.
 
     Args:
-        model_id: Model identifier (e.g. ``"claude-opus-4-7"``,
-            ``"anthropic.claude-opus-4-7"`` for Bedrock Mantle,
-            ``"global.anthropic.claude-opus-4-6-v1"`` for Bedrock).
+        model_id: Model identifier (e.g. ``"claude-opus-4-7"`` for direct API,
+            ``"anthropic.claude-opus-4-7"`` for Bedrock Mantle).
         endpoint_name: Display name for this endpoint.  Defaults to
             ``"anthropic-messages"``.
-        provider: Backend to use.  One of ``"anthropic"`` (direct API),
-            ``"bedrock"`` (InvokeModel-based), or ``"bedrock-mantle"``
-            (Messages API via Mantle).  Defaults to ``"anthropic"``.
-        api_key: API key for the direct Anthropic API.  Ignored for Bedrock
-            providers.
-        aws_region: AWS region for Bedrock providers.  Ignored for direct API.
+        provider: Backend to use -- one of ``"anthropic"``,
+            ``"bedrock-mantle"``, ``"vertex"``, or ``"foundry"``.
+            Defaults to ``"anthropic"``.
+        api_key: API key for the direct Anthropic API.
+        aws_region: AWS region for Bedrock Mantle.
         **kwargs: Additional keyword arguments forwarded to the underlying
             ``anthropic`` client constructor (e.g. ``base_url``,
             ``max_retries``, ``timeout``).
@@ -112,14 +142,19 @@ class AnthropicMessagesEndpoint(Endpoint):
             provider=provider,
         )
         self.aws_region = aws_region
-        self._client = _build_anthropic_client(
-            provider=provider,
-            api_key=api_key,
-            aws_region=aws_region,
-            **kwargs,
-        )
+        client_cls = _ANTHROPIC_CLIENTS.get(provider)
+        if client_cls is None:
+            raise ValueError(
+                f"Unknown provider '{provider}'. "
+                f"Use one of: {', '.join(_ANTHROPIC_CLIENTS)}."
+            )
+        if api_key is not None:
+            kwargs["api_key"] = api_key
+        if aws_region is not None:
+            kwargs["aws_region"] = aws_region
+        self._client = client_cls(**kwargs)
 
-    def _parse_payload(self, payload: dict) -> str:
+    def _parse_payload(self, payload: MessageCreateParams | dict) -> str:
         """Extract user message text from an Anthropic Messages API payload.
 
         Args:
@@ -150,8 +185,9 @@ class AnthropicMessagesEndpoint(Endpoint):
     def create_payload(
         user_message: str,
         max_tokens: int = 256,
+        thinking: dict | None = None,
         **kwargs: Any,
-    ) -> dict:
+    ) -> MessageCreateParams:
         """Create a payload for the Anthropic Messages API.
 
         This is a convenience helper.  You can also build the payload dict
@@ -161,6 +197,41 @@ class AnthropicMessagesEndpoint(Endpoint):
         Args:
             user_message: The user message text.
             max_tokens: Maximum tokens to generate.  Defaults to 256.
+            thinking: Extended thinking configuration.  Common values:
+
+                * ``{"type": "adaptive"}`` -- adaptive thinking
+                  (recommended for Claude Opus 4.6 / Sonnet 4.6 and later).
+                * ``{"type": "enabled", "budget_tokens": 10000}`` -- manual
+                  thinking budget (deprecated on Claude 4.6+, unsupported on
+                  Opus 4.7+).
+                * ``{"type": "disabled"}`` -- explicitly disable thinking.
+                * ``None`` (default) -- omit the parameter, letting the API
+                  use its default behavior.
+
+                The ``display`` key controls how thinking content is returned
+                in streaming responses:
+
+                * ``"summarized"`` (default on most models) -- thinking
+                  blocks contain summarized text; ``thinking_delta`` events
+                  stream before the visible text.
+                * ``"omitted"`` (default on Opus 4.7 / Mythos) -- thinking
+                  blocks have an empty ``thinking`` field; no
+                  ``thinking_delta`` events are emitted, only a
+                  ``signature_delta``.  This reduces time-to-first-text-token
+                  when streaming.
+
+                Example with display::
+
+                    create_payload(
+                        "Solve this problem",
+                        max_tokens=16000,
+                        thinking={
+                            "type": "enabled",
+                            "budget_tokens": 10000,
+                            "display": "omitted",
+                        },
+                    )
+
             **kwargs: Additional payload parameters (``system``,
                 ``temperature``, ``top_p``, ``top_k``, ``stop_sequences``,
                 etc.).
@@ -184,6 +255,21 @@ class AnthropicMessagesEndpoint(Endpoint):
                     system="You are a physics professor.",
                     max_tokens=1024,
                 )
+
+            With adaptive thinking::
+
+                create_payload(
+                    "Prove that there are infinitely many primes.",
+                    max_tokens=16000,
+                    thinking={"type": "adaptive"},
+                )
+
+            With thinking explicitly disabled::
+
+                create_payload(
+                    "Hello!",
+                    thinking={"type": "disabled"},
+                )
         """
         if not isinstance(user_message, str):
             raise TypeError(
@@ -196,25 +282,26 @@ class AnthropicMessagesEndpoint(Endpoint):
             "messages": [{"role": "user", "content": user_message}],
             "max_tokens": max_tokens,
         }
+        if thinking is not None:
+            payload["thinking"] = thinking
         payload.update(kwargs)
-        return payload
+        return payload  # type: ignore[return-value]
 
 
-class AnthropicMessages(AnthropicMessagesEndpoint):
+class AnthropicMessages(AnthropicMessagesEndpoint[Message]):
     """Endpoint for the Anthropic Messages API (non-streaming).
+
+    When extended thinking is enabled, the response may contain ``thinking``
+    content blocks alongside ``text`` blocks.  Only ``text`` blocks contribute
+    to :attr:`~llmeter.endpoints.base.InvocationResponse.response_text`.
+    The reported ``num_tokens_output`` is the total billed count (thinking +
+    text); ``num_tokens_output_reasoning`` is ``None`` because the Anthropic
+    API does not provide a separate thinking token count.
 
     Examples:
         Direct Anthropic API::
 
             endpoint = AnthropicMessages(model_id="claude-opus-4-7")
-
-        Amazon Bedrock (InvokeModel-based)::
-
-            endpoint = AnthropicMessages(
-                model_id="global.anthropic.claude-opus-4-6-v1",
-                provider="bedrock",
-                aws_region="us-west-2",
-            )
 
         Amazon Bedrock Mantle::
 
@@ -225,60 +312,114 @@ class AnthropicMessages(AnthropicMessagesEndpoint):
             )
     """
 
-    @llmeter_invoke
-    def invoke(self, payload: dict) -> InvocationResponse:
+    @AnthropicMessagesEndpoint.llmeter_invoke
+    def invoke(self, payload: MessageCreateParams) -> Message:
         """Invoke the Anthropic Messages API (non-streaming)."""
-        start_t = time.perf_counter()
         client_response = self._client.messages.create(**payload)
-        return self.parse_response(client_response, start_t)
+        return client_response
 
     def prepare_payload(self, payload: dict, **kwargs: Any) -> dict:
         payload = {**kwargs, **payload}
         payload["model"] = self.model_id
         return payload
 
-    def parse_response(self, client_response, start_t: float) -> InvocationResponse:
+    def process_raw_response(
+        self,
+        raw_response: Message,
+        start_t: float,
+        response: InvocationResponse,
+    ) -> None:
         """Parse a non-streaming Anthropic Messages API response.
 
-        Args:
-            client_response: The ``Message`` object returned by the API.
-            start_t: Start time of the API call.
+        Only ``text`` content blocks are extracted into ``response_text``.
+        ``thinking`` and ``redacted_thinking`` blocks are skipped.
 
-        Returns:
-            InvocationResponse with extracted text and token counts.
+        Args:
+            raw_response: The ``Message`` object returned by the API.
+            start_t: Start time of the API call.
+            response: The LLMeter response object to be populated in-place.
         """
-        # Extract text from content blocks
+        response.time_to_last_token = time.perf_counter() - start_t
+        response.id = raw_response.id
+
+        # Extract text from content blocks (skip thinking/redacted_thinking)
         response_text = ""
-        for block in client_response.content:
+        for block in raw_response.content:
             if block.type == "text":
                 response_text += block.text
+        response.response_text = response_text
 
-        usage = client_response.usage
-        input_tokens = getattr(usage, "input_tokens", None) if usage else None
-        output_tokens = getattr(usage, "output_tokens", None) if usage else None
-        cached_tokens = None
+        usage = raw_response.usage
         if usage:
-            cached_tokens = getattr(usage, "cache_read_input_tokens", None)
-
-        return InvocationResponse(
-            id=client_response.id,
-            response_text=response_text,
-            num_tokens_input=input_tokens,
-            num_tokens_output=output_tokens,
-            num_tokens_input_cached=cached_tokens,
-        )
+            response.num_tokens_input = getattr(usage, "input_tokens", None)
+            response.num_tokens_output = getattr(usage, "output_tokens", None)
+            response.num_tokens_input_cached = getattr(
+                usage, "cache_read_input_tokens", None
+            )
 
 
-class AnthropicMessagesStream(AnthropicMessagesEndpoint):
+class AnthropicMessagesStream(
+    AnthropicMessagesEndpoint[Iterable[RawMessageStreamEvent]]
+):
     """Endpoint for the Anthropic Messages API (streaming).
 
     Uses ``client.messages.create(..., stream=True)`` to stream SSE events,
     enabling time-to-first-token and time-to-last-token measurements.
 
+    Extended thinking and TTFT
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    When extended thinking is enabled, the stream contains thinking-related
+    events before the visible text.  The ``ttft_visible_tokens_only``
+    parameter controls which event sets ``time_to_first_token``:
+
+    * ``True`` (default) -- TTFT is set on the first ``text_delta``.
+      Thinking events are ignored.  Use this to measure the latency an end
+      user experiences before seeing output.
+    * ``False`` -- TTFT is set on the first event of any kind, including
+      ``thinking_delta`` (when ``display`` is ``"summarized"``) or
+      ``signature_delta`` (when ``display`` is ``"omitted"``).  Use this to
+      measure when the model first started producing output.
+
+    The ``display`` setting on the thinking configuration affects which
+    events are emitted:
+
+    * ``"summarized"`` -- ``thinking_delta`` events stream before the text.
+      With ``ttft_visible_tokens_only=False``, TTFT captures the first
+      thinking token.
+    * ``"omitted"`` -- no ``thinking_delta`` events; only a
+      ``signature_delta`` signals the end of the thinking block.  With
+      ``ttft_visible_tokens_only=False``, TTFT captures the signature,
+      which arrives later than a thinking delta would.
+
+    This means that for the same model and prompt, measured TTFT with
+    ``ttft_visible_tokens_only=False`` will differ between summarized and
+    omitted modes.  Summarized mode captures the first thinking token;
+    omitted mode captures the signature that arrives after all thinking is
+    complete.
+
+    Args:
+        model_id: Model identifier.
+        endpoint_name: Display name.  Defaults to ``"anthropic-messages"``.
+        provider: Backend to use.  Defaults to ``"anthropic"``.
+        api_key: API key for the direct Anthropic API.
+        aws_region: AWS region for Bedrock Mantle.
+        ttft_visible_tokens_only: When ``True`` (default), TTFT measures
+            time to first visible text token.  When ``False``, TTFT
+            includes thinking/signature events.  See above for details.
+        **kwargs: Additional arguments forwarded to the client constructor.
+
     Examples:
         Direct Anthropic API::
 
             endpoint = AnthropicMessagesStream(model_id="claude-opus-4-7")
+
+        Measure TTFT including thinking::
+
+            endpoint = AnthropicMessagesStream(
+                model_id="claude-sonnet-4-6",
+                ttft_visible_tokens_only=False,
+            )
 
         Amazon Bedrock Mantle::
 
@@ -289,12 +430,31 @@ class AnthropicMessagesStream(AnthropicMessagesEndpoint):
             )
     """
 
-    @llmeter_invoke
-    def invoke(self, payload: dict) -> InvocationResponse:
+    def __init__(
+        self,
+        model_id: str,
+        endpoint_name: str = "anthropic-messages",
+        provider: str = "anthropic",
+        api_key: str | None = None,
+        aws_region: str | None = None,
+        ttft_visible_tokens_only: bool = True,
+        **kwargs: Any,
+    ):
+        super().__init__(
+            model_id=model_id,
+            endpoint_name=endpoint_name,
+            provider=provider,
+            api_key=api_key,
+            aws_region=aws_region,
+            **kwargs,
+        )
+        self.ttft_visible_tokens_only = ttft_visible_tokens_only
+
+    @AnthropicMessagesEndpoint.llmeter_invoke
+    def invoke(self, payload: MessageCreateParams) -> Iterable[RawMessageStreamEvent]:
         """Invoke the Anthropic Messages API with streaming."""
-        start_t = time.perf_counter()
         client_response = self._client.messages.create(**payload)
-        return self.parse_response(client_response, start_t)
+        return client_response
 
     def prepare_payload(self, payload: dict, **kwargs: Any) -> dict:
         payload = {**kwargs, **payload}
@@ -302,63 +462,65 @@ class AnthropicMessagesStream(AnthropicMessagesEndpoint):
         payload["stream"] = True
         return payload
 
-    def parse_response(self, client_response, start_t: float) -> InvocationResponse:
+    def process_raw_response(
+        self,
+        raw_response: Iterable[RawMessageStreamEvent],
+        start_t: float,
+        response: InvocationResponse,
+    ) -> None:
         """Parse a streaming Anthropic Messages API response.
 
-        Processes SSE events to extract text, token counts, and timing
-        information (TTFT and TTLT).
+        Processes SSE events to extract text, token counts, and timing.
+
+        Only ``text_delta`` events contribute to ``response_text``.
+        ``thinking_delta`` and ``signature_delta`` events are used solely
+        for TTFT measurement when ``ttft_visible_tokens_only`` is ``False``.
 
         Args:
-            client_response: The streaming iterator of SSE events.
+            raw_response: The streaming iterator of SSE events.
             start_t: Start time of the API call.
-
-        Returns:
-            InvocationResponse with concatenated text, token counts, TTFT,
-            and TTLT.
+            response: The LLMeter response object to be populated in-place.
         """
-        response_text = ""
-        response_id = None
-        input_tokens = None
-        output_tokens = None
-        cached_tokens = None
-        time_to_first_token = None
+        _THINKING_DELTA_TYPES = frozenset(("thinking_delta", "signature_delta"))
 
-        for event in client_response:
+        for event in raw_response:
+            now = time.perf_counter()
             event_type = event.type
 
             if event_type == "message_start":
-                response_id = event.message.id
-                # input token count is available in the initial message usage
+                response.id = event.message.id
                 if event.message.usage:
-                    input_tokens = getattr(event.message.usage, "input_tokens", None)
-                    cached_tokens = getattr(
+                    response.num_tokens_input = getattr(
+                        event.message.usage, "input_tokens", None
+                    )
+                    response.num_tokens_input_cached = getattr(
                         event.message.usage, "cache_read_input_tokens", None
                     )
 
             elif event_type == "content_block_delta":
                 delta = event.delta
-                if getattr(delta, "type", None) == "text_delta":
+                delta_type = getattr(delta, "type", None)
+
+                if delta_type in _THINKING_DELTA_TYPES:
+                    if (
+                        not self.ttft_visible_tokens_only
+                        and response.time_to_first_token is None
+                    ):
+                        response.time_to_first_token = now - start_t
+
+                elif delta_type == "text_delta":
                     text = getattr(delta, "text", "")
-                    if text and time_to_first_token is None:
-                        time_to_first_token = time.perf_counter() - start_t
-                    response_text += text
+                    if text:
+                        if response.time_to_first_token is None:
+                            response.time_to_first_token = now - start_t
+                        if response.response_text is None:
+                            response.response_text = text
+                        else:
+                            response.response_text += text
+                        response.time_to_last_token = now - start_t
 
             elif event_type == "message_delta":
-                # output token count comes in the message_delta usage
                 if event.usage:
-                    output_tokens = getattr(event.usage, "output_tokens", None)
-
-        time_to_last_token = time.perf_counter() - start_t
-
-        if time_to_first_token is None:
-            time_to_first_token = time_to_last_token
-
-        return InvocationResponse(
-            id=response_id,
-            response_text=response_text,
-            num_tokens_input=input_tokens,
-            num_tokens_output=output_tokens,
-            num_tokens_input_cached=cached_tokens,
-            time_to_first_token=time_to_first_token,
-            time_to_last_token=time_to_last_token,
-        )
+                    response.num_tokens_output = getattr(
+                        event.usage, "output_tokens", None
+                    )

--- a/llmeter/endpoints/anthropic_messages.py
+++ b/llmeter/endpoints/anthropic_messages.py
@@ -1,0 +1,364 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""LLMeter targets for testing Anthropic Messages API endpoints
+
+Supports the Anthropic Messages API via:
+
+* **Direct Anthropic API** — using an API key against ``api.anthropic.com``
+* **Amazon Bedrock** — using ``AnthropicBedrock`` with AWS credentials and
+  ARN-versioned model IDs (``InvokeModel``-based integration)
+* **Amazon Bedrock Mantle** — using ``AnthropicBedrockMantle`` with the
+  ``/anthropic/v1/messages`` endpoint and SSE streaming
+
+All three paths use the same ``anthropic`` Python SDK and the same Messages API
+shape, so a single pair of endpoint classes covers them.
+
+Requires the ``anthropic`` optional dependency::
+
+    pip install 'llmeter[anthropic]'
+
+For Bedrock support, install the bedrock extra instead::
+
+    pip install 'llmeter[anthropic-bedrock]'
+"""
+
+import logging
+import time
+from typing import Any
+
+from ..utils import DeferredError
+from .base import Endpoint, InvocationResponse, llmeter_invoke
+
+logger = logging.getLogger(__name__)
+
+try:
+    import anthropic
+except ImportError as e:
+    logger.debug(
+        "anthropic not available. Install with: pip install 'llmeter[anthropic]' "
+        "or pip install 'llmeter[anthropic-bedrock]' for Bedrock support"
+    )
+    anthropic = DeferredError(e)
+
+
+def _build_anthropic_client(
+    provider: str,
+    api_key: str | None = None,
+    aws_region: str | None = None,
+    **kwargs: Any,
+):
+    """Build the appropriate Anthropic client based on provider.
+
+    Args:
+        provider: One of ``"anthropic"``, ``"bedrock"``, or ``"bedrock-mantle"``.
+        api_key: API key for direct Anthropic API access.
+        aws_region: AWS region for Bedrock providers.
+        **kwargs: Additional keyword arguments passed to the client constructor.
+
+    Returns:
+        An Anthropic client instance.
+
+    Raises:
+        ValueError: If provider is not recognized.
+    """
+    if provider == "anthropic":
+        return anthropic.Anthropic(api_key=api_key, **kwargs)
+    elif provider == "bedrock":
+        return anthropic.AnthropicBedrock(aws_region=aws_region, **kwargs)
+    elif provider == "bedrock-mantle":
+        return anthropic.AnthropicBedrockMantle(aws_region=aws_region, **kwargs)
+    else:
+        raise ValueError(
+            f"Unknown provider '{provider}'. "
+            "Use 'anthropic', 'bedrock', or 'bedrock-mantle'."
+        )
+
+
+class AnthropicMessagesEndpoint(Endpoint):
+    """Base class for Anthropic Messages API endpoints.
+
+    Works with the direct Anthropic API, Amazon Bedrock, and Amazon Bedrock
+    Mantle.  The ``provider`` argument selects which client to instantiate.
+
+    Args:
+        model_id: Model identifier (e.g. ``"claude-opus-4-7"``,
+            ``"anthropic.claude-opus-4-7"`` for Bedrock Mantle,
+            ``"global.anthropic.claude-opus-4-6-v1"`` for Bedrock).
+        endpoint_name: Display name for this endpoint.  Defaults to
+            ``"anthropic-messages"``.
+        provider: Backend to use.  One of ``"anthropic"`` (direct API),
+            ``"bedrock"`` (InvokeModel-based), or ``"bedrock-mantle"``
+            (Messages API via Mantle).  Defaults to ``"anthropic"``.
+        api_key: API key for the direct Anthropic API.  Ignored for Bedrock
+            providers.
+        aws_region: AWS region for Bedrock providers.  Ignored for direct API.
+        **kwargs: Additional keyword arguments forwarded to the underlying
+            ``anthropic`` client constructor (e.g. ``base_url``,
+            ``max_retries``, ``timeout``).
+    """
+
+    def __init__(
+        self,
+        model_id: str,
+        endpoint_name: str = "anthropic-messages",
+        provider: str = "anthropic",
+        api_key: str | None = None,
+        aws_region: str | None = None,
+        **kwargs: Any,
+    ):
+        super().__init__(
+            endpoint_name=endpoint_name,
+            model_id=model_id,
+            provider=provider,
+        )
+        self.aws_region = aws_region
+        self._client = _build_anthropic_client(
+            provider=provider,
+            api_key=api_key,
+            aws_region=aws_region,
+            **kwargs,
+        )
+
+    def _parse_payload(self, payload: dict) -> str:
+        """Extract user message text from an Anthropic Messages API payload.
+
+        Args:
+            payload: Request payload containing ``messages``.
+
+        Returns:
+            Concatenated message text content.
+        """
+        messages = payload.get("messages")
+        if not messages:
+            return ""
+        contents: list[str] = []
+        for msg in messages:
+            content = msg.get("content")
+            if not content:
+                continue
+            if isinstance(content, str):
+                contents.append(content)
+            elif isinstance(content, list):
+                for block in content:
+                    if isinstance(block, str):
+                        contents.append(block)
+                    elif isinstance(block, dict) and block.get("type") == "text":
+                        contents.append(block.get("text", ""))
+        return "\n".join(contents)
+
+    @staticmethod
+    def create_payload(
+        user_message: str,
+        max_tokens: int = 256,
+        **kwargs: Any,
+    ) -> dict:
+        """Create a payload for the Anthropic Messages API.
+
+        This is a convenience helper.  You can also build the payload dict
+        directly following the `Anthropic Messages API reference
+        <https://docs.anthropic.com/en/api/messages>`_.
+
+        Args:
+            user_message: The user message text.
+            max_tokens: Maximum tokens to generate.  Defaults to 256.
+            **kwargs: Additional payload parameters (``system``,
+                ``temperature``, ``top_p``, ``top_k``, ``stop_sequences``,
+                etc.).
+
+        Returns:
+            dict: Formatted payload for the Anthropic Messages API.
+
+        Raises:
+            ValueError: If ``max_tokens`` is not a positive integer.
+            TypeError: If ``user_message`` is not a string.
+
+        Examples:
+            Text only::
+
+                create_payload("Hello, Claude!")
+
+            With system prompt::
+
+                create_payload(
+                    "Explain quantum computing",
+                    system="You are a physics professor.",
+                    max_tokens=1024,
+                )
+        """
+        if not isinstance(user_message, str):
+            raise TypeError(
+                f"user_message must be a str, got {type(user_message).__name__}"
+            )
+        if not isinstance(max_tokens, int) or max_tokens <= 0:
+            raise ValueError("max_tokens must be a positive integer")
+
+        payload: dict = {
+            "messages": [{"role": "user", "content": user_message}],
+            "max_tokens": max_tokens,
+        }
+        payload.update(kwargs)
+        return payload
+
+
+class AnthropicMessages(AnthropicMessagesEndpoint):
+    """Endpoint for the Anthropic Messages API (non-streaming).
+
+    Examples:
+        Direct Anthropic API::
+
+            endpoint = AnthropicMessages(model_id="claude-opus-4-7")
+
+        Amazon Bedrock (InvokeModel-based)::
+
+            endpoint = AnthropicMessages(
+                model_id="global.anthropic.claude-opus-4-6-v1",
+                provider="bedrock",
+                aws_region="us-west-2",
+            )
+
+        Amazon Bedrock Mantle::
+
+            endpoint = AnthropicMessages(
+                model_id="anthropic.claude-opus-4-7",
+                provider="bedrock-mantle",
+                aws_region="us-east-1",
+            )
+    """
+
+    @llmeter_invoke
+    def invoke(self, payload: dict) -> InvocationResponse:
+        """Invoke the Anthropic Messages API (non-streaming)."""
+        client_response = self._client.messages.create(**payload)
+        return self.parse_response(client_response, self._start_t)
+
+    def prepare_payload(self, payload: dict, **kwargs: Any) -> dict:
+        payload = {**kwargs, **payload}
+        payload["model"] = self.model_id
+        return payload
+
+    def parse_response(self, client_response, start_t: float) -> InvocationResponse:
+        """Parse a non-streaming Anthropic Messages API response.
+
+        Args:
+            client_response: The ``Message`` object returned by the API.
+            start_t: Start time of the API call.
+
+        Returns:
+            InvocationResponse with extracted text and token counts.
+        """
+        # Extract text from content blocks
+        response_text = ""
+        for block in client_response.content:
+            if block.type == "text":
+                response_text += block.text
+
+        usage = client_response.usage
+        input_tokens = getattr(usage, "input_tokens", None) if usage else None
+        output_tokens = getattr(usage, "output_tokens", None) if usage else None
+        cached_tokens = None
+        if usage:
+            cached_tokens = getattr(usage, "cache_read_input_tokens", None)
+
+        return InvocationResponse(
+            id=client_response.id,
+            response_text=response_text,
+            num_tokens_input=input_tokens,
+            num_tokens_output=output_tokens,
+            num_tokens_input_cached=cached_tokens,
+        )
+
+
+class AnthropicMessagesStream(AnthropicMessagesEndpoint):
+    """Endpoint for the Anthropic Messages API (streaming).
+
+    Uses ``client.messages.create(..., stream=True)`` to stream SSE events,
+    enabling time-to-first-token and time-to-last-token measurements.
+
+    Examples:
+        Direct Anthropic API::
+
+            endpoint = AnthropicMessagesStream(model_id="claude-opus-4-7")
+
+        Amazon Bedrock Mantle::
+
+            endpoint = AnthropicMessagesStream(
+                model_id="anthropic.claude-opus-4-7",
+                provider="bedrock-mantle",
+                aws_region="us-east-1",
+            )
+    """
+
+    @llmeter_invoke
+    def invoke(self, payload: dict) -> InvocationResponse:
+        """Invoke the Anthropic Messages API with streaming."""
+        client_response = self._client.messages.create(**payload)
+        return self.parse_response(client_response, self._start_t)
+
+    def prepare_payload(self, payload: dict, **kwargs: Any) -> dict:
+        payload = {**kwargs, **payload}
+        payload["model"] = self.model_id
+        payload["stream"] = True
+        return payload
+
+    def parse_response(self, client_response, start_t: float) -> InvocationResponse:
+        """Parse a streaming Anthropic Messages API response.
+
+        Processes SSE events to extract text, token counts, and timing
+        information (TTFT and TTLT).
+
+        Args:
+            client_response: The streaming iterator of SSE events.
+            start_t: Start time of the API call.
+
+        Returns:
+            InvocationResponse with concatenated text, token counts, TTFT,
+            and TTLT.
+        """
+        response_text = ""
+        response_id = None
+        input_tokens = None
+        output_tokens = None
+        cached_tokens = None
+        time_to_first_token = None
+
+        for event in client_response:
+            event_type = event.type
+
+            if event_type == "message_start":
+                response_id = event.message.id
+                # input token count is available in the initial message usage
+                if event.message.usage:
+                    input_tokens = getattr(
+                        event.message.usage, "input_tokens", None
+                    )
+                    cached_tokens = getattr(
+                        event.message.usage, "cache_read_input_tokens", None
+                    )
+
+            elif event_type == "content_block_delta":
+                delta = event.delta
+                if getattr(delta, "type", None) == "text_delta":
+                    text = getattr(delta, "text", "")
+                    if text and time_to_first_token is None:
+                        time_to_first_token = time.perf_counter() - start_t
+                    response_text += text
+
+            elif event_type == "message_delta":
+                # output token count comes in the message_delta usage
+                if event.usage:
+                    output_tokens = getattr(event.usage, "output_tokens", None)
+
+        time_to_last_token = time.perf_counter() - start_t
+
+        if time_to_first_token is None:
+            time_to_first_token = time_to_last_token
+
+        return InvocationResponse(
+            id=response_id,
+            response_text=response_text,
+            num_tokens_input=input_tokens,
+            num_tokens_output=output_tokens,
+            num_tokens_input_cached=cached_tokens,
+            time_to_first_token=time_to_first_token,
+            time_to_last_token=time_to_last_token,
+        )

--- a/llmeter/endpoints/anthropic_messages.py
+++ b/llmeter/endpoints/anthropic_messages.py
@@ -228,8 +228,9 @@ class AnthropicMessages(AnthropicMessagesEndpoint):
     @llmeter_invoke
     def invoke(self, payload: dict) -> InvocationResponse:
         """Invoke the Anthropic Messages API (non-streaming)."""
+        start_t = time.perf_counter()
         client_response = self._client.messages.create(**payload)
-        return self.parse_response(client_response, self._start_t)
+        return self.parse_response(client_response, start_t)
 
     def prepare_payload(self, payload: dict, **kwargs: Any) -> dict:
         payload = {**kwargs, **payload}
@@ -291,8 +292,9 @@ class AnthropicMessagesStream(AnthropicMessagesEndpoint):
     @llmeter_invoke
     def invoke(self, payload: dict) -> InvocationResponse:
         """Invoke the Anthropic Messages API with streaming."""
+        start_t = time.perf_counter()
         client_response = self._client.messages.create(**payload)
-        return self.parse_response(client_response, self._start_t)
+        return self.parse_response(client_response, start_t)
 
     def prepare_payload(self, payload: dict, **kwargs: Any) -> dict:
         payload = {**kwargs, **payload}
@@ -328,9 +330,7 @@ class AnthropicMessagesStream(AnthropicMessagesEndpoint):
                 response_id = event.message.id
                 # input token count is available in the initial message usage
                 if event.message.usage:
-                    input_tokens = getattr(
-                        event.message.usage, "input_tokens", None
-                    )
+                    input_tokens = getattr(event.message.usage, "input_tokens", None)
                     cached_tokens = getattr(
                         event.message.usage, "cache_read_input_tokens", None
                     )

--- a/llmeter/endpoints/anthropic_messages.py
+++ b/llmeter/endpoints/anthropic_messages.py
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """LLMeter endpoints for the Anthropic Messages API.
 
-Supports any client provided by the ``anthropic`` Python SDK:
+Supports any client provided by the `anthropic` Python SDK:
 
-* ``"anthropic"`` -- direct API at ``api.anthropic.com``
-* ``"bedrock-mantle"`` -- Amazon Bedrock Mantle (requires ``anthropic[bedrock]``)
-* ``"vertex"`` -- Google Vertex AI (requires ``anthropic[vertex]``)
-* ``"foundry"`` -- Azure Foundry
+* `"anthropic"` - Direct API at `api.anthropic.com`
+* `"bedrock-mantle"` - Amazon Bedrock Mantle (requires `anthropic[bedrock]`)
+* `"vertex"` - Google Vertex AI (requires `anthropic[vertex]`)
+* `"foundry"` - Azure Foundry
 
 Install the base dependency::
 
@@ -17,63 +17,57 @@ For Bedrock Mantle support::
 
     pip install 'llmeter[anthropic-bedrock]'
 
-Extended thinking
------------------
+### Extended thinking
 
-Claude models can perform internal reasoning ("thinking") before producing a
-visible answer.  The thinking configuration is controlled via the ``thinking``
-parameter on
-:meth:`~AnthropicMessagesEndpoint.create_payload` or passed directly in the
-request payload.
+Claude models can perform internal reasoning ("thinking") before producing a visible answer. The
+configuration for this is controlled via the `thinking` parameter on the request payload (also
+available in the
+[`create_payload`][llmeter.endpoints.anthropic_messages.AnthropicMessagesEndpoint.create_payload]
+utility function).
 
-Token accounting
-~~~~~~~~~~~~~~~~
+It's important to understand how these extra thinking/reasoning tokens that *aren't* part of the
+"final" output will be treated for response timing and token counting.
 
-The Anthropic API reports a single ``output_tokens`` count that **includes**
-both thinking and visible text tokens.  There is no separate
-``reasoning_tokens`` field.  As a result:
+#### Token accounting
 
-* :attr:`~llmeter.endpoints.base.InvocationResponse.num_tokens_output` reflects
-  the total billed output tokens (thinking + text).
-* :attr:`~llmeter.endpoints.base.InvocationResponse.num_tokens_output_reasoning`
-  is always ``None`` for Anthropic endpoints because the API does not provide a
-  breakdown.
+The Anthropic API reports a single `output_tokens` count that **includes** both thinking and
+visible text tokens.  There is no separate `reasoning_tokens` field. As a result:
 
-This differs from OpenAI, which reports ``reasoning_tokens`` separately.  When
-comparing across providers, keep in mind that ``num_tokens_output`` is
-semantically consistent (total billed output) but the reasoning breakdown is
-only available where the provider exposes it.
+* [`InvocationResponse.num_tokens_output`][llmeter.endpoints.base.InvocationResponse] reflects the
+  total billed output tokens (thinking and output).
+* [`InvocationResponse.num_tokens_output_reasoning`][llmeter.endpoints.base.InvocationResponse] is
+  always ``None`` for Anthropic endpoints because the API does not provide this breakdown.
 
-Time to first token (TTFT) and the ``display`` setting
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This differs from OpenAI, which reports `reasoning_tokens` separately.  When comparing across
+providers, keep in mind that LLMeter's `num_tokens_output` is semantically consistent (total billed
+output) but the reasoning breakdown is only available where the provider exposes it.
 
-The ``display`` field on the thinking configuration controls whether thinking
-content is streamed back:
+#### Time to first token (TTFT) and the ``display`` setting
 
-* ``"summarized"`` (default on most models) -- ``thinking_delta`` events stream
-  before the visible text.
-* ``"omitted"`` (default on Claude Opus 4.7 and Mythos) -- no
-  ``thinking_delta`` events are emitted; only a ``signature_delta`` signals
-  that the thinking block completed.
+The `display` field on the thinking configuration controls whether thinking content is streamed
+back to the client:
 
-The ``ttft_visible_tokens_only`` parameter on
-:class:`AnthropicMessagesStream` controls how
-:attr:`~llmeter.endpoints.base.InvocationResponse.time_to_first_token` is
-measured:
+* `"summarized"` (default on most models) - `thinking_delta` events stream before the visible text.
+* `"omitted"` (default on Claude Opus 4.7 and Mythos) - no `thinking_delta` events are emitted;
+  only a `signature_delta` signals that the thinking block completed.
 
-* ``True`` (default) -- TTFT records the first **visible** ``text_delta``.
-  Thinking events (``thinking_delta``, ``signature_delta``) are ignored.  This
-  measures the latency the end user experiences before seeing output.
-* ``False`` -- TTFT records the first token of **any** kind, including
-  ``thinking_delta`` (summarized mode) or ``signature_delta`` (omitted mode).
-  This measures when the model first started producing output.
+The
+[`AnthropicMessagesStream.ttft_visible_tokens_only`][llmeter.endpoints.anthropic_messages.AnthropicMessagesStream]
+parameter controls how
+[`InvocationResponse.time_to_first_token`][llmeter.endpoints.base.InvocationResponse] is measured:
 
-Because ``display: "omitted"`` suppresses ``thinking_delta`` events entirely,
-the ``signature_delta`` is the earliest signal available.  With
-``ttft_visible_tokens_only=False``, the measured TTFT will therefore differ
-between summarized and omitted modes for the same model and prompt:
-summarized mode captures the first thinking token, while omitted mode captures
-the signature that arrives after all thinking is complete.
+* `True` (default) - TTFT records the first **visible** `text_delta`. Thinking events
+  (`thinking_delta`, `signature_delta`) are ignored.  This measures the latency the end user
+  experiences before seeing output.
+* `False` -- TTFT records the first token of **any** kind, including `thinking_delta` (summarized
+  mode) or `signature_delta` (omitted mode). This measures when the model first started producing
+  output.
+
+Because `display: "omitted"` suppresses `thinking_delta` events entirely, the `signature_delta` is
+the earliest signal available.  With `ttft_visible_tokens_only=False`, the measured TTFT will
+therefore differ between summarized and omitted modes for the same model and prompt: summarized
+mode captures the first thinking token, while omitted mode captures the signature that arrives
+after all thinking is complete.
 """
 
 import logging
@@ -190,9 +184,8 @@ class AnthropicMessagesEndpoint(
     ) -> MessageCreateParams:
         """Create a payload for the Anthropic Messages API.
 
-        This is a convenience helper.  You can also build the payload dict
-        directly following the `Anthropic Messages API reference
-        <https://docs.anthropic.com/en/api/messages>`_.
+        This is a convenience helper.  You can also build the payload dict directly following the
+        [Anthropic Messages API reference](https://docs.anthropic.com/en/api/messages)
 
         Args:
             user_message: The user message text.
@@ -220,17 +213,19 @@ class AnthropicMessagesEndpoint(
                   ``signature_delta``.  This reduces time-to-first-text-token
                   when streaming.
 
-                Example with display::
+                Example with display:
 
-                    create_payload(
-                        "Solve this problem",
-                        max_tokens=16000,
-                        thinking={
-                            "type": "enabled",
-                            "budget_tokens": 10000,
-                            "display": "omitted",
-                        },
-                    )
+                ```python
+                create_payload(
+                    "Solve this problem",
+                    max_tokens=16000,
+                    thinking={
+                        "type": "enabled",
+                        "budget_tokens": 10000,
+                        "display": "omitted",
+                    },
+                )
+                ```
 
             **kwargs: Additional payload parameters (``system``,
                 ``temperature``, ``top_p``, ``top_k``, ``stop_sequences``,
@@ -244,32 +239,40 @@ class AnthropicMessagesEndpoint(
             TypeError: If ``user_message`` is not a string.
 
         Examples:
-            Text only::
+            Text only:
 
-                create_payload("Hello, Claude!")
+            ```python
+            create_payload("Hello, Claude!")
+            ```
 
-            With system prompt::
+            With system prompt:
 
-                create_payload(
-                    "Explain quantum computing",
-                    system="You are a physics professor.",
-                    max_tokens=1024,
-                )
+            ```python
+            create_payload(
+                "Explain quantum computing",
+                system="You are a physics professor.",
+                max_tokens=1024,
+            )
+            ```
 
-            With adaptive thinking::
+            With adaptive thinking:
 
-                create_payload(
-                    "Prove that there are infinitely many primes.",
-                    max_tokens=16000,
-                    thinking={"type": "adaptive"},
-                )
+            ```python
+            create_payload(
+                "Prove that there are infinitely many primes.",
+                max_tokens=16000,
+                thinking={"type": "adaptive"},
+            )
+            ```
 
-            With thinking explicitly disabled::
+            With thinking explicitly disabled:
 
-                create_payload(
-                    "Hello!",
-                    thinking={"type": "disabled"},
-                )
+            ```python
+            create_payload(
+                "Hello!",
+                thinking={"type": "disabled"},
+            )
+            ```
         """
         if not isinstance(user_message, str):
             raise TypeError(
@@ -291,25 +294,29 @@ class AnthropicMessagesEndpoint(
 class AnthropicMessages(AnthropicMessagesEndpoint[Message]):
     """Endpoint for the Anthropic Messages API (non-streaming).
 
-    When extended thinking is enabled, the response may contain ``thinking``
-    content blocks alongside ``text`` blocks.  Only ``text`` blocks contribute
-    to :attr:`~llmeter.endpoints.base.InvocationResponse.response_text`.
-    The reported ``num_tokens_output`` is the total billed count (thinking +
-    text); ``num_tokens_output_reasoning`` is ``None`` because the Anthropic
-    API does not provide a separate thinking token count.
+    When extended thinking is enabled, the response may contain `thinking` content blocks
+    alongside `text` blocks.  Only `text` blocks contribute to
+    [`InvocationResponse.response_text`][llmeter.endpoints.base.InvocationResponse].
+    The reported `num_tokens_output` is the total billed count (thinking + text);
+    `num_tokens_output_reasoning` is `None` because the Anthropic API does not provide a separate
+    thinking token count.
 
     Examples:
-        Direct Anthropic API::
+        Direct Anthropic API:
 
-            endpoint = AnthropicMessages(model_id="claude-opus-4-7")
+        ```python
+        endpoint = AnthropicMessages(model_id="claude-opus-4-7")
+        ```
 
-        Amazon Bedrock Mantle::
+        Amazon Bedrock Mantle:
 
-            endpoint = AnthropicMessages(
-                model_id="anthropic.claude-opus-4-7",
-                provider="bedrock-mantle",
-                aws_region="us-east-1",
-            )
+        ```python
+        endpoint = AnthropicMessages(
+            model_id="anthropic.claude-opus-4-7",
+            provider="bedrock-mantle",
+            aws_region="us-east-1",
+        )
+        ```
     """
 
     @AnthropicMessagesEndpoint.llmeter_invoke
@@ -331,11 +338,11 @@ class AnthropicMessages(AnthropicMessagesEndpoint[Message]):
     ) -> None:
         """Parse a non-streaming Anthropic Messages API response.
 
-        Only ``text`` content blocks are extracted into ``response_text``.
-        ``thinking`` and ``redacted_thinking`` blocks are skipped.
+        Only `text` content blocks are extracted into `response_text`. `thinking` and
+        `redacted_thinking` blocks are skipped.
 
         Args:
-            raw_response: The ``Message`` object returned by the API.
+            raw_response: The `Message` object returned by the API.
             start_t: Start time of the API call.
             response: The LLMeter response object to be populated in-place.
         """
@@ -363,71 +370,69 @@ class AnthropicMessagesStream(
 ):
     """Endpoint for the Anthropic Messages API (streaming).
 
-    Uses ``client.messages.create(..., stream=True)`` to stream SSE events,
-    enabling time-to-first-token and time-to-last-token measurements.
+    Uses `client.messages.create(..., stream=True)` to stream SSE events, enabling
+    time-to-first-token and time-to-last-token measurements.
 
-    Extended thinking and TTFT
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+    #### Extended thinking and TTFT
 
-    When extended thinking is enabled, the stream contains thinking-related
-    events before the visible text.  The ``ttft_visible_tokens_only``
-    parameter controls which event sets ``time_to_first_token``:
+    When extended thinking is enabled, the stream contains thinking-related events before the
+    visible text.  The `ttft_visible_tokens_only` parameter controls which event sets
+    `time_to_first_token`:
 
-    * ``True`` (default) -- TTFT is set on the first ``text_delta``.
-      Thinking events are ignored.  Use this to measure the latency an end
-      user experiences before seeing output.
-    * ``False`` -- TTFT is set on the first event of any kind, including
-      ``thinking_delta`` (when ``display`` is ``"summarized"``) or
-      ``signature_delta`` (when ``display`` is ``"omitted"``).  Use this to
-      measure when the model first started producing output.
+    * `True` (default) - TTFT is set on the first `text_delta`. Thinking events are ignored. Use
+      this to measure the latency an end user experiences before seeing output.
+    * `False` - TTFT is set on the first event of any kind, including `thinking_delta` (when
+      `display` is `"summarized"`) or`signature_delta` (when `display` is `"omitted"`).  Use this
+      to measure when the model first started producing output.
 
-    The ``display`` setting on the thinking configuration affects which
-    events are emitted:
+    The `display` setting on the thinking configuration affects which events are emitted:
 
-    * ``"summarized"`` -- ``thinking_delta`` events stream before the text.
-      With ``ttft_visible_tokens_only=False``, TTFT captures the first
-      thinking token.
-    * ``"omitted"`` -- no ``thinking_delta`` events; only a
-      ``signature_delta`` signals the end of the thinking block.  With
-      ``ttft_visible_tokens_only=False``, TTFT captures the signature,
-      which arrives later than a thinking delta would.
+    * `"summarized"` - `thinking_delta` events stream before the text. With
+      `ttft_visible_tokens_only=False`, TTFT captures the first thinking token.
+    * `"omitted"` - no `thinking_delta` events; only a `signature_delta` signals the end of the
+      thinking block.  With `ttft_visible_tokens_only=False`, TTFT captures the signature, which
+      arrives later than a thinking delta would.
 
     This means that for the same model and prompt, measured TTFT with
-    ``ttft_visible_tokens_only=False`` will differ between summarized and
-    omitted modes.  Summarized mode captures the first thinking token;
-    omitted mode captures the signature that arrives after all thinking is
-    complete.
+    `ttft_visible_tokens_only=False` will differ between summarized and omitted modes.  Summarized
+    mode captures the first thinking token; omitted mode captures the signature that arrives after
+    all thinking is complete.
 
     Args:
         model_id: Model identifier.
-        endpoint_name: Display name.  Defaults to ``"anthropic-messages"``.
-        provider: Backend to use.  Defaults to ``"anthropic"``.
+        endpoint_name: Display name.  Defaults to `"anthropic-messages"`.
+        provider: Backend to use.  Defaults to `"anthropic"`.
         api_key: API key for the direct Anthropic API.
         aws_region: AWS region for Bedrock Mantle.
-        ttft_visible_tokens_only: When ``True`` (default), TTFT measures
-            time to first visible text token.  When ``False``, TTFT
-            includes thinking/signature events.  See above for details.
+        ttft_visible_tokens_only: When `True` (default), TTFT measures time to first visible text
+            token.  When `False`, TTFT includes thinking/signature events.  See above for details.
         **kwargs: Additional arguments forwarded to the client constructor.
 
     Examples:
-        Direct Anthropic API::
+        Direct Anthropic API:
 
-            endpoint = AnthropicMessagesStream(model_id="claude-opus-4-7")
+        ```python
+        endpoint = AnthropicMessagesStream(model_id="claude-opus-4-7")
+        ```
 
-        Measure TTFT including thinking::
+        Measure TTFT including thinking:
 
-            endpoint = AnthropicMessagesStream(
-                model_id="claude-sonnet-4-6",
-                ttft_visible_tokens_only=False,
-            )
+        ```python
+        endpoint = AnthropicMessagesStream(
+            model_id="claude-sonnet-4-6",
+            ttft_visible_tokens_only=False,
+        )
+        ```
 
-        Amazon Bedrock Mantle::
+        Amazon Bedrock Mantle:
 
-            endpoint = AnthropicMessagesStream(
-                model_id="anthropic.claude-opus-4-7",
-                provider="bedrock-mantle",
-                aws_region="us-east-1",
-            )
+        ```python
+        endpoint = AnthropicMessagesStream(
+            model_id="anthropic.claude-opus-4-7",
+            provider="bedrock-mantle",
+            aws_region="us-east-1",
+        )
+        ```
     """
 
     def __init__(
@@ -472,9 +477,9 @@ class AnthropicMessagesStream(
 
         Processes SSE events to extract text, token counts, and timing.
 
-        Only ``text_delta`` events contribute to ``response_text``.
-        ``thinking_delta`` and ``signature_delta`` events are used solely
-        for TTFT measurement when ``ttft_visible_tokens_only`` is ``False``.
+        Only `text_delta` events contribute to `response_text`. `thinking_delta` and
+        `signature_delta` events are used solely for TTFT measurement when
+        `ttft_visible_tokens_only` is `False`.
 
         Args:
             raw_response: The streaming iterator of SSE events.

--- a/llmeter/endpoints/base.py
+++ b/llmeter/endpoints/base.py
@@ -42,11 +42,10 @@ class InvocationResponse:
         num_tokens_input (Optional[int]): The number of tokens in the invocation payload.
         num_tokens_input_cached: The number of input tokens served from cache (prompt caching).
         num_tokens_output_reasoning: The number of output tokens used for internal reasoning
-            (included in ``num_tokens_output``). Populated when the provider reports a
-            separate reasoning/thinking token count (e.g. OpenAI ``reasoning_tokens``).
-            ``None`` when the provider does not break out reasoning tokens — for
-            example, Anthropic includes thinking tokens in ``output_tokens`` without
-            a separate count.
+            (included in `num_tokens_output`). Populated when the provider reports a separate
+            reasoning/thinking token count (e.g. OpenAI `reasoning_tokens`). `None` when the
+            provider does not break out reasoning tokens — for example, Anthropic includes
+            thinking tokens in `output_tokens` without a separate count.
         input_prompt (str): The input prompt used in the invocation.
         time_per_output_token (float): The average time taken to generate each token in the response.
         error (str): Any error that occurred during invocation.

--- a/llmeter/endpoints/base.py
+++ b/llmeter/endpoints/base.py
@@ -41,6 +41,12 @@ class InvocationResponse:
         num_tokens_output (Optional[int]): The number of tokens in the response.
         num_tokens_input (Optional[int]): The number of tokens in the invocation payload.
         num_tokens_input_cached: The number of input tokens served from cache (prompt caching).
+        num_tokens_output_reasoning: The number of output tokens used for internal reasoning
+            (included in ``num_tokens_output``). Populated when the provider reports a
+            separate reasoning/thinking token count (e.g. OpenAI ``reasoning_tokens``).
+            ``None`` when the provider does not break out reasoning tokens — for
+            example, Anthropic includes thinking tokens in ``output_tokens`` without
+            a separate count.
         input_prompt (str): The input prompt used in the invocation.
         time_per_output_token (float): The average time taken to generate each token in the response.
         error (str): Any error that occurred during invocation.
@@ -56,6 +62,7 @@ class InvocationResponse:
     num_tokens_input: int | None = None
     num_tokens_output: int | None = None
     num_tokens_input_cached: int | None = None
+    num_tokens_output_reasoning: int | None = None
     time_per_output_token: float | None = None
     error: str | None = None
     retries: int | None = None

--- a/llmeter/endpoints/bedrock.py
+++ b/llmeter/endpoints/bedrock.py
@@ -353,26 +353,23 @@ class BedrockConverse(BedrockBase[ConverseResponseTypeDef]):
 class BedrockConverseStream(BedrockBase[ConverseStreamResponseTypeDef]):
     """Streaming endpoint for the Bedrock Converse API.
 
-    When extended thinking is enabled, the stream contains
-    ``reasoningContent`` deltas before the visible ``text`` deltas.  The
-    ``ttft_visible_tokens_only`` parameter controls which delta sets
-    ``time_to_first_token``:
+    When extended thinking is enabled, the stream contains `reasoningContent` deltas before the
+    visible `text` deltas.  The `ttft_visible_tokens_only` parameter controls which delta sets
+    `time_to_first_token`:
 
-    * ``True`` (default) -- TTFT is set on the first ``text`` delta.
-      Reasoning deltas are ignored for timing.
-    * ``False`` -- TTFT is set on the first delta of any kind, including
-      reasoning content.
+    * `True` (default) - TTFT is set on the first `text` delta. Reasoning deltas are ignored for
+      timing.
+    * `False` - TTFT is set on the first delta of any kind, including reasoning content.
 
     Args:
         model_id: Bedrock model identifier.
-        endpoint_name: Display name.  Defaults to ``None``.
-        region: AWS region.  Defaults to ``None``.
+        endpoint_name: Display name.  Defaults to `None`.
+        region: AWS region.  Defaults to `None`.
         inference_config: Default inference configuration.
         bedrock_boto3_client: Pre-configured boto3 client.
         max_attempts: Maximum retry attempts.  Defaults to 3.
-        ttft_visible_tokens_only: When ``True`` (default), TTFT measures
-            time to first visible text token.  When ``False``, TTFT
-            includes reasoning content deltas.
+        ttft_visible_tokens_only: When `True` (default), TTFT measures time to first visible text
+            token.  When `False`, TTFT includes reasoning content deltas.
     """
 
     def __init__(
@@ -405,13 +402,13 @@ class BedrockConverseStream(BedrockBase[ConverseStreamResponseTypeDef]):
     ) -> None:
         """Parse the streaming response from a Bedrock ConverseStream API call.
 
-        Only ``text`` deltas contribute to ``response_text``.
-        ``reasoningContent`` deltas are used solely for TTFT measurement
-        when ``ttft_visible_tokens_only`` is ``False``.
+        Only `text` deltas contribute to `response_text`. `reasoningContent` deltas are used solely
+        for TTFT measurement when `ttft_visible_tokens_only` is `False`.
 
         Args:
             raw_response: The raw response from the Bedrock API.
             start_t: The timestamp when the request was initiated.
+            response: The output response object to be updated in-place.
         """
         response.id = raw_response["ResponseMetadata"].get("RequestId")
         response.retries = raw_response["ResponseMetadata"]["RetryAttempts"]

--- a/llmeter/endpoints/bedrock.py
+++ b/llmeter/endpoints/bedrock.py
@@ -351,6 +351,50 @@ class BedrockConverse(BedrockBase[ConverseResponseTypeDef]):
 
 
 class BedrockConverseStream(BedrockBase[ConverseStreamResponseTypeDef]):
+    """Streaming endpoint for the Bedrock Converse API.
+
+    When extended thinking is enabled, the stream contains
+    ``reasoningContent`` deltas before the visible ``text`` deltas.  The
+    ``ttft_visible_tokens_only`` parameter controls which delta sets
+    ``time_to_first_token``:
+
+    * ``True`` (default) -- TTFT is set on the first ``text`` delta.
+      Reasoning deltas are ignored for timing.
+    * ``False`` -- TTFT is set on the first delta of any kind, including
+      reasoning content.
+
+    Args:
+        model_id: Bedrock model identifier.
+        endpoint_name: Display name.  Defaults to ``None``.
+        region: AWS region.  Defaults to ``None``.
+        inference_config: Default inference configuration.
+        bedrock_boto3_client: Pre-configured boto3 client.
+        max_attempts: Maximum retry attempts.  Defaults to 3.
+        ttft_visible_tokens_only: When ``True`` (default), TTFT measures
+            time to first visible text token.  When ``False``, TTFT
+            includes reasoning content deltas.
+    """
+
+    def __init__(
+        self,
+        model_id: str,
+        endpoint_name: str | None = None,
+        region: str | None = None,
+        inference_config: dict | None = None,
+        bedrock_boto3_client=None,
+        max_attempts: int = 3,
+        ttft_visible_tokens_only: bool = True,
+    ):
+        super().__init__(
+            model_id=model_id,
+            endpoint_name=endpoint_name,
+            region=region,
+            inference_config=inference_config,
+            bedrock_boto3_client=bedrock_boto3_client,
+            max_attempts=max_attempts,
+        )
+        self.ttft_visible_tokens_only = ttft_visible_tokens_only
+
     @Endpoint.llmeter_invoke
     def invoke(self, payload: dict):
         client_response = self._bedrock_client.converse_stream(**payload)  # type: ignore
@@ -359,35 +403,46 @@ class BedrockConverseStream(BedrockBase[ConverseStreamResponseTypeDef]):
     def process_raw_response(
         self, raw_response, start_t: float, response: InvocationResponse
     ) -> None:
-        """Parse the streaming response from a Bedrock ConverseStream API call
+        """Parse the streaming response from a Bedrock ConverseStream API call.
+
+        Only ``text`` deltas contribute to ``response_text``.
+        ``reasoningContent`` deltas are used solely for TTFT measurement
+        when ``ttft_visible_tokens_only`` is ``False``.
 
         Args:
-            client_response: The raw response from the Bedrock API.
+            raw_response: The raw response from the Bedrock API.
             start_t: The timestamp when the request was initiated.
-
-        Returns:
-            InvocationResponse with the generated text and metadata.
         """
         response.id = raw_response["ResponseMetadata"].get("RequestId")
         response.retries = raw_response["ResponseMetadata"]["RetryAttempts"]
-
-        any_content_received = False
 
         for chunk in raw_response["stream"]:
             now = time.perf_counter()
 
             if "contentBlockDelta" in chunk:
-                delta_text = chunk["contentBlockDelta"]["delta"].get("text", "")
-                if not isinstance(delta_text, str):
-                    raise TypeError("Expected string for delta text")
-                if not any_content_received:
-                    response.time_to_first_token = now - start_t
-                    any_content_received = True
-                if delta_text:
-                    if response.response_text is None:
-                        response.response_text = delta_text
-                    else:
-                        response.response_text += delta_text
+                delta = chunk["contentBlockDelta"]["delta"]
+
+                if "reasoningContent" in delta:
+                    # Reasoning delta -- only counts for TTFT when
+                    # ttft_visible_tokens_only is False.
+                    if (
+                        not self.ttft_visible_tokens_only
+                        and response.time_to_first_token is None
+                    ):
+                        response.time_to_first_token = now - start_t
+
+                elif "text" in delta:
+                    delta_text = delta["text"]
+                    if not isinstance(delta_text, str):
+                        raise TypeError("Expected string for delta text")
+                    if delta_text:
+                        if response.time_to_first_token is None:
+                            response.time_to_first_token = now - start_t
+                        if response.response_text is None:
+                            response.response_text = delta_text
+                        else:
+                            response.response_text += delta_text
+                        response.time_to_last_token = now - start_t
 
             if "contentBlockStop" in chunk:
                 response.time_to_last_token = now - start_t

--- a/llmeter/endpoints/openai.py
+++ b/llmeter/endpoints/openai.py
@@ -264,6 +264,10 @@ class OpenAICompletionEndpoint(OpenAIEndpoint[ChatCompletion]):
                 response.num_tokens_input_cached = getattr(
                     usage.prompt_tokens_details, "cached_tokens", None
                 )
+            if usage.completion_tokens_details:
+                response.num_tokens_output_reasoning = getattr(
+                    usage.completion_tokens_details, "reasoning_tokens", None
+                )
 
 
 class OpenAICompletionStreamEndpoint(OpenAIEndpoint[Iterable[ChatCompletionChunk]]):
@@ -317,4 +321,10 @@ class OpenAICompletionStreamEndpoint(OpenAIEndpoint[Iterable[ChatCompletionChunk
                 if chunk.usage.prompt_tokens_details:
                     response.num_tokens_input_cached = getattr(
                         chunk.usage.prompt_tokens_details, "cached_tokens", None
+                    )
+                if chunk.usage.completion_tokens_details:
+                    response.num_tokens_output_reasoning = getattr(
+                        chunk.usage.completion_tokens_details,
+                        "reasoning_tokens",
+                        None,
                     )

--- a/llmeter/endpoints/openai_response.py
+++ b/llmeter/endpoints/openai_response.py
@@ -197,17 +197,16 @@ class OpenAIResponseEndpoint(OpenAIEndpointBase[Response]):
 class OpenAIResponseStreamEndpoint(OpenAIEndpointBase[Iterable[ResponseStreamEvent]]):
     """Endpoint for OpenAI Responses API (streaming).
 
-    This endpoint provides streaming access to OpenAI's Responses API, enabling
-    time-to-first-token measurements and incremental response processing.
+    This endpoint provides streaming access to OpenAI's Responses API, enabling time-to-first-token
+    measurements and incremental response processing.
 
     Args:
-        ttft_visible_tokens_only: Controls how ``time_to_first_token`` is measured
-            for reasoning models. When ``True`` (default), TTFT records the time
-            to the first *visible* text token (``response.output_text.delta``),
-            ignoring reasoning events. When ``False``, TTFT records the time to
-            the first token of any kind — including reasoning summary or reasoning
-            text deltas — giving a measure of when the model first started
-            producing output. Has no effect for non-reasoning models.
+        ttft_visible_tokens_only: Controls how `time_to_first_token` is measured for reasoning
+            models. When `True` (default), TTFT records the time to the first *visible* text token
+            (`response.output_text.delta`), ignoring reasoning events. When `False`, TTFT records
+            the time to the first token of any kind — including reasoning summary or reasoning text
+            deltas — giving a measure of when the model first started producing output. Has no
+            effect for non-reasoning models.
     """
 
     def __init__(
@@ -226,9 +225,8 @@ class OpenAIResponseStreamEndpoint(OpenAIEndpointBase[Iterable[ResponseStreamEve
             endpoint_name: Name of the endpoint (default: "openai-response-stream")
             api_key: OpenAI API key (optional, uses OPENAI_API_KEY env var if not provided)
             provider: Provider name (default: "openai")
-            ttft_visible_tokens_only: When True (default), TTFT measures time to
-                first visible text token. When False, TTFT includes reasoning
-                token events.
+            ttft_visible_tokens_only: When True (default), TTFT measures time to first visible text
+                token. When False, TTFT includes reasoning token events.
             **kwargs: Additional arguments passed to OpenAI client
         """
         super().__init__(
@@ -264,13 +262,13 @@ class OpenAIResponseStreamEndpoint(OpenAIEndpointBase[Iterable[ResponseStreamEve
 
         Processes typed events from the stream:
 
-        - ``ResponseCreatedEvent``: captures ``response.id``
-        - ``ResponseTextDeltaEvent``: accumulates text deltas, records TTFT
-        - ``ResponseCompletedEvent``: extracts usage from ``response.usage``
-        - ``ResponseFailedEvent``: captures API-level errors
-        - Reasoning events (``response.reasoning_summary_text.delta``,
-          ``response.reasoning_text.delta``): when ``ttft_visible_tokens_only``
-          is ``False``, these set TTFT on the first reasoning token.
+        - `ResponseCreatedEvent`: captures `response.id`
+        - `ResponseTextDeltaEvent`: accumulates text deltas, records TTFT
+        - `ResponseCompletedEvent`: extracts usage from `response.usage`
+        - `ResponseFailedEvent`: captures API-level errors
+        - Reasoning events (`response.reasoning_summary_text.delta`,
+          `response.reasoning_text.delta`): when `ttft_visible_tokens_only` is ``False``, these set
+          TTFT on the first reasoning token.
         """
         _REASONING_DELTA_TYPES = frozenset((
             "response.reasoning_summary_text.delta",

--- a/llmeter/endpoints/openai_response.py
+++ b/llmeter/endpoints/openai_response.py
@@ -161,6 +161,19 @@ class OpenAIResponseEndpoint(OpenAIEndpointBase[Response]):
     def process_raw_response(
         self, raw_response: Response, start_t: float, response: InvocationResponse
     ) -> None:
+        # Check for API-level errors (e.g. status="failed" with an error object)
+        if getattr(raw_response, "status", None) == "failed":
+            error_obj = getattr(raw_response, "error", None)
+            if error_obj is not None:
+                error_msg = getattr(error_obj, "message", None) or str(error_obj)
+                error_code = getattr(error_obj, "code", None)
+                if error_code:
+                    error_msg = f"{error_code}: {error_msg}"
+            else:
+                error_msg = "Response API request failed"
+            response.error = error_msg
+            return
+
         response.time_to_last_token = time.perf_counter() - start_t
         response.id = raw_response.id
         response.response_text = raw_response.output_text
@@ -174,6 +187,11 @@ class OpenAIResponseEndpoint(OpenAIEndpointBase[Response]):
                 response.num_tokens_input_cached = getattr(
                     details, "cached_tokens", None
                 )
+            output_details = getattr(usage, "output_tokens_details", None)
+            if output_details:
+                response.num_tokens_output_reasoning = getattr(
+                    output_details, "reasoning_tokens", None
+                )
 
 
 class OpenAIResponseStreamEndpoint(OpenAIEndpointBase[Iterable[ResponseStreamEvent]]):
@@ -181,6 +199,15 @@ class OpenAIResponseStreamEndpoint(OpenAIEndpointBase[Iterable[ResponseStreamEve
 
     This endpoint provides streaming access to OpenAI's Responses API, enabling
     time-to-first-token measurements and incremental response processing.
+
+    Args:
+        ttft_visible_tokens_only: Controls how ``time_to_first_token`` is measured
+            for reasoning models. When ``True`` (default), TTFT records the time
+            to the first *visible* text token (``response.output_text.delta``),
+            ignoring reasoning events. When ``False``, TTFT records the time to
+            the first token of any kind — including reasoning summary or reasoning
+            text deltas — giving a measure of when the model first started
+            producing output. Has no effect for non-reasoning models.
     """
 
     def __init__(
@@ -189,6 +216,7 @@ class OpenAIResponseStreamEndpoint(OpenAIEndpointBase[Iterable[ResponseStreamEve
         endpoint_name: str = "openai-response-stream",
         api_key: str | None = None,
         provider: str = "openai",
+        ttft_visible_tokens_only: bool = True,
         **kwargs,
     ):
         """Initialize streaming Response API endpoint.
@@ -198,6 +226,9 @@ class OpenAIResponseStreamEndpoint(OpenAIEndpointBase[Iterable[ResponseStreamEve
             endpoint_name: Name of the endpoint (default: "openai-response-stream")
             api_key: OpenAI API key (optional, uses OPENAI_API_KEY env var if not provided)
             provider: Provider name (default: "openai")
+            ttft_visible_tokens_only: When True (default), TTFT measures time to
+                first visible text token. When False, TTFT includes reasoning
+                token events.
             **kwargs: Additional arguments passed to OpenAI client
         """
         super().__init__(
@@ -207,6 +238,7 @@ class OpenAIResponseStreamEndpoint(OpenAIEndpointBase[Iterable[ResponseStreamEve
             provider=provider,
             **kwargs,
         )
+        self.ttft_visible_tokens_only = ttft_visible_tokens_only
 
     @OpenAIEndpointBase.llmeter_invoke
     def invoke(self, payload: ResponseCreateParamsStreaming):
@@ -231,10 +263,20 @@ class OpenAIResponseStreamEndpoint(OpenAIEndpointBase[Iterable[ResponseStreamEve
         """Parse streaming Response API output into InvocationResponse.
 
         Processes typed events from the stream:
+
         - ``ResponseCreatedEvent``: captures ``response.id``
         - ``ResponseTextDeltaEvent``: accumulates text deltas, records TTFT
         - ``ResponseCompletedEvent``: extracts usage from ``response.usage``
+        - ``ResponseFailedEvent``: captures API-level errors
+        - Reasoning events (``response.reasoning_summary_text.delta``,
+          ``response.reasoning_text.delta``): when ``ttft_visible_tokens_only``
+          is ``False``, these set TTFT on the first reasoning token.
         """
+        _REASONING_DELTA_TYPES = frozenset((
+            "response.reasoning_summary_text.delta",
+            "response.reasoning_text.delta",
+        ))
+
         for event in raw_response:
             now = time.perf_counter()
             if event.type == "response.created":
@@ -243,10 +285,18 @@ class OpenAIResponseStreamEndpoint(OpenAIEndpointBase[Iterable[ResponseStreamEve
             elif event.type == "response.output_text.delta":
                 if response.response_text is None:
                     response.response_text = event.delta
-                    response.time_to_first_token = now - start_t
+                    if response.time_to_first_token is None:
+                        response.time_to_first_token = now - start_t
                 else:
                     response.response_text += event.delta
                 response.time_to_last_token = now - start_t
+
+            elif (
+                not self.ttft_visible_tokens_only
+                and event.type in _REASONING_DELTA_TYPES
+            ):
+                if response.time_to_first_token is None:
+                    response.time_to_first_token = now - start_t
 
             elif event.type == "response.completed":
                 usage = event.response.usage
@@ -258,3 +308,22 @@ class OpenAIResponseStreamEndpoint(OpenAIEndpointBase[Iterable[ResponseStreamEve
                         response.num_tokens_input_cached = getattr(
                             details, "cached_tokens", None
                         )
+                    output_details = getattr(usage, "output_tokens_details", None)
+                    if output_details:
+                        response.num_tokens_output_reasoning = getattr(
+                            output_details, "reasoning_tokens", None
+                        )
+
+            elif event.type == "response.failed":
+                error_obj = getattr(event.response, "error", None)
+                if error_obj is not None:
+                    error_msg = (
+                        getattr(error_obj, "message", None) or str(error_obj)
+                    )
+                    error_code = getattr(error_obj, "code", None)
+                    if error_code:
+                        error_msg = f"{error_code}: {error_msg}"
+                else:
+                    error_msg = "Response API request failed"
+                response.error = error_msg
+                response.time_to_last_token = now - start_t

--- a/llmeter/results.py
+++ b/llmeter/results.py
@@ -482,6 +482,9 @@ def _get_run_stats(results: Result):
     stats["total_cached_input_tokens"] = sum(
         v for v in jmespath.search("[:].num_tokens_input_cached", data=data) if v
     )
+    stats["total_reasoning_output_tokens"] = sum(
+        v for v in jmespath.search("[:].num_tokens_output_reasoning", data=data) if v
+    )
     stats["average_input_tokens_per_minute"] = (
         results.total_test_time
         and stats["total_input_tokens"] / results.total_test_time * 60

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
       - mlflow: reference/callbacks/mlflow.md
     - endpoints:
       - reference/endpoints/index.md
+      - anthropic_messages: reference/endpoints/anthropic_messages.md
       - base: reference/endpoints/base.md
       - bedrock: reference/endpoints/bedrock.md
       - bedrock_invoke: reference/endpoints/bedrock_invoke.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+anthropic = ["anthropic>=0.40.0"]
+anthropic-bedrock = ["anthropic[bedrock]>=0.40.0"]
 openai = ["openai>=1.35.1"]
 litellm = ["litellm>=1.47.1"]
 plotting = ["plotly>=5.24.1", "kaleido<=0.2.1", "pandas>=2.2.0"]
 mlflow = ["mlflow-skinny>=3.10.0"]
 multimodal = ["puremagic>=1.28"]
-all = ["openai>=1.35.1", "litellm>=1.47.1", "plotly>=5.24.1", "kaleido<=0.2.1", "pandas>=2.2.0", "mlflow-skinny>=3.10.0", "puremagic>=1.28"]
+all = ["anthropic[bedrock]>=0.40.0", "openai>=1.35.1", "litellm>=1.47.1", "plotly>=5.24.1", "kaleido<=0.2.1", "pandas>=2.2.0", "mlflow-skinny>=3.10.0", "puremagic>=1.28"]
 
 [project.urls]
 Repository = "https://github.com/awslabs/llmeter"
@@ -59,6 +61,7 @@ test = [
     "pillow>=12.1.1",
     "aws-bedrock-token-generator>=1.1.0",
     # Include all optional dependencies for comprehensive testing
+    "anthropic[bedrock]>=0.40.0",
     "openai>=1.35.1",
     "litellm>=1.47.1",
     "plotly>=5.24.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,14 +18,16 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-anthropic = ["anthropic>=0.40.0"]
-anthropic-bedrock = ["anthropic[bedrock]>=0.40.0"]
+anthropic = ["anthropic>=0.91.0"]
 openai = ["openai>=1.35.1"]
 litellm = ["litellm>=1.47.1"]
 plotting = ["plotly>=5.24.1", "kaleido<=0.2.1", "pandas>=2.2.0"]
 mlflow = ["mlflow-skinny>=3.10.0"]
 multimodal = ["puremagic>=1.28"]
-all = ["anthropic[bedrock]>=0.40.0", "openai>=1.35.1", "litellm>=1.47.1", "plotly>=5.24.1", "kaleido<=0.2.1", "pandas>=2.2.0", "mlflow-skinny>=3.10.0", "puremagic>=1.28"]
+tokenizers = ["transformers>=4.40.2", "tiktoken>=0.7.0"]
+all = [
+    "llmeter[anthropic,openai,litellm,plotting,mlflow,multimodal,tokenizers]",
+]
 
 [project.urls]
 Repository = "https://github.com/awslabs/llmeter"
@@ -39,10 +41,8 @@ dev = [
     "boto3-stubs[bedrock,bedrock-runtime,essential,sagemaker,sagemaker-runtime]>=1.35.24",
     "ipykernel>=6.29.0",
     "ipywidgets>=8.1.3",
-    "transformers>=4.40.2",
     "sagemaker>=2.224.0",
     "ruff>=0.6.5",
-    "tiktoken>=0.7.0",
     "nbformat>=5.10.4",
     "bandit>=1.7.10",
     "aws-bedrock-token-generator>=1.1.0",
@@ -60,17 +60,8 @@ test = [
     "pytest-cov>=5.0.0",
     "pillow>=12.1.1",
     "aws-bedrock-token-generator>=1.1.0",
-    # Include all optional dependencies for comprehensive testing
-    "anthropic[bedrock]>=0.40.0",
-    "openai>=1.35.1",
-    "litellm>=1.47.1",
-    "plotly>=5.24.1",
-    "kaleido<=0.2.1",
-    "pandas>=2.2.0",
-    "mlflow-skinny>=3.10.0",
-    "puremagic>=1.28",
-    "transformers>=4.40.2",
-    "tiktoken>=0.7.0",
+    # Pull in all optional dependencies for comprehensive testing
+    "llmeter[all]",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/integ/conftest.py
+++ b/tests/integ/conftest.py
@@ -135,6 +135,38 @@ def bedrock_openai_multimodal_test_model():
     )
 
 
+@pytest.fixture(scope="session")
+def bedrock_anthropic_mantle_test_model():
+    """
+    Get test model ID for Anthropic Messages API tests via Bedrock Mantle.
+
+    The model ID can be overridden via the BEDROCK_ANTHROPIC_MANTLE_TEST_MODEL
+    environment variable.  Defaults to ``anthropic.claude-opus-4-7``.
+
+    Returns:
+        str: Anthropic model ID for Bedrock Mantle testing.
+    """
+    return os.environ.get(
+        "BEDROCK_ANTHROPIC_MANTLE_TEST_MODEL", "anthropic.claude-opus-4-7"
+    )
+
+
+@pytest.fixture(scope="session")
+def bedrock_anthropic_mantle_region():
+    """
+    Get AWS region for Anthropic Messages API tests via Bedrock Mantle.
+
+    The Bedrock Mantle Anthropic Messages endpoint may not be available in all
+    regions.  This fixture defaults to ``us-east-1`` (the first region where
+    the endpoint launched) and can be overridden via the
+    ``BEDROCK_ANTHROPIC_MANTLE_REGION`` environment variable.
+
+    Returns:
+        str: AWS region for Bedrock Mantle Anthropic testing.
+    """
+    return os.environ.get("BEDROCK_ANTHROPIC_MANTLE_REGION", "us-east-1")
+
+
 @pytest.fixture
 def test_image_bytes():
     """

--- a/tests/integ/test_anthropic_messages_bedrock.py
+++ b/tests/integ/test_anthropic_messages_bedrock.py
@@ -1,0 +1,223 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Integration tests for Anthropic Messages API endpoints via Amazon Bedrock Mantle.
+
+This module verifies that the llmeter AnthropicMessages and AnthropicMessagesStream
+wrappers work correctly with the Anthropic Messages API served through the
+Bedrock Mantle endpoint (``bedrock-mantle.{region}.api.aws/anthropic/v1/messages``).
+
+Tests are marked with @pytest.mark.integ and are skipped by default to avoid
+AWS costs and credential requirements during regular development.
+
+To run these tests:
+    uv run pytest tests/integ/test_anthropic_messages_bedrock.py -m integ
+
+Required AWS Permissions:
+    - bedrock-mantle:CreateInference (or equivalent Bedrock permissions)
+
+Environment Variables:
+    - BEDROCK_ANTHROPIC_MANTLE_REGION: AWS region (default: us-east-1)
+    - BEDROCK_ANTHROPIC_MANTLE_TEST_MODEL: Model ID
+      (default: anthropic.claude-opus-4-7)
+
+Estimated Cost:
+    - ~$0.001 per test run (Opus 4.7 pricing)
+    - ~$0.003 total for all tests in this module
+"""
+
+from datetime import datetime
+
+import pytest
+
+from llmeter.endpoints.anthropic_messages import (
+    AnthropicMessages,
+    AnthropicMessagesEndpoint,
+    AnthropicMessagesStream,
+)
+
+
+@pytest.mark.integ
+def test_anthropic_messages_non_streaming(
+    aws_credentials,
+    bedrock_anthropic_mantle_region,
+    bedrock_anthropic_mantle_test_model,
+):
+    """
+    Test AnthropicMessages endpoint with Bedrock Mantle (non-streaming).
+
+    Validates that the endpoint can:
+    - Initialize with Bedrock Mantle provider and AWS credentials
+    - Invoke the Anthropic Messages API via create_payload helper
+    - Return an InvocationResponse with text, token counts, and timing
+    - Complete without errors
+
+    Args:
+        aws_credentials: Boto3 session with valid AWS credentials.
+        bedrock_anthropic_mantle_region: AWS region for Bedrock Mantle.
+        bedrock_anthropic_mantle_test_model: Anthropic model ID for Bedrock Mantle.
+
+    Estimated Cost: ~$0.001 per run
+    """
+    endpoint = AnthropicMessages(
+        model_id=bedrock_anthropic_mantle_test_model,
+        provider="bedrock-mantle",
+        aws_region=bedrock_anthropic_mantle_region,
+    )
+
+    payload = AnthropicMessagesEndpoint.create_payload(
+        user_message="Hello, this is a test. Please respond with a brief greeting.",
+        max_tokens=100,
+    )
+
+    response = endpoint.invoke(payload)
+
+    # No errors
+    assert response.error is None, (
+        f"Response should not contain errors: {response.error}"
+    )
+
+    # Response text
+    assert response.response_text is not None, "Response text should not be None"
+    assert len(response.response_text) > 0, "Response text should not be empty"
+    assert isinstance(response.response_text, str)
+
+    # Token counts
+    assert response.num_tokens_input is not None, "Input token count should be present"
+    assert response.num_tokens_input > 0, "Input token count should be positive"
+    assert response.num_tokens_output is not None, (
+        "Output token count should be present"
+    )
+    assert response.num_tokens_output > 0, "Output token count should be positive"
+
+    # Timing (back-filled by base class for non-streaming)
+    assert response.time_to_last_token is not None, "Response time should be present"
+    assert response.time_to_last_token > 0, "Response time should be positive"
+
+    # Response ID (Anthropic msg_ format)
+    assert response.id is not None, "Response should have an ID"
+    assert response.id.startswith("msg_"), (
+        f"Response ID should be Anthropic format (msg_...), got: {response.id}"
+    )
+
+    # Metadata back-fill
+    assert isinstance(response.request_time, datetime)
+    assert response.input_payload is not None
+
+
+@pytest.mark.integ
+def test_anthropic_messages_streaming(
+    aws_credentials,
+    bedrock_anthropic_mantle_region,
+    bedrock_anthropic_mantle_test_model,
+):
+    """
+    Test AnthropicMessagesStream endpoint with Bedrock Mantle (streaming).
+
+    Validates that the endpoint can:
+    - Initialize with Bedrock Mantle provider and AWS credentials
+    - Invoke the streaming Anthropic Messages API
+    - Return an InvocationResponse with text, TTFT, TTLT, and token counts
+    - Verify TTLT > TTFT
+    - Complete without errors
+
+    Args:
+        aws_credentials: Boto3 session with valid AWS credentials.
+        bedrock_anthropic_mantle_region: AWS region for Bedrock Mantle.
+        bedrock_anthropic_mantle_test_model: Anthropic model ID for Bedrock Mantle.
+
+    Estimated Cost: ~$0.001 per run
+    """
+    endpoint = AnthropicMessagesStream(
+        model_id=bedrock_anthropic_mantle_test_model,
+        provider="bedrock-mantle",
+        aws_region=bedrock_anthropic_mantle_region,
+    )
+
+    payload = AnthropicMessagesEndpoint.create_payload(
+        user_message="Hello, this is a test. Please respond with a brief greeting.",
+        max_tokens=100,
+    )
+
+    response = endpoint.invoke(payload)
+
+    # No errors
+    assert response.error is None, (
+        f"Response should not contain errors: {response.error}"
+    )
+
+    # Response text
+    assert response.response_text is not None, "Response text should not be None"
+    assert len(response.response_text) > 0, "Response text should not be empty"
+    assert isinstance(response.response_text, str)
+
+    # Token counts
+    assert response.num_tokens_input is not None, "Input token count should be present"
+    assert response.num_tokens_input > 0, "Input token count should be positive"
+    assert response.num_tokens_output is not None, (
+        "Output token count should be present"
+    )
+    assert response.num_tokens_output > 0, "Output token count should be positive"
+
+    # TTFT
+    assert response.time_to_first_token is not None, "TTFT should be present"
+    assert response.time_to_first_token > 0, "TTFT should be positive"
+
+    # TTLT
+    assert response.time_to_last_token is not None, "TTLT should be present"
+    assert response.time_to_last_token > 0, "TTLT should be positive"
+
+    # TTLT > TTFT
+    assert response.time_to_last_token > response.time_to_first_token, (
+        "TTLT should be greater than TTFT"
+    )
+
+    # Response ID
+    assert response.id is not None, "Response should have an ID"
+    assert response.id.startswith("msg_"), (
+        f"Response ID should be Anthropic format (msg_...), got: {response.id}"
+    )
+
+    # Metadata back-fill
+    assert isinstance(response.request_time, datetime)
+
+
+@pytest.mark.integ
+def test_anthropic_messages_create_payload_roundtrip(
+    aws_credentials,
+    bedrock_anthropic_mantle_region,
+    bedrock_anthropic_mantle_test_model,
+):
+    """
+    Test that create_payload output works end-to-end with the endpoint.
+
+    Validates the full flow: create_payload → invoke → valid response,
+    including extra kwargs like system prompt and temperature.
+
+    Args:
+        aws_credentials: Boto3 session with valid AWS credentials.
+        bedrock_anthropic_mantle_region: AWS region for Bedrock Mantle.
+        bedrock_anthropic_mantle_test_model: Anthropic model ID for Bedrock Mantle.
+
+    Estimated Cost: ~$0.001 per run
+    """
+    endpoint = AnthropicMessages(
+        model_id=bedrock_anthropic_mantle_test_model,
+        provider="bedrock-mantle",
+        aws_region=bedrock_anthropic_mantle_region,
+    )
+
+    payload = AnthropicMessagesEndpoint.create_payload(
+        user_message="What is 2 + 2? Answer with just the number.",
+        max_tokens=10,
+        system="You are a calculator. Only output numbers.",
+    )
+
+    response = endpoint.invoke(payload)
+
+    assert response.error is None, f"Unexpected error: {response.error}"
+    assert response.response_text is not None
+    assert "4" in response.response_text, (
+        f"Expected '4' in response, got: {response.response_text}"
+    )

--- a/tests/integ/test_bedrock_converse_reasoning.py
+++ b/tests/integ/test_bedrock_converse_reasoning.py
@@ -1,0 +1,196 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Integration tests for reasoning token parsing via Bedrock Converse API.
+
+This module tests that BedrockConverseStream correctly handles reasoning
+(extended thinking) content when using a reasoning-capable model
+(openai.gpt-oss-120b) through the Bedrock Converse API.
+
+Tests are marked with @pytest.mark.integ and are skipped by default to avoid
+AWS costs and credential requirements during regular development.
+
+To run these tests:
+    uv run pytest -m integ -k reasoning
+
+Required AWS Permissions:
+    - bedrock:InvokeModelWithResponseStream
+
+Estimated Cost:
+    - ~$0.001 per test run (reasoning models use more tokens)
+
+Environment Variables:
+    - AWS_REGION: AWS region for testing (default: us-east-1)
+    - BEDROCK_REASONING_TEST_MODEL: Model ID for reasoning tests
+      (default: openai.gpt-oss-120b-1:0)
+"""
+
+import os
+
+import pytest
+
+from llmeter.endpoints.bedrock import BedrockConverseStream
+
+
+@pytest.fixture(scope="module")
+def reasoning_model_id():
+    """Get the reasoning-capable model ID for Converse API tests.
+
+    Defaults to openai.gpt-oss-120b-1:0 which supports extended thinking
+    via the Bedrock Converse API.
+    """
+    return os.environ.get(
+        "BEDROCK_REASONING_TEST_MODEL", "openai.gpt-oss-120b-1:0"
+    )
+
+
+@pytest.mark.integ
+def test_converse_stream_reasoning_visible_ttft(
+    aws_credentials, aws_region, reasoning_model_id
+):
+    """Test streaming with a reasoning model and ttft_visible_tokens_only=True (default).
+
+    Validates that:
+    - The endpoint successfully invokes a reasoning-capable model
+    - Response text is returned (reasoning content is not included)
+    - TTFT is measured on the first visible text token
+    - TTLT >= TTFT
+    - Token counts are populated
+
+    With ttft_visible_tokens_only=True, TTFT should reflect the time to the
+    first *visible* text token, excluding any reasoning/thinking time.
+    """
+    endpoint = BedrockConverseStream(
+        model_id=reasoning_model_id,
+        region=aws_region,
+    )
+
+    payload = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"text": "What is 15 * 37? Reply with just the number."}
+                ],
+            }
+        ],
+        "inferenceConfig": {"maxTokens": 200},
+    }
+
+    response = endpoint.invoke(payload)
+
+    assert response.error is None, (
+        f"Response should not contain errors: {response.error}"
+    )
+
+    # Verify response text
+    assert response.response_text is not None, "Response text should not be None"
+    assert len(response.response_text) > 0, "Response text should not be empty"
+    assert "555" in response.response_text, (
+        f"Expected '555' in response, got: {response.response_text}"
+    )
+
+    # Verify timing
+    assert response.time_to_first_token is not None, (
+        "Time to first token should not be None"
+    )
+    assert response.time_to_first_token > 0, "TTFT should be positive"
+    assert response.time_to_last_token is not None, (
+        "Time to last token should not be None"
+    )
+    assert response.time_to_last_token >= response.time_to_first_token, (
+        "TTLT should be >= TTFT"
+    )
+
+    # Verify token counts
+    if response.num_tokens_input is not None:
+        assert response.num_tokens_input > 0, "Input token count should be positive"
+    if response.num_tokens_output is not None:
+        assert response.num_tokens_output > 0, "Output token count should be positive"
+
+
+@pytest.mark.integ
+def test_converse_stream_reasoning_inclusive_ttft(
+    aws_credentials, aws_region, reasoning_model_id
+):
+    """Test streaming with a reasoning model and ttft_visible_tokens_only=False.
+
+    Validates that:
+    - TTFT is measured on the first token of any kind (including reasoning)
+    - TTFT with reasoning included should be <= TTFT with visible-only
+    - Response text still contains only visible content
+    - TTLT >= TTFT
+
+    This test creates two endpoints — one with visible-only TTFT and one with
+    inclusive TTFT — and compares their timing to verify reasoning tokens are
+    being detected.
+    """
+    payload = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"text": "What is 15 * 37? Reply with just the number."}
+                ],
+            }
+        ],
+        "inferenceConfig": {"maxTokens": 200},
+    }
+
+    # Inclusive TTFT (includes reasoning tokens)
+    endpoint_inclusive = BedrockConverseStream(
+        model_id=reasoning_model_id,
+        region=aws_region,
+        ttft_visible_tokens_only=False,
+    )
+    response_inclusive = endpoint_inclusive.invoke(payload)
+
+    assert response_inclusive.error is None, (
+        f"Inclusive response should not contain errors: {response_inclusive.error}"
+    )
+
+    # Verify response text
+    assert response_inclusive.response_text is not None, (
+        "Response text should not be None"
+    )
+    assert "555" in response_inclusive.response_text, (
+        f"Expected '555' in response, got: {response_inclusive.response_text}"
+    )
+
+    # Verify timing
+    assert response_inclusive.time_to_first_token is not None, (
+        "Inclusive TTFT should not be None"
+    )
+    assert response_inclusive.time_to_first_token > 0, (
+        "Inclusive TTFT should be positive"
+    )
+    assert response_inclusive.time_to_last_token is not None, (
+        "TTLT should not be None"
+    )
+    assert response_inclusive.time_to_last_token >= response_inclusive.time_to_first_token, (
+        "TTLT should be >= TTFT"
+    )
+
+    # Visible-only TTFT
+    endpoint_visible = BedrockConverseStream(
+        model_id=reasoning_model_id,
+        region=aws_region,
+        ttft_visible_tokens_only=True,
+    )
+    response_visible = endpoint_visible.invoke(payload)
+
+    assert response_visible.error is None, (
+        f"Visible response should not contain errors: {response_visible.error}"
+    )
+    assert response_visible.time_to_first_token is not None, (
+        "Visible TTFT should not be None"
+    )
+
+    # The inclusive TTFT should be <= visible-only TTFT because reasoning
+    # tokens arrive before visible text tokens. We allow a small tolerance
+    # for network jitter.
+    assert response_inclusive.time_to_first_token <= response_visible.time_to_first_token + 0.5, (
+        f"Inclusive TTFT ({response_inclusive.time_to_first_token:.3f}s) should be "
+        f"<= visible TTFT ({response_visible.time_to_first_token:.3f}s) + tolerance"
+    )

--- a/tests/integ/test_openai_completion_reasoning.py
+++ b/tests/integ/test_openai_completion_reasoning.py
@@ -1,0 +1,229 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Integration tests for reasoning token parsing via OpenAI Chat Completions API.
+
+This module tests that OpenAICompletionEndpoint and OpenAICompletionStreamEndpoint
+correctly extract reasoning token counts when using a reasoning-capable model
+(openai.gpt-oss-120b) through Bedrock's OpenAI-compatible endpoint.
+
+Tests are marked with @pytest.mark.integ and are skipped by default to avoid
+AWS costs and credential requirements during regular development.
+
+To run these tests:
+    uv run pytest -m integ -k reasoning
+
+Required AWS Permissions:
+    - bedrock:InvokeModel
+    - bedrock:InvokeModelWithResponseStream
+
+Estimated Cost:
+    - ~$0.001 per test run (reasoning models use more tokens)
+
+Environment Variables:
+    - AWS_REGION: AWS region for testing (default: us-east-1)
+    - BEDROCK_OPENAI_TEST_MODEL: Model ID for OpenAI SDK tests
+      (default: openai.gpt-oss-20b-1:0)
+"""
+
+import os
+
+import pytest
+
+try:
+    from aws_bedrock_token_generator import provide_token
+
+    OPENAI_AVAILABLE = True
+except ImportError:
+    OPENAI_AVAILABLE = False
+
+from llmeter.endpoints.openai import (
+    OpenAICompletionEndpoint,
+    OpenAICompletionStreamEndpoint,
+)
+
+
+def _mantle_base_url(region: str) -> str:
+    return f"https://bedrock-mantle.{region}.api.aws/v1"
+
+
+def _strip_model_version(model_id: str) -> str:
+    """Strip version suffix for Mantle API compatibility.
+
+    Mantle requires model ID without version suffix
+    (e.g., openai.gpt-oss-120b instead of openai.gpt-oss-120b-1:0).
+    """
+    if "-" in model_id and ":" in model_id:
+        return model_id.rsplit("-", 1)[0]
+    return model_id
+
+
+@pytest.fixture(scope="module")
+def reasoning_model_id():
+    """Get the reasoning-capable model ID for Chat Completions API tests.
+
+    Defaults to openai.gpt-oss-120b which supports reasoning via the
+    Bedrock Mantle OpenAI-compatible Chat Completions API.
+
+    The version suffix is stripped automatically since Mantle does not
+    accept versioned model IDs.
+    """
+    raw = os.environ.get(
+        "BEDROCK_REASONING_OPENAI_TEST_MODEL", "openai.gpt-oss-120b-1:0"
+    )
+    return _strip_model_version(raw)
+
+
+@pytest.mark.integ
+@pytest.mark.skipif(not OPENAI_AVAILABLE, reason="OpenAI SDK not installed")
+def test_completion_non_streaming_reasoning_tokens(
+    aws_credentials, aws_region, reasoning_model_id
+):
+    """Test non-streaming Chat Completions with a reasoning model.
+
+    Validates that OpenAICompletionEndpoint correctly extracts:
+    - Response text
+    - num_tokens_output_reasoning from completion_tokens_details
+    - Standard token counts (input, output)
+    - Timing information
+    """
+    token = provide_token(region=aws_region)
+    base_url = _mantle_base_url(aws_region)
+
+    endpoint = OpenAICompletionEndpoint(
+        model_id=reasoning_model_id,
+        api_key=token,
+        base_url=base_url,
+    )
+
+    payload = OpenAICompletionEndpoint.create_payload(
+        user_message="What is 15 * 37? Reply with just the number.",
+        max_tokens=200,
+    )
+
+    response = endpoint.invoke(payload)
+
+    # Verify no errors
+    assert response.error is None, (
+        f"Response should not contain errors: {response.error}"
+    )
+
+    # Verify response text
+    assert response.response_text is not None, "Response text should not be None"
+    assert len(response.response_text) > 0, "Response text should not be empty"
+    assert "555" in response.response_text, (
+        f"Expected '555' in response, got: {response.response_text}"
+    )
+
+    # Verify token counts
+    assert response.num_tokens_input is not None, (
+        "Input token count should not be None"
+    )
+    assert response.num_tokens_input > 0, "Input token count should be positive"
+    assert response.num_tokens_output is not None, (
+        "Output token count should not be None"
+    )
+    assert response.num_tokens_output > 0, "Output token count should be positive"
+
+    # Verify reasoning token count is populated for a reasoning model
+    if response.num_tokens_output_reasoning is not None:
+        assert response.num_tokens_output_reasoning >= 0, (
+            "Reasoning token count should be non-negative"
+        )
+        # Reasoning tokens should be included in total output tokens
+        assert response.num_tokens_output_reasoning <= response.num_tokens_output, (
+            f"Reasoning tokens ({response.num_tokens_output_reasoning}) should be "
+            f"<= total output tokens ({response.num_tokens_output})"
+        )
+
+    # Verify timing
+    assert response.time_to_last_token is not None, (
+        "Time to last token should not be None"
+    )
+    assert response.time_to_last_token > 0, "Response time should be positive"
+
+    # Verify response ID
+    assert response.id is not None, "Response should have an ID"
+
+
+@pytest.mark.integ
+@pytest.mark.skipif(not OPENAI_AVAILABLE, reason="OpenAI SDK not installed")
+def test_completion_streaming_reasoning_tokens(
+    aws_credentials, aws_region, reasoning_model_id
+):
+    """Test streaming Chat Completions with a reasoning model.
+
+    Validates that OpenAICompletionStreamEndpoint correctly extracts:
+    - Response text assembled from stream chunks
+    - num_tokens_output_reasoning from the final usage chunk
+    - Standard token counts (input, output)
+    - TTFT and TTLT timing
+    """
+    token = provide_token(region=aws_region)
+    base_url = _mantle_base_url(aws_region)
+
+    endpoint = OpenAICompletionStreamEndpoint(
+        model_id=reasoning_model_id,
+        api_key=token,
+        base_url=base_url,
+    )
+
+    payload = OpenAICompletionStreamEndpoint.create_payload(
+        user_message="What is 15 * 37? Reply with just the number.",
+        max_tokens=200,
+    )
+
+    response = endpoint.invoke(payload)
+
+    # Verify no errors
+    assert response.error is None, (
+        f"Response should not contain errors: {response.error}"
+    )
+
+    # Verify response text
+    assert response.response_text is not None, "Response text should not be None"
+    assert len(response.response_text) > 0, "Response text should not be empty"
+    assert "555" in response.response_text, (
+        f"Expected '555' in response, got: {response.response_text}"
+    )
+
+    # Verify token counts
+    assert response.num_tokens_input is not None, (
+        "Input token count should not be None"
+    )
+    assert response.num_tokens_input > 0, "Input token count should be positive"
+    assert response.num_tokens_output is not None, (
+        "Output token count should not be None"
+    )
+    assert response.num_tokens_output > 0, "Output token count should be positive"
+
+    # Verify reasoning token count is populated for a reasoning model
+    if response.num_tokens_output_reasoning is not None:
+        assert response.num_tokens_output_reasoning >= 0, (
+            "Reasoning token count should be non-negative"
+        )
+        assert response.num_tokens_output_reasoning <= response.num_tokens_output, (
+            f"Reasoning tokens ({response.num_tokens_output_reasoning}) should be "
+            f"<= total output tokens ({response.num_tokens_output})"
+        )
+
+    # Verify TTFT
+    assert response.time_to_first_token is not None, (
+        "Time to first token should not be None"
+    )
+    assert response.time_to_first_token > 0, "TTFT should be positive"
+
+    # Verify TTLT
+    assert response.time_to_last_token is not None, (
+        "Time to last token should not be None"
+    )
+    assert response.time_to_last_token > 0, "TTLT should be positive"
+
+    # Verify TTLT >= TTFT
+    assert response.time_to_last_token >= response.time_to_first_token, (
+        "TTLT should be >= TTFT"
+    )
+
+    # Verify response ID
+    assert response.id is not None, "Response should have an ID"

--- a/tests/integ/test_openai_response_reasoning.py
+++ b/tests/integ/test_openai_response_reasoning.py
@@ -1,0 +1,275 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Integration tests for reasoning token parsing via OpenAI Response API.
+
+This module tests that OpenAIResponseEndpoint and OpenAIResponseStreamEndpoint
+correctly handle reasoning tokens when using a reasoning-capable model
+(openai.gpt-oss-120b) through Bedrock's Mantle endpoint.
+
+Tests cover:
+- Non-streaming: num_tokens_output_reasoning extraction
+- Streaming with ttft_visible_tokens_only=True: TTFT on first visible text token
+- Streaming with ttft_visible_tokens_only=False: TTFT on first reasoning token
+- Comparison of inclusive vs visible-only TTFT
+
+Tests are marked with @pytest.mark.integ and are skipped by default to avoid
+AWS costs and credential requirements during regular development.
+
+To run these tests:
+    uv run pytest -m integ -k reasoning
+
+Required AWS Permissions:
+    - bedrock:InvokeModel
+    - bedrock:InvokeModelWithResponseStream
+
+Estimated Cost:
+    - ~$0.003 per full run (reasoning models use more tokens)
+
+Environment Variables:
+    - AWS_REGION: AWS region for testing (default: us-east-1)
+    - BEDROCK_REASONING_OPENAI_TEST_MODEL: Model ID for reasoning tests
+      (default: openai.gpt-oss-120b-1:0, version suffix stripped automatically)
+"""
+
+import os
+
+import pytest
+
+try:
+    from aws_bedrock_token_generator import provide_token
+
+    OPENAI_AVAILABLE = True
+except ImportError:
+    OPENAI_AVAILABLE = False
+
+from llmeter.endpoints.openai_response import (
+    OpenAIResponseEndpoint,
+    OpenAIResponseStreamEndpoint,
+)
+
+
+def _mantle_base_url(region: str) -> str:
+    return f"https://bedrock-mantle.{region}.api.aws/v1"
+
+
+def _strip_model_version(model_id: str) -> str:
+    """Strip version suffix for Mantle API compatibility.
+
+    Mantle requires model ID without version suffix
+    (e.g., openai.gpt-oss-120b instead of openai.gpt-oss-120b-1:0).
+    """
+    if "-" in model_id and ":" in model_id:
+        return model_id.rsplit("-", 1)[0]
+    return model_id
+
+
+@pytest.fixture(scope="module")
+def reasoning_model_id():
+    """Get the reasoning-capable model ID for Response API tests.
+
+    Defaults to openai.gpt-oss-120b (version suffix stripped automatically).
+    """
+    raw = os.environ.get(
+        "BEDROCK_REASONING_OPENAI_TEST_MODEL", "openai.gpt-oss-120b-1:0"
+    )
+    return _strip_model_version(raw)
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integ
+@pytest.mark.skipif(not OPENAI_AVAILABLE, reason="OpenAI SDK not installed")
+def test_response_non_streaming_reasoning_tokens(
+    aws_credentials, aws_region, reasoning_model_id
+):
+    """Test non-streaming Response API with a reasoning model.
+
+    Validates that OpenAIResponseEndpoint correctly extracts:
+    - Response text
+    - num_tokens_output_reasoning from output_tokens_details
+    - Standard token counts (input, output)
+    - Timing information
+    """
+    token = provide_token(region=aws_region)
+
+    endpoint = OpenAIResponseEndpoint(
+        model_id=reasoning_model_id,
+        api_key=token,
+        base_url=_mantle_base_url(aws_region),
+    )
+
+    payload = OpenAIResponseEndpoint.create_payload(
+        user_message="What is 15 * 37? Reply with just the number.",
+        max_output_tokens=200,
+    )
+
+    response = endpoint.invoke(payload)
+
+    assert response.error is None, (
+        f"Response should not contain errors: {response.error}"
+    )
+
+    # Verify response text
+    assert response.response_text is not None, "Response text should not be None"
+    assert len(response.response_text) > 0, "Response text should not be empty"
+    assert "555" in response.response_text, (
+        f"Expected '555' in response, got: {response.response_text}"
+    )
+
+    # Verify token counts
+    if response.num_tokens_input is not None:
+        assert response.num_tokens_input > 0, "Input token count should be positive"
+    if response.num_tokens_output is not None:
+        assert response.num_tokens_output > 0, "Output token count should be positive"
+
+    # Verify reasoning token count if available
+    if response.num_tokens_output_reasoning is not None:
+        assert response.num_tokens_output_reasoning >= 0, (
+            "Reasoning token count should be non-negative"
+        )
+        if response.num_tokens_output is not None:
+            assert response.num_tokens_output_reasoning <= response.num_tokens_output, (
+                f"Reasoning tokens ({response.num_tokens_output_reasoning}) should be "
+                f"<= total output tokens ({response.num_tokens_output})"
+            )
+
+    # Verify timing
+    assert response.time_to_last_token is not None
+    assert response.time_to_last_token > 0
+
+    # Verify response ID
+    assert response.id is not None, "Response should have an ID"
+
+
+# ---------------------------------------------------------------------------
+# Streaming — visible-only TTFT (default)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integ
+@pytest.mark.skipif(not OPENAI_AVAILABLE, reason="OpenAI SDK not installed")
+def test_response_streaming_reasoning_visible_ttft(
+    aws_credentials, aws_region, reasoning_model_id
+):
+    """Test streaming Response API with ttft_visible_tokens_only=True (default).
+
+    Validates that:
+    - TTFT is measured on the first visible text token
+    - Reasoning tokens do not set TTFT
+    - Response text contains only visible content
+    - num_tokens_output_reasoning is extracted from the completed event
+    """
+    token = provide_token(region=aws_region)
+
+    endpoint = OpenAIResponseStreamEndpoint(
+        model_id=reasoning_model_id,
+        api_key=token,
+        base_url=_mantle_base_url(aws_region),
+    )
+
+    payload = OpenAIResponseEndpoint.create_payload(
+        user_message="What is 15 * 37? Reply with just the number.",
+        max_output_tokens=200,
+    )
+
+    response = endpoint.invoke(payload)
+
+    assert response.error is None, (
+        f"Response should not contain errors: {response.error}"
+    )
+
+    # Verify response text
+    assert response.response_text is not None, "Response text should not be None"
+    assert "555" in response.response_text, (
+        f"Expected '555' in response, got: {response.response_text}"
+    )
+
+    # Verify TTFT and TTLT
+    assert response.time_to_first_token is not None, "TTFT should not be None"
+    assert response.time_to_first_token > 0, "TTFT should be positive"
+    assert response.time_to_last_token is not None, "TTLT should not be None"
+    assert response.time_to_last_token >= response.time_to_first_token, (
+        "TTLT should be >= TTFT"
+    )
+
+    # Verify reasoning token count if available
+    if response.num_tokens_output_reasoning is not None:
+        assert response.num_tokens_output_reasoning >= 0
+        if response.num_tokens_output is not None:
+            assert response.num_tokens_output_reasoning <= response.num_tokens_output
+
+    assert response.id is not None, "Response should have an ID"
+
+
+# ---------------------------------------------------------------------------
+# Streaming — inclusive TTFT (includes reasoning)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integ
+@pytest.mark.skipif(not OPENAI_AVAILABLE, reason="OpenAI SDK not installed")
+def test_response_streaming_reasoning_inclusive_ttft(
+    aws_credentials, aws_region, reasoning_model_id
+):
+    """Test streaming Response API with ttft_visible_tokens_only=False.
+
+    Validates that:
+    - TTFT is measured on the first token of any kind (including reasoning)
+    - Inclusive TTFT should be <= visible-only TTFT
+    - Response text still contains only visible content
+    """
+    token = provide_token(region=aws_region)
+    payload = OpenAIResponseEndpoint.create_payload(
+        user_message="What is 15 * 37? Reply with just the number.",
+        max_output_tokens=200,
+    )
+
+    # Inclusive TTFT (includes reasoning tokens)
+    endpoint_inclusive = OpenAIResponseStreamEndpoint(
+        model_id=reasoning_model_id,
+        api_key=token,
+        base_url=_mantle_base_url(aws_region),
+        ttft_visible_tokens_only=False,
+    )
+    response_inclusive = endpoint_inclusive.invoke(payload)
+
+    assert response_inclusive.error is None, (
+        f"Inclusive response error: {response_inclusive.error}"
+    )
+    assert response_inclusive.response_text is not None
+    assert "555" in response_inclusive.response_text, (
+        f"Expected '555', got: {response_inclusive.response_text}"
+    )
+    assert response_inclusive.time_to_first_token is not None, (
+        "Inclusive TTFT should not be None"
+    )
+    assert response_inclusive.time_to_first_token > 0
+    assert response_inclusive.time_to_last_token >= response_inclusive.time_to_first_token
+
+    # Visible-only TTFT
+    endpoint_visible = OpenAIResponseStreamEndpoint(
+        model_id=reasoning_model_id,
+        api_key=token,
+        base_url=_mantle_base_url(aws_region),
+        ttft_visible_tokens_only=True,
+    )
+    response_visible = endpoint_visible.invoke(payload)
+
+    assert response_visible.error is None, (
+        f"Visible response error: {response_visible.error}"
+    )
+    assert response_visible.time_to_first_token is not None, (
+        "Visible TTFT should not be None"
+    )
+
+    # Inclusive TTFT should be <= visible-only TTFT (reasoning arrives first).
+    # Allow tolerance for network jitter between two separate API calls.
+    assert response_inclusive.time_to_first_token <= response_visible.time_to_first_token + 0.5, (
+        f"Inclusive TTFT ({response_inclusive.time_to_first_token:.3f}s) should be "
+        f"<= visible TTFT ({response_visible.time_to_first_token:.3f}s) + tolerance"
+    )

--- a/tests/unit/endpoints/test_anthropic_messages.py
+++ b/tests/unit/endpoints/test_anthropic_messages.py
@@ -1,0 +1,560 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import time
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from llmeter.endpoints.anthropic_messages import (
+    AnthropicMessages,
+    AnthropicMessagesEndpoint,
+    AnthropicMessagesStream,
+    _build_anthropic_client,
+)
+from llmeter.endpoints.base import InvocationResponse
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_message(
+    msg_id="msg_test123",
+    text="Hello, world!",
+    input_tokens=10,
+    output_tokens=5,
+    cache_read_input_tokens=None,
+):
+    """Build a mock non-streaming Message response."""
+    text_block = Mock()
+    text_block.type = "text"
+    text_block.text = text
+
+    usage = Mock()
+    usage.input_tokens = input_tokens
+    usage.output_tokens = output_tokens
+    usage.cache_read_input_tokens = cache_read_input_tokens
+
+    message = Mock()
+    message.id = msg_id
+    message.content = [text_block]
+    message.usage = usage
+    return message
+
+
+def _make_stream_events(
+    msg_id="msg_stream123",
+    text_chunks=None,
+    input_tokens=10,
+    output_tokens=5,
+    cache_read_input_tokens=None,
+):
+    """Build a list of mock SSE streaming events."""
+    if text_chunks is None:
+        text_chunks = ["Hello", ", ", "world!"]
+
+    events = []
+
+    # message_start
+    msg_start_usage = Mock()
+    msg_start_usage.input_tokens = input_tokens
+    msg_start_usage.cache_read_input_tokens = cache_read_input_tokens
+
+    msg_start_message = Mock()
+    msg_start_message.id = msg_id
+    msg_start_message.usage = msg_start_usage
+
+    msg_start = Mock()
+    msg_start.type = "message_start"
+    msg_start.message = msg_start_message
+    events.append(msg_start)
+
+    # content_block_start
+    block_start = Mock()
+    block_start.type = "content_block_start"
+    events.append(block_start)
+
+    # content_block_delta events (text)
+    for chunk in text_chunks:
+        delta = Mock()
+        delta.type = "text_delta"
+        delta.text = chunk
+
+        event = Mock()
+        event.type = "content_block_delta"
+        event.delta = delta
+        events.append(event)
+
+    # content_block_stop
+    block_stop = Mock()
+    block_stop.type = "content_block_stop"
+    events.append(block_stop)
+
+    # message_delta with usage
+    msg_delta_usage = Mock()
+    msg_delta_usage.output_tokens = output_tokens
+
+    msg_delta = Mock()
+    msg_delta.type = "message_delta"
+    msg_delta.usage = msg_delta_usage
+    events.append(msg_delta)
+
+    # message_stop
+    msg_stop = Mock()
+    msg_stop.type = "message_stop"
+    events.append(msg_stop)
+
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Tests: _build_anthropic_client
+# ---------------------------------------------------------------------------
+
+
+class TestBuildClient:
+    @patch("llmeter.endpoints.anthropic_messages.anthropic")
+    def test_build_anthropic_client(self, mock_anthropic):
+        _build_anthropic_client(provider="anthropic", api_key="test-key")
+        mock_anthropic.Anthropic.assert_called_once_with(api_key="test-key")
+
+    @patch("llmeter.endpoints.anthropic_messages.anthropic")
+    def test_build_bedrock_client(self, mock_anthropic):
+        _build_anthropic_client(provider="bedrock", aws_region="us-west-2")
+        mock_anthropic.AnthropicBedrock.assert_called_once_with(
+            aws_region="us-west-2"
+        )
+
+    @patch("llmeter.endpoints.anthropic_messages.anthropic")
+    def test_build_bedrock_mantle_client(self, mock_anthropic):
+        _build_anthropic_client(provider="bedrock-mantle", aws_region="us-east-1")
+        mock_anthropic.AnthropicBedrockMantle.assert_called_once_with(
+            aws_region="us-east-1"
+        )
+
+    @patch("llmeter.endpoints.anthropic_messages.anthropic")
+    def test_build_unknown_provider_raises(self, mock_anthropic):
+        with pytest.raises(ValueError, match="Unknown provider"):
+            _build_anthropic_client(provider="unknown")
+
+
+# ---------------------------------------------------------------------------
+# Tests: create_payload
+# ---------------------------------------------------------------------------
+
+
+class TestCreatePayload:
+    def test_basic_payload(self):
+        payload = AnthropicMessagesEndpoint.create_payload("Hello!")
+        assert payload == {
+            "messages": [{"role": "user", "content": "Hello!"}],
+            "max_tokens": 256,
+        }
+
+    def test_custom_max_tokens(self):
+        payload = AnthropicMessagesEndpoint.create_payload("Hi", max_tokens=1024)
+        assert payload["max_tokens"] == 1024
+
+    def test_extra_kwargs(self):
+        payload = AnthropicMessagesEndpoint.create_payload(
+            "Hi", system="Be helpful", temperature=0.7
+        )
+        assert payload["system"] == "Be helpful"
+        assert payload["temperature"] == 0.7
+
+    def test_invalid_max_tokens(self):
+        with pytest.raises(ValueError, match="positive integer"):
+            AnthropicMessagesEndpoint.create_payload("Hi", max_tokens=-1)
+
+    def test_zero_max_tokens(self):
+        with pytest.raises(ValueError, match="positive integer"):
+            AnthropicMessagesEndpoint.create_payload("Hi", max_tokens=0)
+
+    def test_non_string_message(self):
+        with pytest.raises(TypeError, match="must be a str"):
+            AnthropicMessagesEndpoint.create_payload(123)
+
+
+# ---------------------------------------------------------------------------
+# Tests: _parse_payload
+# ---------------------------------------------------------------------------
+
+
+class TestParsePayload:
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_parse_string_content(self, mock_build):
+        endpoint = AnthropicMessages(model_id="test-model")
+        payload = {"messages": [{"role": "user", "content": "Hello"}]}
+        assert endpoint._parse_payload(payload) == "Hello"
+
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_parse_block_content(self, mock_build):
+        endpoint = AnthropicMessages(model_id="test-model")
+        payload = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Hello"},
+                        {"type": "text", "text": "World"},
+                    ],
+                }
+            ]
+        }
+        assert endpoint._parse_payload(payload) == "Hello\nWorld"
+
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_parse_empty_messages(self, mock_build):
+        endpoint = AnthropicMessages(model_id="test-model")
+        assert endpoint._parse_payload({"messages": []}) == ""
+
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_parse_no_messages_key(self, mock_build):
+        endpoint = AnthropicMessages(model_id="test-model")
+        assert endpoint._parse_payload({}) == ""
+
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_parse_mixed_content_types(self, mock_build):
+        endpoint = AnthropicMessages(model_id="test-model")
+        payload = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Describe this:"},
+                        {"type": "image", "source": {"type": "base64", "data": "..."}},
+                    ],
+                }
+            ]
+        }
+        assert endpoint._parse_payload(payload) == "Describe this:"
+
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_parse_multi_turn(self, mock_build):
+        endpoint = AnthropicMessages(model_id="test-model")
+        payload = {
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there!"},
+                {"role": "user", "content": "How are you?"},
+            ]
+        }
+        assert endpoint._parse_payload(payload) == "Hello\nHi there!\nHow are you?"
+
+
+# ---------------------------------------------------------------------------
+# Tests: AnthropicMessages (non-streaming)
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicMessages:
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_parse_response(self, mock_build):
+        endpoint = AnthropicMessages(model_id="test-model")
+        mock_response = _make_mock_message()
+
+        result = endpoint.parse_response(mock_response, time.perf_counter())
+
+        assert isinstance(result, InvocationResponse)
+        assert result.id == "msg_test123"
+        assert result.response_text == "Hello, world!"
+        assert result.num_tokens_input == 10
+        assert result.num_tokens_output == 5
+
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_parse_response_with_cache(self, mock_build):
+        endpoint = AnthropicMessages(model_id="test-model")
+        mock_response = _make_mock_message(cache_read_input_tokens=3)
+
+        result = endpoint.parse_response(mock_response, time.perf_counter())
+
+        assert result.num_tokens_input_cached == 3
+
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_parse_response_no_usage(self, mock_build):
+        endpoint = AnthropicMessages(model_id="test-model")
+        mock_response = _make_mock_message()
+        mock_response.usage = None
+
+        result = endpoint.parse_response(mock_response, time.perf_counter())
+
+        assert result.num_tokens_input is None
+        assert result.num_tokens_output is None
+        assert result.num_tokens_input_cached is None
+
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_parse_response_multiple_text_blocks(self, mock_build):
+        endpoint = AnthropicMessages(model_id="test-model")
+
+        block1 = Mock()
+        block1.type = "text"
+        block1.text = "Part 1. "
+
+        block2 = Mock()
+        block2.type = "text"
+        block2.text = "Part 2."
+
+        mock_response = _make_mock_message()
+        mock_response.content = [block1, block2]
+
+        result = endpoint.parse_response(mock_response, time.perf_counter())
+        assert result.response_text == "Part 1. Part 2."
+
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_invoke_success(self, mock_build):
+        mock_client = MagicMock()
+        mock_build.return_value = mock_client
+        mock_client.messages.create.return_value = _make_mock_message()
+
+        endpoint = AnthropicMessages(model_id="test-model")
+        result = endpoint.invoke(
+            {"messages": [{"role": "user", "content": "Hello"}], "max_tokens": 256}
+        )
+
+        assert isinstance(result, InvocationResponse)
+        assert result.response_text == "Hello, world!"
+        assert result.error is None
+
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_invoke_api_error(self, mock_build):
+        mock_client = MagicMock()
+        mock_build.return_value = mock_client
+        mock_client.messages.create.side_effect = Exception("API error")
+
+        endpoint = AnthropicMessages(model_id="test-model")
+        result = endpoint.invoke(
+            {"messages": [{"role": "user", "content": "Hello"}], "max_tokens": 256}
+        )
+
+        assert isinstance(result, InvocationResponse)
+        assert result.error is not None
+        assert "API error" in result.error
+
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_prepare_payload_sets_model(self, mock_build):
+        endpoint = AnthropicMessages(model_id="claude-opus-4-7")
+        payload = {"messages": [{"role": "user", "content": "Hi"}], "max_tokens": 256}
+
+        prepared = endpoint.prepare_payload(payload)
+
+        assert prepared["model"] == "claude-opus-4-7"
+
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_prepare_payload_merges_kwargs(self, mock_build):
+        endpoint = AnthropicMessages(model_id="test-model")
+        payload = {"messages": [{"role": "user", "content": "Hi"}], "max_tokens": 256}
+
+        prepared = endpoint.prepare_payload(payload, temperature=0.5)
+
+        assert prepared["temperature"] == 0.5
+        assert prepared["model"] == "test-model"
+
+
+# ---------------------------------------------------------------------------
+# Tests: AnthropicMessagesStream (streaming)
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicMessagesStream:
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_parse_response_basic(self, mock_build):
+        endpoint = AnthropicMessagesStream(model_id="test-model")
+        events = _make_stream_events()
+
+        start_t = time.perf_counter()
+        result = endpoint.parse_response(iter(events), start_t)
+
+        assert isinstance(result, InvocationResponse)
+        assert result.id == "msg_stream123"
+        assert result.response_text == "Hello, world!"
+        assert result.num_tokens_input == 10
+        assert result.num_tokens_output == 5
+        assert result.time_to_first_token is not None
+        assert result.time_to_last_token is not None
+        assert result.time_to_first_token <= result.time_to_last_token
+
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_parse_response_with_cache(self, mock_build):
+        endpoint = AnthropicMessagesStream(model_id="test-model")
+        events = _make_stream_events(cache_read_input_tokens=7)
+
+        result = endpoint.parse_response(iter(events), time.perf_counter())
+
+        assert result.num_tokens_input_cached == 7
+
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_parse_response_empty_stream(self, mock_build):
+        endpoint = AnthropicMessagesStream(model_id="test-model")
+
+        start_t = time.perf_counter()
+        result = endpoint.parse_response(iter([]), start_t)
+
+        assert isinstance(result, InvocationResponse)
+        assert result.response_text == ""
+        assert result.id is None
+        assert result.time_to_first_token == result.time_to_last_token
+
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_parse_response_no_text_deltas(self, mock_build):
+        """Stream with message_start and message_delta but no text content."""
+        endpoint = AnthropicMessagesStream(model_id="test-model")
+        events = _make_stream_events(text_chunks=[])
+
+        result = endpoint.parse_response(iter(events), time.perf_counter())
+
+        assert result.response_text == ""
+        # TTFT should equal TTLT when no text was received
+        assert result.time_to_first_token == result.time_to_last_token
+
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_parse_response_timing(self, mock_build):
+        """Verify TTFT is captured on the first text delta."""
+        endpoint = AnthropicMessagesStream(model_id="test-model")
+        events = _make_stream_events(text_chunks=["First", " Second"])
+
+        start_t = time.perf_counter()
+        result = endpoint.parse_response(iter(events), start_t)
+
+        assert result.time_to_first_token is not None
+        assert result.time_to_last_token is not None
+        assert result.time_to_first_token > 0
+        assert result.time_to_last_token >= result.time_to_first_token
+
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_prepare_payload_sets_stream(self, mock_build):
+        endpoint = AnthropicMessagesStream(model_id="test-model")
+        payload = {"messages": [{"role": "user", "content": "Hi"}], "max_tokens": 256}
+
+        prepared = endpoint.prepare_payload(payload)
+
+        assert prepared["stream"] is True
+        assert prepared["model"] == "test-model"
+
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_invoke_success(self, mock_build):
+        mock_client = MagicMock()
+        mock_build.return_value = mock_client
+        mock_client.messages.create.return_value = iter(
+            _make_stream_events(text_chunks=["Hi!"])
+        )
+
+        endpoint = AnthropicMessagesStream(model_id="test-model")
+        result = endpoint.invoke(
+            {"messages": [{"role": "user", "content": "Hello"}], "max_tokens": 256}
+        )
+
+        assert isinstance(result, InvocationResponse)
+        assert result.response_text == "Hi!"
+        assert result.error is None
+
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_invoke_api_error(self, mock_build):
+        mock_client = MagicMock()
+        mock_build.return_value = mock_client
+        mock_client.messages.create.side_effect = Exception("Stream error")
+
+        endpoint = AnthropicMessagesStream(model_id="test-model")
+        result = endpoint.invoke(
+            {"messages": [{"role": "user", "content": "Hello"}], "max_tokens": 256}
+        )
+
+        assert isinstance(result, InvocationResponse)
+        assert result.error is not None
+        assert "Stream error" in result.error
+
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_parse_response_ignores_non_text_deltas(self, mock_build):
+        """Verify that non-text deltas (e.g. thinking, input_json) are ignored."""
+        endpoint = AnthropicMessagesStream(model_id="test-model")
+
+        events = []
+
+        # message_start
+        msg_start = Mock()
+        msg_start.type = "message_start"
+        msg_start.message = Mock()
+        msg_start.message.id = "msg_1"
+        msg_start.message.usage = Mock()
+        msg_start.message.usage.input_tokens = 5
+        msg_start.message.usage.cache_read_input_tokens = None
+        events.append(msg_start)
+
+        # A thinking delta (should be ignored)
+        thinking_delta = Mock()
+        thinking_delta.type = "content_block_delta"
+        thinking_delta.delta = Mock()
+        thinking_delta.delta.type = "thinking_delta"
+        thinking_delta.delta.thinking = "Let me think..."
+        events.append(thinking_delta)
+
+        # A text delta
+        text_delta = Mock()
+        text_delta.type = "content_block_delta"
+        text_delta.delta = Mock()
+        text_delta.delta.type = "text_delta"
+        text_delta.delta.text = "Answer"
+        events.append(text_delta)
+
+        # message_delta
+        msg_delta = Mock()
+        msg_delta.type = "message_delta"
+        msg_delta.usage = Mock()
+        msg_delta.usage.output_tokens = 3
+        events.append(msg_delta)
+
+        result = endpoint.parse_response(iter(events), time.perf_counter())
+
+        assert result.response_text == "Answer"
+        assert result.num_tokens_output == 3
+
+
+# ---------------------------------------------------------------------------
+# Tests: Endpoint initialization
+# ---------------------------------------------------------------------------
+
+
+class TestEndpointInit:
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_default_provider(self, mock_build):
+        endpoint = AnthropicMessages(model_id="claude-opus-4-7")
+        assert endpoint.provider == "anthropic"
+        assert endpoint.model_id == "claude-opus-4-7"
+        assert endpoint.endpoint_name == "anthropic-messages"
+
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_bedrock_provider(self, mock_build):
+        endpoint = AnthropicMessages(
+            model_id="global.anthropic.claude-opus-4-6-v1",
+            provider="bedrock",
+            aws_region="us-west-2",
+        )
+        assert endpoint.provider == "bedrock"
+        assert endpoint.aws_region == "us-west-2"
+        mock_build.assert_called_once_with(
+            provider="bedrock",
+            api_key=None,
+            aws_region="us-west-2",
+        )
+
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_bedrock_mantle_provider(self, mock_build):
+        endpoint = AnthropicMessages(
+            model_id="anthropic.claude-opus-4-7",
+            provider="bedrock-mantle",
+            aws_region="us-east-1",
+        )
+        assert endpoint.provider == "bedrock-mantle"
+        mock_build.assert_called_once_with(
+            provider="bedrock-mantle",
+            api_key=None,
+            aws_region="us-east-1",
+        )
+
+    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
+    def test_custom_endpoint_name(self, mock_build):
+        endpoint = AnthropicMessages(
+            model_id="test-model", endpoint_name="my-custom-endpoint"
+        )
+        assert endpoint.endpoint_name == "my-custom-endpoint"

--- a/tests/unit/endpoints/test_anthropic_messages.py
+++ b/tests/unit/endpoints/test_anthropic_messages.py
@@ -2,17 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import time
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
 from llmeter.endpoints.anthropic_messages import (
+    _ANTHROPIC_CLIENTS,
     AnthropicMessages,
     AnthropicMessagesEndpoint,
     AnthropicMessagesStream,
-    _build_anthropic_client,
 )
 from llmeter.endpoints.base import InvocationResponse
+
+_PATCH_CLIENTS = "llmeter.endpoints.anthropic_messages._ANTHROPIC_CLIENTS"
 
 
 # ---------------------------------------------------------------------------
@@ -109,35 +111,38 @@ def _make_stream_events(
     return events
 
 
+def _make_draft_response() -> InvocationResponse:
+    """Create a draft InvocationResponse like llmeter_invoke does."""
+    return InvocationResponse(response_text=None)
+
+
+@pytest.fixture()
+def mock_client():
+    """Replace every provider in _ANTHROPIC_CLIENTS with a single Mock class."""
+    cls = Mock()
+    with patch.dict(_ANTHROPIC_CLIENTS, {k: cls for k in _ANTHROPIC_CLIENTS}):
+        yield cls
+
+
 # ---------------------------------------------------------------------------
-# Tests: _build_anthropic_client
+# Tests: client construction
 # ---------------------------------------------------------------------------
 
 
 class TestBuildClient:
-    @patch("llmeter.endpoints.anthropic_messages.anthropic")
-    def test_build_anthropic_client(self, mock_anthropic):
-        _build_anthropic_client(provider="anthropic", api_key="test-key")
-        mock_anthropic.Anthropic.assert_called_once_with(api_key="test-key")
+    def test_anthropic_provider(self, mock_client):
+        AnthropicMessages(model_id="test-model", provider="anthropic", api_key="k")
+        mock_client.assert_called_once_with(api_key="k")
 
-    @patch("llmeter.endpoints.anthropic_messages.anthropic")
-    def test_build_bedrock_client(self, mock_anthropic):
-        _build_anthropic_client(provider="bedrock", aws_region="us-west-2")
-        mock_anthropic.AnthropicBedrock.assert_called_once_with(
-            aws_region="us-west-2"
+    def test_bedrock_mantle_provider(self, mock_client):
+        AnthropicMessages(
+            model_id="test-model", provider="bedrock-mantle", aws_region="us-east-1"
         )
+        mock_client.assert_called_once_with(aws_region="us-east-1")
 
-    @patch("llmeter.endpoints.anthropic_messages.anthropic")
-    def test_build_bedrock_mantle_client(self, mock_anthropic):
-        _build_anthropic_client(provider="bedrock-mantle", aws_region="us-east-1")
-        mock_anthropic.AnthropicBedrockMantle.assert_called_once_with(
-            aws_region="us-east-1"
-        )
-
-    @patch("llmeter.endpoints.anthropic_messages.anthropic")
-    def test_build_unknown_provider_raises(self, mock_anthropic):
+    def test_unknown_provider_raises(self):
         with pytest.raises(ValueError, match="Unknown provider"):
-            _build_anthropic_client(provider="unknown")
+            AnthropicMessages(model_id="test-model", provider="unknown")
 
 
 # ---------------------------------------------------------------------------
@@ -176,6 +181,32 @@ class TestCreatePayload:
         with pytest.raises(TypeError, match="must be a str"):
             AnthropicMessagesEndpoint.create_payload(123)
 
+    def test_thinking_adaptive(self):
+        payload = AnthropicMessagesEndpoint.create_payload(
+            "Think hard", max_tokens=16000, thinking={"type": "adaptive"}
+        )
+        assert payload["thinking"] == {"type": "adaptive"}
+        assert payload["max_tokens"] == 16000
+
+    def test_thinking_enabled_with_budget(self):
+        payload = AnthropicMessagesEndpoint.create_payload(
+            "Prove it",
+            max_tokens=16000,
+            thinking={"type": "enabled", "budget_tokens": 10000},
+        )
+        assert payload["thinking"]["type"] == "enabled"
+        assert payload["thinking"]["budget_tokens"] == 10000
+
+    def test_thinking_disabled(self):
+        payload = AnthropicMessagesEndpoint.create_payload(
+            "Hello", thinking={"type": "disabled"}
+        )
+        assert payload["thinking"] == {"type": "disabled"}
+
+    def test_thinking_none_omitted(self):
+        payload = AnthropicMessagesEndpoint.create_payload("Hello")
+        assert "thinking" not in payload
+
 
 # ---------------------------------------------------------------------------
 # Tests: _parse_payload
@@ -183,14 +214,12 @@ class TestCreatePayload:
 
 
 class TestParsePayload:
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_parse_string_content(self, mock_build):
+    def test_parse_string_content(self, mock_client):
         endpoint = AnthropicMessages(model_id="test-model")
         payload = {"messages": [{"role": "user", "content": "Hello"}]}
         assert endpoint._parse_payload(payload) == "Hello"
 
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_parse_block_content(self, mock_build):
+    def test_parse_block_content(self, mock_client):
         endpoint = AnthropicMessages(model_id="test-model")
         payload = {
             "messages": [
@@ -205,18 +234,15 @@ class TestParsePayload:
         }
         assert endpoint._parse_payload(payload) == "Hello\nWorld"
 
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_parse_empty_messages(self, mock_build):
+    def test_parse_empty_messages(self, mock_client):
         endpoint = AnthropicMessages(model_id="test-model")
         assert endpoint._parse_payload({"messages": []}) == ""
 
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_parse_no_messages_key(self, mock_build):
+    def test_parse_no_messages_key(self, mock_client):
         endpoint = AnthropicMessages(model_id="test-model")
         assert endpoint._parse_payload({}) == ""
 
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_parse_mixed_content_types(self, mock_build):
+    def test_parse_mixed_content_types(self, mock_client):
         endpoint = AnthropicMessages(model_id="test-model")
         payload = {
             "messages": [
@@ -231,8 +257,7 @@ class TestParsePayload:
         }
         assert endpoint._parse_payload(payload) == "Describe this:"
 
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_parse_multi_turn(self, mock_build):
+    def test_parse_multi_turn(self, mock_client):
         endpoint = AnthropicMessages(model_id="test-model")
         payload = {
             "messages": [
@@ -250,42 +275,41 @@ class TestParsePayload:
 
 
 class TestAnthropicMessages:
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_parse_response(self, mock_build):
+    def test_process_raw_response(self, mock_client):
         endpoint = AnthropicMessages(model_id="test-model")
         mock_response = _make_mock_message()
+        response = _make_draft_response()
 
-        result = endpoint.parse_response(mock_response, time.perf_counter())
+        endpoint.process_raw_response(mock_response, time.perf_counter(), response)
 
-        assert isinstance(result, InvocationResponse)
-        assert result.id == "msg_test123"
-        assert result.response_text == "Hello, world!"
-        assert result.num_tokens_input == 10
-        assert result.num_tokens_output == 5
+        assert response.id == "msg_test123"
+        assert response.response_text == "Hello, world!"
+        assert response.num_tokens_input == 10
+        assert response.num_tokens_output == 5
+        assert response.time_to_last_token is not None
 
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_parse_response_with_cache(self, mock_build):
+    def test_process_raw_response_with_cache(self, mock_client):
         endpoint = AnthropicMessages(model_id="test-model")
         mock_response = _make_mock_message(cache_read_input_tokens=3)
+        response = _make_draft_response()
 
-        result = endpoint.parse_response(mock_response, time.perf_counter())
+        endpoint.process_raw_response(mock_response, time.perf_counter(), response)
 
-        assert result.num_tokens_input_cached == 3
+        assert response.num_tokens_input_cached == 3
 
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_parse_response_no_usage(self, mock_build):
+    def test_process_raw_response_no_usage(self, mock_client):
         endpoint = AnthropicMessages(model_id="test-model")
         mock_response = _make_mock_message()
         mock_response.usage = None
+        response = _make_draft_response()
 
-        result = endpoint.parse_response(mock_response, time.perf_counter())
+        endpoint.process_raw_response(mock_response, time.perf_counter(), response)
 
-        assert result.num_tokens_input is None
-        assert result.num_tokens_output is None
-        assert result.num_tokens_input_cached is None
+        assert response.num_tokens_input is None
+        assert response.num_tokens_output is None
+        assert response.num_tokens_input_cached is None
 
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_parse_response_multiple_text_blocks(self, mock_build):
+    def test_process_raw_response_multiple_text_blocks(self, mock_client):
         endpoint = AnthropicMessages(model_id="test-model")
 
         block1 = Mock()
@@ -298,15 +322,13 @@ class TestAnthropicMessages:
 
         mock_response = _make_mock_message()
         mock_response.content = [block1, block2]
+        response = _make_draft_response()
 
-        result = endpoint.parse_response(mock_response, time.perf_counter())
-        assert result.response_text == "Part 1. Part 2."
+        endpoint.process_raw_response(mock_response, time.perf_counter(), response)
+        assert response.response_text == "Part 1. Part 2."
 
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_invoke_success(self, mock_build):
-        mock_client = MagicMock()
-        mock_build.return_value = mock_client
-        mock_client.messages.create.return_value = _make_mock_message()
+    def test_invoke_success(self, mock_client):
+        mock_client.return_value.messages.create.return_value = _make_mock_message()
 
         endpoint = AnthropicMessages(model_id="test-model")
         result = endpoint.invoke(
@@ -317,11 +339,8 @@ class TestAnthropicMessages:
         assert result.response_text == "Hello, world!"
         assert result.error is None
 
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_invoke_api_error(self, mock_build):
-        mock_client = MagicMock()
-        mock_build.return_value = mock_client
-        mock_client.messages.create.side_effect = Exception("API error")
+    def test_invoke_api_error(self, mock_client):
+        mock_client.return_value.messages.create.side_effect = Exception("API error")
 
         endpoint = AnthropicMessages(model_id="test-model")
         result = endpoint.invoke(
@@ -332,8 +351,7 @@ class TestAnthropicMessages:
         assert result.error is not None
         assert "API error" in result.error
 
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_prepare_payload_sets_model(self, mock_build):
+    def test_prepare_payload_sets_model(self, mock_client):
         endpoint = AnthropicMessages(model_id="claude-opus-4-7")
         payload = {"messages": [{"role": "user", "content": "Hi"}], "max_tokens": 256}
 
@@ -341,8 +359,7 @@ class TestAnthropicMessages:
 
         assert prepared["model"] == "claude-opus-4-7"
 
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_prepare_payload_merges_kwargs(self, mock_build):
+    def test_prepare_payload_merges_kwargs(self, mock_client):
         endpoint = AnthropicMessages(model_id="test-model")
         payload = {"messages": [{"role": "user", "content": "Hi"}], "max_tokens": 256}
 
@@ -358,72 +375,65 @@ class TestAnthropicMessages:
 
 
 class TestAnthropicMessagesStream:
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_parse_response_basic(self, mock_build):
+    def test_process_raw_response_basic(self, mock_client):
         endpoint = AnthropicMessagesStream(model_id="test-model")
         events = _make_stream_events()
+        response = _make_draft_response()
 
-        start_t = time.perf_counter()
-        result = endpoint.parse_response(iter(events), start_t)
+        endpoint.process_raw_response(iter(events), time.perf_counter(), response)
 
-        assert isinstance(result, InvocationResponse)
-        assert result.id == "msg_stream123"
-        assert result.response_text == "Hello, world!"
-        assert result.num_tokens_input == 10
-        assert result.num_tokens_output == 5
-        assert result.time_to_first_token is not None
-        assert result.time_to_last_token is not None
-        assert result.time_to_first_token <= result.time_to_last_token
+        assert response.id == "msg_stream123"
+        assert response.response_text == "Hello, world!"
+        assert response.num_tokens_input == 10
+        assert response.num_tokens_output == 5
+        assert response.time_to_first_token is not None
+        assert response.time_to_last_token is not None
+        assert response.time_to_first_token <= response.time_to_last_token
 
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_parse_response_with_cache(self, mock_build):
+    def test_process_raw_response_with_cache(self, mock_client):
         endpoint = AnthropicMessagesStream(model_id="test-model")
         events = _make_stream_events(cache_read_input_tokens=7)
+        response = _make_draft_response()
 
-        result = endpoint.parse_response(iter(events), time.perf_counter())
+        endpoint.process_raw_response(iter(events), time.perf_counter(), response)
 
-        assert result.num_tokens_input_cached == 7
+        assert response.num_tokens_input_cached == 7
 
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_parse_response_empty_stream(self, mock_build):
+    def test_process_raw_response_empty_stream(self, mock_client):
         endpoint = AnthropicMessagesStream(model_id="test-model")
+        response = _make_draft_response()
 
-        start_t = time.perf_counter()
-        result = endpoint.parse_response(iter([]), start_t)
+        endpoint.process_raw_response(iter([]), time.perf_counter(), response)
 
-        assert isinstance(result, InvocationResponse)
-        assert result.response_text == ""
-        assert result.id is None
-        assert result.time_to_first_token == result.time_to_last_token
+        assert response.response_text is None
+        assert response.id is None
 
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_parse_response_no_text_deltas(self, mock_build):
+    def test_process_raw_response_no_text_deltas(self, mock_client):
         """Stream with message_start and message_delta but no text content."""
         endpoint = AnthropicMessagesStream(model_id="test-model")
         events = _make_stream_events(text_chunks=[])
+        response = _make_draft_response()
 
-        result = endpoint.parse_response(iter(events), time.perf_counter())
+        endpoint.process_raw_response(iter(events), time.perf_counter(), response)
 
-        assert result.response_text == ""
-        # TTFT should equal TTLT when no text was received
-        assert result.time_to_first_token == result.time_to_last_token
+        assert response.response_text is None
+        assert response.time_to_first_token is None
 
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_parse_response_timing(self, mock_build):
+    def test_process_raw_response_timing(self, mock_client):
         """Verify TTFT is captured on the first text delta."""
         endpoint = AnthropicMessagesStream(model_id="test-model")
         events = _make_stream_events(text_chunks=["First", " Second"])
+        response = _make_draft_response()
 
         start_t = time.perf_counter()
-        result = endpoint.parse_response(iter(events), start_t)
+        endpoint.process_raw_response(iter(events), start_t, response)
 
-        assert result.time_to_first_token is not None
-        assert result.time_to_last_token is not None
-        assert result.time_to_first_token > 0
-        assert result.time_to_last_token >= result.time_to_first_token
+        assert response.time_to_first_token is not None
+        assert response.time_to_last_token is not None
+        assert response.time_to_first_token > 0
+        assert response.time_to_last_token >= response.time_to_first_token
 
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_prepare_payload_sets_stream(self, mock_build):
+    def test_prepare_payload_sets_stream(self, mock_client):
         endpoint = AnthropicMessagesStream(model_id="test-model")
         payload = {"messages": [{"role": "user", "content": "Hi"}], "max_tokens": 256}
 
@@ -432,11 +442,8 @@ class TestAnthropicMessagesStream:
         assert prepared["stream"] is True
         assert prepared["model"] == "test-model"
 
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_invoke_success(self, mock_build):
-        mock_client = MagicMock()
-        mock_build.return_value = mock_client
-        mock_client.messages.create.return_value = iter(
+    def test_invoke_success(self, mock_client):
+        mock_client.return_value.messages.create.return_value = iter(
             _make_stream_events(text_chunks=["Hi!"])
         )
 
@@ -449,11 +456,10 @@ class TestAnthropicMessagesStream:
         assert result.response_text == "Hi!"
         assert result.error is None
 
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_invoke_api_error(self, mock_build):
-        mock_client = MagicMock()
-        mock_build.return_value = mock_client
-        mock_client.messages.create.side_effect = Exception("Stream error")
+    def test_invoke_api_error(self, mock_client):
+        mock_client.return_value.messages.create.side_effect = Exception(
+            "Stream error"
+        )
 
         endpoint = AnthropicMessagesStream(model_id="test-model")
         result = endpoint.invoke(
@@ -464,9 +470,8 @@ class TestAnthropicMessagesStream:
         assert result.error is not None
         assert "Stream error" in result.error
 
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_parse_response_ignores_non_text_deltas(self, mock_build):
-        """Verify that non-text deltas (e.g. thinking, input_json) are ignored."""
+    def test_process_raw_response_thinking_deltas_excluded_from_text(self, mock_client):
+        """Thinking deltas don't contribute to response_text (default ttft_visible_tokens_only=True)."""
         endpoint = AnthropicMessagesStream(model_id="test-model")
 
         events = []
@@ -481,7 +486,7 @@ class TestAnthropicMessagesStream:
         msg_start.message.usage.cache_read_input_tokens = None
         events.append(msg_start)
 
-        # A thinking delta (should be ignored)
+        # A thinking delta (should not affect response_text or TTFT)
         thinking_delta = Mock()
         thinking_delta.type = "content_block_delta"
         thinking_delta.delta = Mock()
@@ -504,10 +509,174 @@ class TestAnthropicMessagesStream:
         msg_delta.usage.output_tokens = 3
         events.append(msg_delta)
 
-        result = endpoint.parse_response(iter(events), time.perf_counter())
+        response = _make_draft_response()
+        endpoint.process_raw_response(iter(events), time.perf_counter(), response)
 
-        assert result.response_text == "Answer"
-        assert result.num_tokens_output == 3
+        assert response.response_text == "Answer"
+        assert response.num_tokens_output == 3
+
+    def test_ttft_visible_tokens_only_true_ignores_thinking(self, mock_client):
+        """With ttft_visible_tokens_only=True (default), TTFT is set on first text_delta."""
+        endpoint = AnthropicMessagesStream(model_id="test-model")
+
+        events = []
+
+        msg_start = Mock()
+        msg_start.type = "message_start"
+        msg_start.message = Mock()
+        msg_start.message.id = "msg_1"
+        msg_start.message.usage = Mock()
+        msg_start.message.usage.input_tokens = 5
+        msg_start.message.usage.cache_read_input_tokens = None
+        events.append(msg_start)
+
+        # Thinking delta — should NOT set TTFT
+        thinking = Mock()
+        thinking.type = "content_block_delta"
+        thinking.delta = Mock()
+        thinking.delta.type = "thinking_delta"
+        thinking.delta.thinking = "Reasoning..."
+        events.append(thinking)
+
+        # Text delta — should set TTFT
+        text = Mock()
+        text.type = "content_block_delta"
+        text.delta = Mock()
+        text.delta.type = "text_delta"
+        text.delta.text = "Result"
+        events.append(text)
+
+        response = _make_draft_response()
+        start_t = time.perf_counter()
+        endpoint.process_raw_response(iter(events), start_t, response)
+
+        assert response.time_to_first_token is not None
+        assert response.response_text == "Result"
+
+    def test_ttft_visible_tokens_only_false_includes_thinking(self, mock_client):
+        """With ttft_visible_tokens_only=False, TTFT is set on first thinking_delta."""
+        endpoint = AnthropicMessagesStream(
+            model_id="test-model", ttft_visible_tokens_only=False
+        )
+
+        events = []
+
+        msg_start = Mock()
+        msg_start.type = "message_start"
+        msg_start.message = Mock()
+        msg_start.message.id = "msg_1"
+        msg_start.message.usage = Mock()
+        msg_start.message.usage.input_tokens = 5
+        msg_start.message.usage.cache_read_input_tokens = None
+        events.append(msg_start)
+
+        # Thinking delta — should set TTFT
+        thinking = Mock()
+        thinking.type = "content_block_delta"
+        thinking.delta = Mock()
+        thinking.delta.type = "thinking_delta"
+        thinking.delta.thinking = "Reasoning..."
+        events.append(thinking)
+
+        # Text delta — TTFT already set, should not change it
+        text = Mock()
+        text.type = "content_block_delta"
+        text.delta = Mock()
+        text.delta.type = "text_delta"
+        text.delta.text = "Result"
+        events.append(text)
+
+        response = _make_draft_response()
+        start_t = time.perf_counter()
+        endpoint.process_raw_response(iter(events), start_t, response)
+
+        # TTFT was set on the thinking delta, before the text delta
+        assert response.time_to_first_token is not None
+        assert response.time_to_first_token <= response.time_to_last_token
+        assert response.response_text == "Result"
+
+    def test_ttft_signature_delta_with_display_omitted(self, mock_client):
+        """With display=omitted, no thinking_delta is emitted — only signature_delta.
+
+        When ttft_visible_tokens_only=False, the signature_delta should set TTFT.
+        """
+        endpoint = AnthropicMessagesStream(
+            model_id="test-model", ttft_visible_tokens_only=False
+        )
+
+        events = []
+
+        msg_start = Mock()
+        msg_start.type = "message_start"
+        msg_start.message = Mock()
+        msg_start.message.id = "msg_1"
+        msg_start.message.usage = Mock()
+        msg_start.message.usage.input_tokens = 5
+        msg_start.message.usage.cache_read_input_tokens = None
+        events.append(msg_start)
+
+        # signature_delta — the only thinking-block signal in omitted mode
+        sig = Mock()
+        sig.type = "content_block_delta"
+        sig.delta = Mock()
+        sig.delta.type = "signature_delta"
+        sig.delta.signature = "EosnCkYICxIMMb3LzNrMu..."
+        events.append(sig)
+
+        # Text delta
+        text = Mock()
+        text.type = "content_block_delta"
+        text.delta = Mock()
+        text.delta.type = "text_delta"
+        text.delta.text = "Answer"
+        events.append(text)
+
+        response = _make_draft_response()
+        start_t = time.perf_counter()
+        endpoint.process_raw_response(iter(events), start_t, response)
+
+        # TTFT was set on the signature_delta, not the text_delta
+        assert response.time_to_first_token is not None
+        assert response.time_to_first_token <= response.time_to_last_token
+        assert response.response_text == "Answer"
+
+    def test_ttft_signature_delta_ignored_when_visible_only(self, mock_client):
+        """With ttft_visible_tokens_only=True (default), signature_delta is ignored for TTFT."""
+        endpoint = AnthropicMessagesStream(model_id="test-model")
+
+        events = []
+
+        msg_start = Mock()
+        msg_start.type = "message_start"
+        msg_start.message = Mock()
+        msg_start.message.id = "msg_1"
+        msg_start.message.usage = Mock()
+        msg_start.message.usage.input_tokens = 5
+        msg_start.message.usage.cache_read_input_tokens = None
+        events.append(msg_start)
+
+        # signature_delta — should NOT set TTFT
+        sig = Mock()
+        sig.type = "content_block_delta"
+        sig.delta = Mock()
+        sig.delta.type = "signature_delta"
+        sig.delta.signature = "EosnCkYICxIMMb3LzNrMu..."
+        events.append(sig)
+
+        # Text delta — should set TTFT
+        text = Mock()
+        text.type = "content_block_delta"
+        text.delta = Mock()
+        text.delta.type = "text_delta"
+        text.delta.text = "Answer"
+        events.append(text)
+
+        response = _make_draft_response()
+        start_t = time.perf_counter()
+        endpoint.process_raw_response(iter(events), start_t, response)
+
+        assert response.time_to_first_token is not None
+        assert response.response_text == "Answer"
 
 
 # ---------------------------------------------------------------------------
@@ -516,44 +685,22 @@ class TestAnthropicMessagesStream:
 
 
 class TestEndpointInit:
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_default_provider(self, mock_build):
+    def test_default_provider(self, mock_client):
         endpoint = AnthropicMessages(model_id="claude-opus-4-7")
         assert endpoint.provider == "anthropic"
         assert endpoint.model_id == "claude-opus-4-7"
         assert endpoint.endpoint_name == "anthropic-messages"
 
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_bedrock_provider(self, mock_build):
-        endpoint = AnthropicMessages(
-            model_id="global.anthropic.claude-opus-4-6-v1",
-            provider="bedrock",
-            aws_region="us-west-2",
-        )
-        assert endpoint.provider == "bedrock"
-        assert endpoint.aws_region == "us-west-2"
-        mock_build.assert_called_once_with(
-            provider="bedrock",
-            api_key=None,
-            aws_region="us-west-2",
-        )
-
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_bedrock_mantle_provider(self, mock_build):
+    def test_bedrock_mantle_provider(self, mock_client):
         endpoint = AnthropicMessages(
             model_id="anthropic.claude-opus-4-7",
             provider="bedrock-mantle",
             aws_region="us-east-1",
         )
         assert endpoint.provider == "bedrock-mantle"
-        mock_build.assert_called_once_with(
-            provider="bedrock-mantle",
-            api_key=None,
-            aws_region="us-east-1",
-        )
+        mock_client.assert_called_once_with(aws_region="us-east-1")
 
-    @patch("llmeter.endpoints.anthropic_messages._build_anthropic_client")
-    def test_custom_endpoint_name(self, mock_build):
+    def test_custom_endpoint_name(self, mock_client):
         endpoint = AnthropicMessages(
             model_id="test-model", endpoint_name="my-custom-endpoint"
         )

--- a/tests/unit/endpoints/test_bedrock_reasoning.py
+++ b/tests/unit/endpoints/test_bedrock_reasoning.py
@@ -1,0 +1,210 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for reasoning token parsing in BedrockConverseStream.
+
+Covers:
+- TTFT measurement with ``ttft_visible_tokens_only=True`` (default): reasoning
+  content deltas are ignored, TTFT set on first visible text delta.
+- TTFT measurement with ``ttft_visible_tokens_only=False``: TTFT set on first
+  ``reasoningContent`` delta.
+- Reasoning deltas do not contribute to ``response_text``.
+"""
+
+import time
+from unittest.mock import patch
+
+from llmeter.endpoints.base import InvocationResponse
+from llmeter.endpoints.bedrock import BedrockConverseStream
+
+
+def _make_draft_response() -> InvocationResponse:
+    return InvocationResponse(response_text=None, id=None)
+
+
+def _stream_response(stream_chunks: list[dict]) -> dict:
+    """Wrap stream chunks in the Bedrock ConverseStream response envelope."""
+    return {
+        "stream": stream_chunks,
+        "ResponseMetadata": {"RequestId": "req-123", "RetryAttempts": 0},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests: TTFT with ttft_visible_tokens_only=True (default)
+# ---------------------------------------------------------------------------
+
+
+class TestTTFTVisibleTokensOnly:
+    """When ttft_visible_tokens_only=True, reasoningContent deltas must not set TTFT."""
+
+    def test_reasoning_delta_ignored_for_ttft(self):
+        """reasoningContent delta should NOT set TTFT when visible_only=True."""
+        endpoint = BedrockConverseStream(model_id="test-model")
+
+        raw = _stream_response([
+            {"contentBlockDelta": {"delta": {"reasoningContent": {"text": "thinking..."}}}},
+            {"contentBlockDelta": {"delta": {"text": "Hello"}}},
+            {"contentBlockStop": {}},
+            {"metadata": {"usage": {"inputTokens": 10, "outputTokens": 5}}},
+        ])
+
+        response = _make_draft_response()
+        start_t = time.perf_counter()
+        endpoint.process_raw_response(raw, start_t, response)
+
+        assert response.time_to_first_token is not None
+        assert response.response_text == "Hello"
+
+    def test_multiple_reasoning_deltas_ignored(self):
+        """Multiple reasoningContent deltas should all be ignored for TTFT."""
+        endpoint = BedrockConverseStream(model_id="test-model")
+
+        raw = _stream_response([
+            {"contentBlockDelta": {"delta": {"reasoningContent": {"text": "step 1"}}}},
+            {"contentBlockDelta": {"delta": {"reasoningContent": {"text": "step 2"}}}},
+            {"contentBlockDelta": {"delta": {"text": "Answer"}}},
+            {"contentBlockStop": {}},
+            {"metadata": {"usage": {"inputTokens": 10, "outputTokens": 5}}},
+        ])
+
+        response = _make_draft_response()
+        start_t = time.perf_counter()
+        endpoint.process_raw_response(raw, start_t, response)
+
+        assert response.time_to_first_token is not None
+        assert response.response_text == "Answer"
+
+    def test_reasoning_deltas_do_not_contribute_to_response_text(self):
+        """reasoningContent deltas must never appear in response_text."""
+        endpoint = BedrockConverseStream(model_id="test-model")
+
+        raw = _stream_response([
+            {"contentBlockDelta": {"delta": {"reasoningContent": {"text": "internal thought"}}}},
+            {"contentBlockDelta": {"delta": {"text": "Visible"}}},
+            {"contentBlockDelta": {"delta": {"text": " answer"}}},
+            {"contentBlockStop": {}},
+            {"metadata": {"usage": {"inputTokens": 10, "outputTokens": 5}}},
+        ])
+
+        response = _make_draft_response()
+        endpoint.process_raw_response(raw, time.perf_counter(), response)
+
+        assert response.response_text == "Visible answer"
+
+    @patch("time.perf_counter")
+    def test_ttft_set_on_text_not_reasoning(self, mock_perf_counter):
+        """Verify TTFT value corresponds to the text delta, not the reasoning delta."""
+        start_t = 100.0
+        # Calls: reasoning_delta, text_delta, contentBlockStop, metadata
+        mock_perf_counter.side_effect = [100.3, 100.5, 100.6, 100.7]
+
+        endpoint = BedrockConverseStream(model_id="test-model")
+
+        raw = _stream_response([
+            {"contentBlockDelta": {"delta": {"reasoningContent": {"text": "thinking"}}}},
+            {"contentBlockDelta": {"delta": {"text": "Result"}}},
+            {"contentBlockStop": {}},
+            {"metadata": {"usage": {"inputTokens": 10, "outputTokens": 5}}},
+        ])
+
+        response = _make_draft_response()
+        endpoint.process_raw_response(raw, start_t, response)
+
+        # TTFT should be ~0.5 (text delta), not ~0.3 (reasoning delta)
+        assert abs(response.time_to_first_token - 0.5) < 1e-5
+
+
+# ---------------------------------------------------------------------------
+# Tests: TTFT with ttft_visible_tokens_only=False
+# ---------------------------------------------------------------------------
+
+
+class TestTTFTIncludesReasoning:
+    """When ttft_visible_tokens_only=False, first reasoningContent delta sets TTFT."""
+
+    def test_reasoning_delta_sets_ttft(self):
+        """reasoningContent delta should set TTFT when visible_only=False."""
+        endpoint = BedrockConverseStream(
+            model_id="test-model", ttft_visible_tokens_only=False
+        )
+
+        raw = _stream_response([
+            {"contentBlockDelta": {"delta": {"reasoningContent": {"text": "thinking..."}}}},
+            {"contentBlockDelta": {"delta": {"text": "Result"}}},
+            {"contentBlockStop": {}},
+            {"metadata": {"usage": {"inputTokens": 10, "outputTokens": 5}}},
+        ])
+
+        response = _make_draft_response()
+        start_t = time.perf_counter()
+        endpoint.process_raw_response(raw, start_t, response)
+
+        assert response.time_to_first_token is not None
+        assert response.time_to_first_token <= response.time_to_last_token
+        assert response.response_text == "Result"
+
+    def test_ttft_not_overwritten_by_later_text_delta(self):
+        """Once TTFT is set by reasoning delta, text delta must not overwrite it."""
+        endpoint = BedrockConverseStream(
+            model_id="test-model", ttft_visible_tokens_only=False
+        )
+
+        raw = _stream_response([
+            {"contentBlockDelta": {"delta": {"reasoningContent": {"text": "step 1"}}}},
+            {"contentBlockDelta": {"delta": {"reasoningContent": {"text": "step 2"}}}},
+            {"contentBlockDelta": {"delta": {"text": "Final"}}},
+            {"contentBlockStop": {}},
+            {"metadata": {"usage": {"inputTokens": 10, "outputTokens": 5}}},
+        ])
+
+        response = _make_draft_response()
+        start_t = time.perf_counter()
+        endpoint.process_raw_response(raw, start_t, response)
+
+        assert response.time_to_first_token is not None
+        assert response.time_to_first_token <= response.time_to_last_token
+
+    @patch("time.perf_counter")
+    def test_ttft_timing_set_on_reasoning_not_text(self, mock_perf_counter):
+        """Verify TTFT value corresponds to the reasoning delta, not the text delta."""
+        start_t = 100.0
+        # Calls: reasoning_delta, text_delta, contentBlockStop, metadata
+        mock_perf_counter.side_effect = [100.2, 100.5, 100.6, 100.7]
+
+        endpoint = BedrockConverseStream(
+            model_id="test-model", ttft_visible_tokens_only=False
+        )
+
+        raw = _stream_response([
+            {"contentBlockDelta": {"delta": {"reasoningContent": {"text": "thinking"}}}},
+            {"contentBlockDelta": {"delta": {"text": "Answer"}}},
+            {"contentBlockStop": {}},
+            {"metadata": {"usage": {"inputTokens": 10, "outputTokens": 5}}},
+        ])
+
+        response = _make_draft_response()
+        endpoint.process_raw_response(raw, start_t, response)
+
+        # TTFT should be ~0.2 (reasoning delta), not ~0.5 (text delta)
+        assert abs(response.time_to_first_token - 0.2) < 1e-5
+        assert abs(response.time_to_last_token - 0.6) < 1e-5
+
+    def test_only_reasoning_no_text(self):
+        """Stream with only reasoning deltas and no text — TTFT set, no response_text."""
+        endpoint = BedrockConverseStream(
+            model_id="test-model", ttft_visible_tokens_only=False
+        )
+
+        raw = _stream_response([
+            {"contentBlockDelta": {"delta": {"reasoningContent": {"text": "thinking"}}}},
+            {"contentBlockStop": {}},
+            {"metadata": {"usage": {"inputTokens": 10, "outputTokens": 0}}},
+        ])
+
+        response = _make_draft_response()
+        start_t = time.perf_counter()
+        endpoint.process_raw_response(raw, start_t, response)
+
+        assert response.time_to_first_token is not None
+        assert response.response_text is None

--- a/tests/unit/endpoints/test_openai_response_reasoning.py
+++ b/tests/unit/endpoints/test_openai_response_reasoning.py
@@ -1,0 +1,358 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for reasoning token parsing in OpenAIResponseStreamEndpoint.
+
+Covers:
+- TTFT measurement with ``ttft_visible_tokens_only=True`` (default): reasoning
+  deltas are ignored, TTFT set on first visible text delta.
+- TTFT measurement with ``ttft_visible_tokens_only=False``: TTFT set on first
+  reasoning delta (``response.reasoning_text.delta`` or
+  ``response.reasoning_summary_text.delta``).
+- ``num_tokens_output_reasoning`` extraction from ``output_tokens_details``.
+- ``num_tokens_input_cached`` extraction from ``input_tokens_details``.
+"""
+
+import time
+from unittest.mock import Mock, patch
+
+from llmeter.endpoints.base import InvocationResponse
+from llmeter.endpoints.openai_response import OpenAIResponseStreamEndpoint
+
+
+def _make_draft_response() -> InvocationResponse:
+    return InvocationResponse(response_text=None)
+
+
+def _event(event_type: str, **attrs) -> Mock:
+    """Build a mock streaming event with the given type and attributes."""
+    e = Mock()
+    e.type = event_type
+    for k, v in attrs.items():
+        setattr(e, k, v)
+    return e
+
+
+def _created_event(response_id: str = "resp_123") -> Mock:
+    resp = Mock()
+    resp.id = response_id
+    return _event("response.created", response=resp)
+
+
+def _text_delta_event(text: str) -> Mock:
+    return _event("response.output_text.delta", delta=text)
+
+
+def _reasoning_text_delta_event() -> Mock:
+    return _event("response.reasoning_text.delta", delta="thinking...")
+
+
+def _reasoning_summary_delta_event() -> Mock:
+    return _event("response.reasoning_summary_text.delta", delta="summary...")
+
+
+def _completed_event(
+    input_tokens: int = 10,
+    output_tokens: int = 20,
+    reasoning_tokens: int | None = None,
+    cached_tokens: int | None = None,
+) -> Mock:
+    usage = Mock()
+    usage.input_tokens = input_tokens
+    usage.output_tokens = output_tokens
+
+    if cached_tokens is not None:
+        details = Mock()
+        details.cached_tokens = cached_tokens
+        usage.input_tokens_details = details
+    else:
+        usage.input_tokens_details = None
+
+    if reasoning_tokens is not None:
+        output_details = Mock()
+        output_details.reasoning_tokens = reasoning_tokens
+        usage.output_tokens_details = output_details
+    else:
+        usage.output_tokens_details = None
+
+    resp = Mock()
+    resp.usage = usage
+    return _event("response.completed", response=resp)
+
+
+# ---------------------------------------------------------------------------
+# Tests: TTFT with ttft_visible_tokens_only=True (default)
+# ---------------------------------------------------------------------------
+
+
+class TestTTFTVisibleTokensOnly:
+    """When ttft_visible_tokens_only=True, reasoning deltas must not set TTFT."""
+
+    @patch("llmeter.endpoints.openai_response.OpenAI")
+    def test_reasoning_text_delta_ignored_for_ttft(self, mock_openai_class):
+        """response.reasoning_text.delta should NOT set TTFT."""
+        endpoint = OpenAIResponseStreamEndpoint(model_id="test-model")
+
+        events = [
+            _created_event(),
+            _reasoning_text_delta_event(),
+            _text_delta_event("Hello"),
+            _completed_event(reasoning_tokens=5),
+        ]
+
+        response = _make_draft_response()
+        start_t = time.perf_counter()
+        endpoint.process_raw_response(iter(events), start_t, response)
+
+        assert response.time_to_first_token is not None
+        assert response.response_text == "Hello"
+
+    @patch("llmeter.endpoints.openai_response.OpenAI")
+    def test_reasoning_summary_delta_ignored_for_ttft(self, mock_openai_class):
+        """response.reasoning_summary_text.delta should NOT set TTFT."""
+        endpoint = OpenAIResponseStreamEndpoint(model_id="test-model")
+
+        events = [
+            _created_event(),
+            _reasoning_summary_delta_event(),
+            _text_delta_event("World"),
+            _completed_event(reasoning_tokens=8),
+        ]
+
+        response = _make_draft_response()
+        start_t = time.perf_counter()
+        endpoint.process_raw_response(iter(events), start_t, response)
+
+        assert response.time_to_first_token is not None
+        assert response.response_text == "World"
+
+    @patch("llmeter.endpoints.openai_response.OpenAI")
+    def test_reasoning_deltas_do_not_contribute_to_response_text(
+        self, mock_openai_class
+    ):
+        """Reasoning deltas must never appear in response_text."""
+        endpoint = OpenAIResponseStreamEndpoint(model_id="test-model")
+
+        events = [
+            _created_event(),
+            _reasoning_text_delta_event(),
+            _reasoning_summary_delta_event(),
+            _text_delta_event("Answer"),
+            _completed_event(),
+        ]
+
+        response = _make_draft_response()
+        endpoint.process_raw_response(
+            iter(events), time.perf_counter(), response
+        )
+
+        assert response.response_text == "Answer"
+
+
+# ---------------------------------------------------------------------------
+# Tests: TTFT with ttft_visible_tokens_only=False
+# ---------------------------------------------------------------------------
+
+
+class TestTTFTIncludesReasoning:
+    """When ttft_visible_tokens_only=False, first reasoning delta sets TTFT."""
+
+    @patch("llmeter.endpoints.openai_response.OpenAI")
+    def test_reasoning_text_delta_sets_ttft(self, mock_openai_class):
+        """response.reasoning_text.delta should set TTFT when visible_only=False."""
+        endpoint = OpenAIResponseStreamEndpoint(
+            model_id="test-model", ttft_visible_tokens_only=False
+        )
+
+        events = [
+            _created_event(),
+            _reasoning_text_delta_event(),
+            _text_delta_event("Result"),
+            _completed_event(reasoning_tokens=5),
+        ]
+
+        response = _make_draft_response()
+        start_t = time.perf_counter()
+        endpoint.process_raw_response(iter(events), start_t, response)
+
+        assert response.time_to_first_token is not None
+        assert response.time_to_first_token <= response.time_to_last_token
+        assert response.response_text == "Result"
+
+    @patch("llmeter.endpoints.openai_response.OpenAI")
+    def test_reasoning_summary_delta_sets_ttft(self, mock_openai_class):
+        """response.reasoning_summary_text.delta should set TTFT when visible_only=False."""
+        endpoint = OpenAIResponseStreamEndpoint(
+            model_id="test-model", ttft_visible_tokens_only=False
+        )
+
+        events = [
+            _created_event(),
+            _reasoning_summary_delta_event(),
+            _text_delta_event("Result"),
+            _completed_event(reasoning_tokens=3),
+        ]
+
+        response = _make_draft_response()
+        start_t = time.perf_counter()
+        endpoint.process_raw_response(iter(events), start_t, response)
+
+        assert response.time_to_first_token is not None
+        assert response.time_to_first_token <= response.time_to_last_token
+        assert response.response_text == "Result"
+
+    @patch("llmeter.endpoints.openai_response.OpenAI")
+    def test_ttft_not_overwritten_by_later_text_delta(self, mock_openai_class):
+        """Once TTFT is set by a reasoning delta, a later text delta must not overwrite it."""
+        endpoint = OpenAIResponseStreamEndpoint(
+            model_id="test-model", ttft_visible_tokens_only=False
+        )
+
+        events = [
+            _created_event(),
+            _reasoning_text_delta_event(),
+            _reasoning_text_delta_event(),
+            _text_delta_event("Final"),
+            _completed_event(),
+        ]
+
+        response = _make_draft_response()
+        start_t = time.perf_counter()
+        endpoint.process_raw_response(iter(events), start_t, response)
+
+        # TTFT was set on the first reasoning delta; the text delta should not
+        # have changed it.
+        assert response.time_to_first_token is not None
+        assert response.time_to_first_token <= response.time_to_last_token
+
+    @patch("llmeter.endpoints.openai_response.OpenAI")
+    @patch("time.perf_counter")
+    def test_ttft_timing_set_on_reasoning_not_text(
+        self, mock_perf_counter, mock_openai_class
+    ):
+        """Verify TTFT value corresponds to the reasoning delta, not the text delta."""
+        start_t = 100.0
+        # Calls: created, reasoning_delta, text_delta, completed
+        mock_perf_counter.side_effect = [100.1, 100.2, 100.5, 100.6]
+
+        endpoint = OpenAIResponseStreamEndpoint(
+            model_id="test-model", ttft_visible_tokens_only=False
+        )
+
+        events = [
+            _created_event(),
+            _reasoning_text_delta_event(),
+            _text_delta_event("Answer"),
+            _completed_event(reasoning_tokens=10),
+        ]
+
+        response = _make_draft_response()
+        endpoint.process_raw_response(iter(events), start_t, response)
+
+        # TTFT should be ~0.2 (reasoning delta), not ~0.5 (text delta)
+        assert abs(response.time_to_first_token - 0.2) < 1e-5
+        assert abs(response.time_to_last_token - 0.5) < 1e-5
+
+
+# ---------------------------------------------------------------------------
+# Tests: num_tokens_output_reasoning extraction
+# ---------------------------------------------------------------------------
+
+
+class TestReasoningTokenCount:
+    """Verify num_tokens_output_reasoning is extracted from output_tokens_details."""
+
+    @patch("llmeter.endpoints.openai_response.OpenAI")
+    def test_reasoning_tokens_extracted(self, mock_openai_class):
+        endpoint = OpenAIResponseStreamEndpoint(model_id="test-model")
+
+        events = [
+            _created_event(),
+            _text_delta_event("Hi"),
+            _completed_event(
+                input_tokens=15,
+                output_tokens=25,
+                reasoning_tokens=12,
+            ),
+        ]
+
+        response = _make_draft_response()
+        endpoint.process_raw_response(
+            iter(events), time.perf_counter(), response
+        )
+
+        assert response.num_tokens_output_reasoning == 12
+        assert response.num_tokens_input == 15
+        assert response.num_tokens_output == 25
+
+    @patch("llmeter.endpoints.openai_response.OpenAI")
+    def test_reasoning_tokens_none_when_not_present(self, mock_openai_class):
+        """When output_tokens_details is absent, reasoning count stays None."""
+        endpoint = OpenAIResponseStreamEndpoint(model_id="test-model")
+
+        events = [
+            _created_event(),
+            _text_delta_event("Hi"),
+            _completed_event(
+                input_tokens=10,
+                output_tokens=20,
+                reasoning_tokens=None,
+            ),
+        ]
+
+        response = _make_draft_response()
+        endpoint.process_raw_response(
+            iter(events), time.perf_counter(), response
+        )
+
+        assert response.num_tokens_output_reasoning is None
+        assert response.num_tokens_output == 20
+
+    @patch("llmeter.endpoints.openai_response.OpenAI")
+    def test_cached_tokens_extracted(self, mock_openai_class):
+        """Verify input_tokens_details.cached_tokens is captured."""
+        endpoint = OpenAIResponseStreamEndpoint(model_id="test-model")
+
+        events = [
+            _created_event(),
+            _text_delta_event("Hi"),
+            _completed_event(
+                input_tokens=100,
+                output_tokens=20,
+                cached_tokens=80,
+            ),
+        ]
+
+        response = _make_draft_response()
+        endpoint.process_raw_response(
+            iter(events), time.perf_counter(), response
+        )
+
+        assert response.num_tokens_input_cached == 80
+        assert response.num_tokens_input == 100
+
+    @patch("llmeter.endpoints.openai_response.OpenAI")
+    def test_reasoning_and_cached_tokens_together(self, mock_openai_class):
+        """Both reasoning and cached token counts extracted in the same response."""
+        endpoint = OpenAIResponseStreamEndpoint(model_id="test-model")
+
+        events = [
+            _created_event(),
+            _text_delta_event("Hi"),
+            _completed_event(
+                input_tokens=100,
+                output_tokens=50,
+                reasoning_tokens=30,
+                cached_tokens=60,
+            ),
+        ]
+
+        response = _make_draft_response()
+        endpoint.process_raw_response(
+            iter(events), time.perf_counter(), response
+        )
+
+        assert response.num_tokens_output_reasoning == 30
+        assert response.num_tokens_input_cached == 60
+        assert response.num_tokens_input == 100
+        assert response.num_tokens_output == 50


### PR DESCRIPTION
## Summary

Add support for the Anthropic Messages API as a new LLMeter endpoint type.

Closes #62

## What's included

**New endpoint classes** (`llmeter/endpoints/anthropic_messages.py`):
- `AnthropicMessages` — non-streaming
- `AnthropicMessagesStream` — streaming with TTFT/TTLT measurement

Supports three providers via a single `provider` argument:
- `"anthropic"` — direct Anthropic API
- `"bedrock"` — `AnthropicBedrock` (InvokeModel-based)
- `"bedrock-mantle"` — `AnthropicBedrockMantle` (Messages API via Mantle)

**Dependencies** (`pyproject.toml`):
- `anthropic` optional extra (base SDK)
- `anthropic-bedrock` optional extra (`anthropic[bedrock]` for AWS auth)
- Added to `all` and `test` groups

**Tests**:
- 37 unit tests covering client construction, payload creation/parsing, response parsing, error handling, all three providers
- 3 integration tests against Bedrock Mantle (`us-east-1`, Opus 4.7)

**Docs**:
- API reference page + mkdocs nav entry

**Example notebook**:
- Compares TTFT between Converse API and Anthropic Messages API on Bedrock
- Uses a `NoCacheCallback` to defeat prompt caching

## Testing

```bash
# Unit tests
uv run pytest tests/unit/endpoints/test_anthropic_messages.py -v

# Integration tests (requires AWS credentials and Bedrock access)
uv run pytest tests/integ/test_anthropic_messages_bedrock.py -m integ -v
```