### PR TITLE
Fix loading timestamps from result & response files

### DIFF
--- a/llmeter/endpoints/base.py
+++ b/llmeter/endpoints/base.py
@@ -21,7 +21,7 @@ from uuid import uuid4
 from upath import UPath as Path
 from upath.types import ReadablePathLike, WritablePathLike
 
-from ..json_utils import llmeter_default_serializer
+from ..json_utils import llmeter_bytes_decoder, llmeter_default_serializer
 from ..utils import ensure_path
 
 logger = logging.getLogger(__name__)
@@ -66,6 +66,38 @@ class InvocationResponse:
     error: str | None = None
     retries: int | None = None
     request_time: datetime | None = None
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "InvocationResponse":
+        """Deserialize a JSON string into an `InvocationResponse`.
+
+        This is the inverse of [`to_json`][llmeter.endpoints.base.InvocationResponse.to_json]. It
+        correctly restores types that the default JSON round-trip would leave as strings or marker
+        objects:
+
+        * `request_time` is parsed from an ISO-8601 string back to a Python `datetime`
+        * `payload`s containing `bytes` (as `__llmeter_bytes__` markers) are correctly loaded back
+          as bytes.
+
+        Args:
+            json_str: A JSON string representation of an InvocationResponse (produced by `to_json`
+            or similar).
+
+        Returns:
+            InvocationResponse: The deserialized response.
+
+        Example:
+
+            ```python
+            original = InvocationResponse(response_text="hi", ...)
+            restored = InvocationResponse.from_json(original.to_json())
+            ```
+        """
+        data = json.loads(json_str, object_hook=llmeter_bytes_decoder)
+        rt = data.get("request_time")
+        if rt is not None and isinstance(rt, str):
+            data["request_time"] = datetime.fromisoformat(rt.replace("Z", "+00:00"))
+        return cls(**data)
 
     def to_json(self, default=llmeter_default_serializer, **kwargs) -> str:
         """Serialize this response to a JSON string.

--- a/llmeter/endpoints/base.py
+++ b/llmeter/endpoints/base.py
@@ -87,7 +87,7 @@ class InvocationResponse:
             InvocationResponse: The deserialized response.
 
         Example:
-
+            A round-trip can be run as follows:
             ```python
             original = InvocationResponse(response_text="hi", ...)
             restored = InvocationResponse.from_json(original.to_json())
@@ -102,15 +102,13 @@ class InvocationResponse:
     def to_json(self, default=llmeter_default_serializer, **kwargs) -> str:
         """Serialize this response to a JSON string.
 
-        Uses :func:`~llmeter.json_utils.llmeter_default_serializer` by default,
-        which handles ``bytes``, ``datetime``, ``PathLike``, and other common
-        non-serializable types.
+        Uses [`llmeter_default_serializer`][llmeter.json_utils.llmeter_default_serializer] by
+        default, which handles `bytes`, `datetime`, `PathLike`, and other common non-serializable
+        types.
 
         Args:
-            default: Fallback serializer passed to :func:`json.dumps`.
-                Defaults to :func:`~llmeter.json_utils.llmeter_default_serializer`.
-            **kwargs: Additional arguments passed to :func:`json.dumps`
-                (e.g., ``indent``, ``sort_keys``).
+            default: Fallback serializer passed to `json.dumps`.
+            **kwargs: Additional arguments passed to `json.dumps` (e.g., `indent`, `sort_keys`).
 
         Returns:
             str: JSON representation of the response.
@@ -144,22 +142,20 @@ class InvocationResponse:
             # default=str
         )
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
         """Return a dictionary representation of this response.
 
-        Returns a plain ``dict`` produced by :func:`dataclasses.asdict`,
-        preserving native Python types (e.g. ``datetime`` for
-        ``request_time``).  This is suitable for programmatic access —
-        for example :class:`~llmeter.utils.RunningStats` consumes this
-        output and relies on ``datetime`` comparisons and arithmetic.
+        Returns a plain `dict` produced by `dataclasses.asdict`, preserving native Python types
+        (e.g. `datetime` for `request_time`).  This is suitable for programmatic access — for
+        example [`RunningStats`][llmeter.utils.RunningStats] consumes this output and relies on
+        `datetime` comparisons and arithmetic.
 
-        For JSON output, use :meth:`to_json` which delegates to
-        :func:`~llmeter.json_utils.llmeter_default_serializer` for
-        non-serializable types, or pass the dict through
-        ``json.dumps(response.to_dict(), default=llmeter_default_serializer)``.
+        For JSON output, use [`to_json`][llmeter.endpoints.base.InvocationResponse.to_json], (which
+        delegates to [`llmeter_default_serializer`][llmeter.json_utils.llmeter_default_serializer]
+        by default, for non-JSON-serializable data types).
 
         Returns:
-            dict: A dictionary of response fields with native Python types.
+            dict: A dictionary of response fields native Python types.
         """
         return asdict(self)
 

