### PR TITLE
Fix README badge for supported Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![Latest Version](https://img.shields.io/pypi/v/llmeter.svg)](https://pypi.python.org/pypi/llmeter)
 [![Documentation: Online](https://img.shields.io/badge/Documentation-online-green)](https://awslabs.github.io/llmeter)
-[![Supported Python Versions](https://img.shields.io/pypi/pyversions/llmeter)](https://pypi.python.org/pypi/llmeter)
+[![Supported Python Versions](https://img.shields.io/badge/dynamic/json?query=info.requires_python&label=python&url=https%3A%2F%2Fpypi.org%2Fpypi%2Fllmeter%2Fjson)](https://pypi.python.org/pypi/llmeter)
 [![Code Style: Ruff](https://img.shields.io/badge/code_style-ruff-000000.svg)](https://github.com/astral-sh/ruff)
 
 </div>


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**

The supported Python versions badge on our README was showing as "missing" (presumably since the shift to UV?) because the badge backend depended on classifiers rather than the requires_python toml field we're using. Further discussion and source of the fix at: https://github.com/badges/shields/issues/5551#issuecomment-755503136

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
