### PR TITLE
fix: prevent duplicate pages artifact on workflow re-run

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,6 +45,7 @@ jobs:
       uses: actions/upload-pages-artifact@v4
       with:
         path: site
+        overwrite: true
 
     - name: Deploy
       id: deploy


### PR DESCRIPTION
## Problem

When the docs workflow is re-run, `actions/upload-pages-artifact` creates a second `github-pages` artifact, causing `actions/deploy-pages` to fail with:

> Multiple artifacts named "github-pages" were unexpectedly found for this workflow run. Artifact count is 2.

## Fix

Add `overwrite: true` to the `upload-pages-artifact` step so that any existing artifact is replaced instead of creating a duplicate.