--- a/llmeter/endpoints/base.py
+++ b/llmeter/endpoints/base.py
@@ -155,7 +155,7 @@ class InvocationResponse:
         by default, for non-JSON-serializable data types).
 
         Returns:
-            dict: A dictionary of response fields native Python types.
+            dict: A dictionary of response fields with native Python types.
         """
         return asdict(self)
 

--- a/llmeter/results.py
+++ b/llmeter/results.py
@@ -174,9 +174,7 @@ class Result:
             )
         responses_path = ensure_path(self.output_path) / "responses.jsonl"
         with responses_path.open("r") as f:
-            self.responses = [
-                InvocationResponse(**json.loads(line)) for line in f if line
-            ]
+            self.responses = [InvocationResponse.from_json(line) for line in f if line]
         logger.info("Loaded %d responses from %s", len(self.responses), responses_path)
         # Recompute stats from the freshly loaded responses
         self._preloaded_stats = self._compute_stats(self)
@@ -229,7 +227,9 @@ class Result:
         ]:
             if key in summary and summary[key] and isinstance(summary[key], str):
                 try:
-                    summary[key] = datetime.fromisoformat(summary[key])
+                    summary[key] = datetime.fromisoformat(
+                        summary[key].replace("Z", "+00:00")
+                    )
                 except ValueError:
                     pass
 
@@ -240,9 +240,7 @@ class Result:
         if load_responses:
             responses_path = result_path / "responses.jsonl"
             with responses_path.open("r") as f:
-                responses = [
-                    InvocationResponse(**json.loads(line)) for line in f if line
-                ]
+                responses = [InvocationResponse.from_json(line) for line in f if line]
         else:
             responses = []
             responses_path = result_path / "responses.jsonl"
@@ -273,7 +271,7 @@ class Result:
                         if val and isinstance(val, str):
                             try:
                                 result._preloaded_stats[key] = datetime.fromisoformat(
-                                    val
+                                    val.replace("Z", "+00:00")
                                 )
                             except ValueError:
                                 pass

--- a/tests/unit/test_invocation_response.py
+++ b/tests/unit/test_invocation_response.py
@@ -1,0 +1,178 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for InvocationResponse"""
+
+import json
+from datetime import datetime, timedelta, timezone
+
+from llmeter.endpoints.base import InvocationResponse
+from llmeter.json_utils import llmeter_default_serializer
+
+
+class TestToJson:
+    def test_full_response_to_json(self):
+        """A fully-populated InvocationResponse must serialize via to_json()."""
+        response = InvocationResponse(
+            id="resp-001",
+            response_text="The answer is 42.",
+            input_payload={"messages": [{"role": "user", "content": "What is 6*7?"}]},
+            input_prompt="What is 6*7?",
+            time_to_first_token=0.15,
+            time_to_last_token=0.85,
+            num_tokens_input=12,
+            num_tokens_output=5,
+            num_tokens_input_cached=4,
+            num_tokens_output_reasoning=2,
+            time_per_output_token=0.14,
+            error=None,
+            retries=0,
+            request_time=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        )
+        serialized = response.to_json()
+        assert isinstance(serialized, str)
+
+        parsed = json.loads(serialized)
+        assert isinstance(parsed, dict)
+        assert parsed["id"] == "resp-001"
+        assert parsed["response_text"] == "The answer is 42."
+        assert isinstance(parsed["input_payload"], dict)
+        assert parsed["input_prompt"] == "What is 6*7?"
+        assert parsed["time_to_first_token"] == 0.15
+        assert parsed["time_to_last_token"] == 0.85
+        assert parsed["num_tokens_input"] == 12
+        assert parsed["num_tokens_output"] == 5
+        assert parsed["num_tokens_input_cached"] == 4
+        assert parsed["num_tokens_output_reasoning"] == 2
+        assert parsed["time_per_output_token"] == 0.14
+        assert parsed["error"] is None
+        assert parsed["retries"] == 0
+        # ISO with 'Z' suffix:
+        assert parsed["request_time"] == "2026-01-01T12:00:00Z"
+
+    def test_error_response_to_json(self):
+        """Error responses with request_time must also serialize cleanly."""
+        response = InvocationResponse.error_output(
+            input_payload={"messages": []},
+            error="Connection timeout",
+            request_time=datetime.now(timezone.utc),
+        )
+        parsed = json.loads(response.to_json())
+        assert isinstance(parsed, dict)
+        assert parsed["error"] == "Connection timeout"
+
+    def test_save_request_time_with_offset(self):
+        """Maps local timestamps to UTC in saved files"""
+        response = InvocationResponse(
+            response_text="hi",
+            request_time=datetime(
+                2026, 1, 1, 12, 0, 0, tzinfo=timezone(timedelta(hours=8))
+            ),
+        )
+        parsed = json.loads(response.to_json())
+        assert parsed["request_time"] == "2026-01-01T04:00:00Z"
+
+
+class TestFromJson:
+    def test_round_trip_minimal(self):
+        original = InvocationResponse(response_text="hello")
+        restored = InvocationResponse.from_json(original.to_json())
+        assert restored.response_text == "hello"
+        assert restored.request_time is None
+
+    def test_round_trip_error_response(self):
+        dt = datetime(2026, 3, 1, 9, 0, 0, tzinfo=timezone.utc)
+        original = InvocationResponse.error_output(
+            input_payload={"messages": []},
+            error="Connection timeout",
+            request_time=dt,
+        )
+        restored = InvocationResponse.from_json(original.to_json())
+        assert restored.error == "Connection timeout"
+        assert restored.response_text is None
+        assert isinstance(restored.request_time, datetime)
+        assert restored.request_time == dt
+
+    def test_round_trip_all_fields(self):
+        dt = datetime(2026, 6, 15, 8, 30, 45, tzinfo=timezone.utc)
+        original = InvocationResponse(
+            id="resp-001",
+            response_text="The answer is 42.",
+            input_payload={"messages": [{"role": "user", "content": "What is 6*7?"}]},
+            input_prompt="What is 6*7?",
+            time_to_first_token=0.15,
+            time_to_last_token=0.85,
+            num_tokens_input=12,
+            num_tokens_output=5,
+            num_tokens_input_cached=4,
+            num_tokens_output_reasoning=2,
+            time_per_output_token=0.14,
+            error=None,
+            retries=0,
+            request_time=dt,
+        )
+        restored = InvocationResponse.from_json(original.to_json())
+
+        assert restored.id == original.id
+        assert restored.response_text == original.response_text
+        assert restored.input_payload == original.input_payload
+        assert restored.input_prompt == original.input_prompt
+        assert restored.time_to_first_token == original.time_to_first_token
+        assert restored.time_to_last_token == original.time_to_last_token
+        assert restored.num_tokens_input == original.num_tokens_input
+        assert restored.num_tokens_output == original.num_tokens_output
+        assert restored.num_tokens_input_cached == original.num_tokens_input_cached
+        assert (
+            restored.num_tokens_output_reasoning == original.num_tokens_output_reasoning
+        )
+        assert restored.time_per_output_token == original.time_per_output_token
+        assert restored.error == original.error
+        assert restored.retries == original.retries
+        assert restored.request_time == dt
+        assert isinstance(restored.request_time, datetime)
+
+    def test_load_request_time_with_offset(self):
+        json_str = json.dumps(
+            {"response_text": "hi", "request_time": "2026-01-01T14:00:00+02:00"},
+            default=llmeter_default_serializer,
+        )
+        restored = InvocationResponse.from_json(json_str)
+        assert isinstance(restored.request_time, datetime)
+        assert restored.request_time == datetime(
+            2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc
+        )
+
+    def test_round_trip_with_binary_payload(self):
+        original = InvocationResponse(
+            response_text="A cat",
+            input_payload={
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"text": "What is this?"},
+                            {
+                                "image": {
+                                    "format": "jpeg",
+                                    "source": {"bytes": b"\xff\xd8\xff\xe0"},
+                                }
+                            },
+                        ],
+                    }
+                ]
+            },
+        )
+        restored = InvocationResponse.from_json(original.to_json())
+        source_bytes = restored.input_payload["messages"][0]["content"][1]["image"][
+            "source"
+        ]["bytes"]
+        assert isinstance(source_bytes, bytes)
+        assert source_bytes == b"\xff\xd8\xff\xe0"
+
+    def test_no_bytes_marker_without_binary(self):
+        original = InvocationResponse(
+            response_text="hi",
+            input_payload={"prompt": "hello"},
+        )
+        restored = InvocationResponse.from_json(original.to_json())
+        assert restored.input_payload == {"prompt": "hello"}

--- a/tests/unit/test_invocation_response_integration.py
+++ b/tests/unit/test_invocation_response_integration.py
@@ -2,19 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Integration tests for InvocationResponse.to_dict() with its downstream consumers.
+Integration tests for InvocationResponse.to_dict() with RunningStats.
 
 These tests exercise the real pipeline:
     InvocationResponse.to_dict() → RunningStats.update() → to_stats()
 
 They ensure that any changes to to_dict() serialization remain compatible
-with RunningStats (which compares and subtracts request_time values) and
-with json.dumps() (for Lambda marshaling and other plain-JSON code paths).
+with RunningStats (which compares and subtracts request_time values).
 
 See: https://github.com/awslabs/llmeter/issues/67
 """
 
-import json
 from datetime import datetime, timezone
 
 import pytest
@@ -116,61 +114,3 @@ class TestToDictRunningStatsIntegration:
         assert isinstance(rs._last_send_time, datetime)
         assert rs._first_send_time == t1
         assert rs._last_send_time == t2
-
-
-# ── to_dict() → json.dumps() integration ────────────────────────────────────
-
-
-class TestToDictJsonIntegration:
-    """Verify that InvocationResponse.to_dict() output can be serialized to
-    JSON, either via to_json() or with llmeter_default_serializer."""
-
-    def test_to_json_with_request_time(self):
-        """to_json() must handle datetime request_time without error."""
-        response = _make_response(
-            request_time=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-        )
-        serialized = response.to_json()
-        parsed = json.loads(serialized)
-        assert isinstance(parsed["request_time"], str)
-
-    def test_to_json_round_trips_request_time(self):
-        """The serialized request_time should parse back to the same instant."""
-        dt = datetime(2026, 6, 15, 8, 30, 45, tzinfo=timezone.utc)
-        response = _make_response(request_time=dt)
-        parsed = json.loads(response.to_json())
-        restored = datetime.fromisoformat(
-            parsed["request_time"].replace("Z", "+00:00")
-        )
-        assert restored == dt
-
-    def test_error_response_to_json(self):
-        """Error responses with request_time must also serialize cleanly."""
-        response = InvocationResponse.error_output(
-            input_payload={"messages": []},
-            error="Connection timeout",
-            request_time=datetime.now(timezone.utc),
-        )
-        serialized = response.to_json()
-        assert isinstance(json.loads(serialized), dict)
-
-    def test_full_response_to_json(self):
-        """A fully-populated InvocationResponse must serialize via to_json()."""
-        response = InvocationResponse(
-            id="resp-001",
-            response_text="The answer is 42.",
-            input_payload={"messages": [{"role": "user", "content": "What is 6*7?"}]},
-            input_prompt="What is 6*7?",
-            time_to_first_token=0.15,
-            time_to_last_token=0.85,
-            num_tokens_input=12,
-            num_tokens_output=5,
-            num_tokens_input_cached=4,
-            num_tokens_output_reasoning=2,
-            time_per_output_token=0.14,
-            error=None,
-            retries=0,
-            request_time=datetime.now(timezone.utc),
-        )
-        serialized = response.to_json()
-        assert isinstance(json.loads(serialized), dict)

--- a/tests/unit/test_lazy_load.py
+++ b/tests/unit/test_lazy_load.py
@@ -175,6 +175,38 @@ class TestLoadResponsesOnDemand:
         with pytest.raises(FileNotFoundError):
             result.load_responses()
 
+    def test_load_responses_restores_request_time_as_datetime(self, tmp_path):
+        """load_responses() must parse request_time back to datetime, not leave as str."""
+        from datetime import datetime, timezone
+
+        dt = datetime(2025, 4, 10, 14, 30, 0, tzinfo=timezone.utc)
+        responses = [
+            InvocationResponse(
+                id="rt_lazy",
+                response_text="hello",
+                request_time=dt,
+                num_tokens_input=5,
+                num_tokens_output=3,
+            )
+        ]
+        result = Result(
+            responses=responses,
+            total_requests=1,
+            clients=1,
+            n_requests=1,
+            total_test_time=1.0,
+        )
+        output = UPath(tmp_path) / "rt_output"
+        result.save(output)
+
+        loaded = Result.load(output, load_responses=False)
+        assert loaded.responses == []
+
+        loaded.load_responses()
+        assert len(loaded.responses) == 1
+        assert isinstance(loaded.responses[0].request_time, datetime)
+        assert loaded.responses[0].request_time == dt
+
 
 # --- LoadTestResult.load with load_responses ---
 

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -313,6 +313,64 @@ def test_load_method(sample_result: Result, temp_dir: UPath):
         assert orig.num_tokens_input == loaded.num_tokens_input
 
 
+def test_load_restores_summary_datetimes(temp_dir: UPath):
+    """Result.load must parse Z-suffixed ISO-8601 strings back to datetime."""
+    from datetime import datetime, timezone
+
+    dt_start = datetime(2025, 6, 1, 10, 0, 0, tzinfo=timezone.utc)
+    dt_end = datetime(2025, 6, 1, 10, 5, 0, tzinfo=timezone.utc)
+    result = Result(
+        responses=sample_responses_successful[:2],
+        total_requests=2,
+        clients=1,
+        n_requests=2,
+        total_test_time=300.0,
+        start_time=dt_start,
+        end_time=dt_end,
+        first_request_time=dt_start,
+        last_request_time=dt_end,
+    )
+    output_path = temp_dir / "datetime_output"
+    result.save(output_path)
+
+    loaded = Result.load(output_path)
+    assert isinstance(loaded.start_time, datetime)
+    assert isinstance(loaded.end_time, datetime)
+    assert isinstance(loaded.first_request_time, datetime)
+    assert isinstance(loaded.last_request_time, datetime)
+    assert loaded.start_time == dt_start
+    assert loaded.end_time == dt_end
+
+
+def test_load_restores_response_request_time(temp_dir: UPath):
+    """Result.load must restore request_time on responses as datetime, not str."""
+    from datetime import datetime, timezone
+
+    dt = datetime(2025, 3, 15, 8, 30, 0, tzinfo=timezone.utc)
+    responses = [
+        InvocationResponse(
+            id="rt_test",
+            response_text="hello",
+            request_time=dt,
+            num_tokens_input=5,
+            num_tokens_output=3,
+        )
+    ]
+    result = Result(
+        responses=responses,
+        total_requests=1,
+        clients=1,
+        n_requests=1,
+        total_test_time=1.0,
+    )
+    output_path = temp_dir / "request_time_output"
+    result.save(output_path)
+
+    loaded = Result.load(output_path)
+    assert isinstance(loaded.responses[0].request_time, datetime)
+    assert loaded.responses[0].request_time == dt
+
+
 def test_save_method_no_output_path(sample_result: Result):
     with pytest.raises(ValueError, match="No output path provided"):
         sample_result.save()


### PR DESCRIPTION
**Issue #, if available:** Fixes #74

**Description of changes:**

1. Add an `InvocationResponse.from_json` class constructor to explicitly handle converting native types from saved JSON, including:
    - `request_time` as datetime
    - Potential `bytes` stored inside the `input_payload`
2. Update `Result.load` and `load_responses` methods to correctly deserialize InvocationResponses via this method
3. Fix instances (Result summary-level timestamp loading) where we were calling [`datetime.fromisoformat`](https://docs.python.org/3.11/library/datetime.html#datetime.datetime.fromisoformat) without explicitly catching and supporting the `Z` format - which needs to be guarded for Python 3.10 (but can be consumed directly by `fromisoformat` when we upgrade to 3.11+)
4. Tweaked some of the `InvocationResponse` docstrings which included formatting not supported by Zensical.

Added associated tests (passing), ran ruff format, and checked the docs build and look okay.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
