### PR TITLE
Add user guide for callbacks

### DIFF
--- a/docs/user_guide/callbacks/cache_buster.md
+++ b/docs/user_guide/callbacks/cache_buster.md
@@ -1,0 +1,45 @@
+# Avoid Prompt Caching
+
+Many inference APIs implement some form of **implicit prompt caching**. With this feature, repeated calls whose prompt inputs are the same or share a common prefix can *re-use* part of the computation of previous ones - for faster responses.
+
+While that's great for performance in general, it could become an issue if the cache hit rate *for your test dataset is very different* than what you expect to see in production - as your test results would no longer be representative. This is especially likely if, for example, you're running a test that will repeat a very **small dataset** (maybe even a single payload) many times.
+
+If you're not able to generate a larger dataset, you could consider using a **cache busting callback** similar to the example below, to insert a randomised prefix before each invocation and avoid hitting your endpoint's implicit prompt cache:
+
+```python
+from uuid import uuid4
+from llmeter.callbacks import Callback
+
+class CacheBusterCallback(Callback):
+    """Add a unique prefix to each request to defeat prompt caching."""
+
+    @staticmethod
+    def _generate_prefix() -> str:
+        return f"[req-{uuid4()}] "
+
+    async def before_invoke(self, payload: dict) -> None:
+        tag = self._generate_prefix()
+
+        messages = payload.get("messages", [])
+        if not messages:
+            return
+
+        first_msg = messages[0]
+        content = first_msg.get("content")
+
+        # Messages API format: content is a plain string
+        if isinstance(content, str):
+            first_msg["content"] = tag + content
+            return
+
+        # Converse format: content is a list of blocks
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and "text" in block:
+                    block["text"] = tag + block["text"]
+                    return
+
+        # TODO: Other formats too?
+```
+
+This callback is not natively included in LLMeter today, because the payload manipulation logic is dependent on which Endpoint's being targeted. If you have ideas or a draft implementation that balances ease of use and maintainability across APIs, please let us know on GitHub! For now, you can use the example to implement a callback that suits your needs.

--- a/docs/user_guide/callbacks/cost.md
+++ b/docs/user_guide/callbacks/cost.md
@@ -1,0 +1,11 @@
+# Model and Compare Costs
+
+Comparing AI endpoints and models by inference speed alone is, of course, not particularly useful: A holistic evaluation should consider other factors including cost and the various different ways "quality" can be measured too.
+
+Unfortunately, pricing for AI inference is not as simple as common "dollars per input and output token" listings might first appear:
+- Many services offer multiple "service tiers", volume discounts, region-specific prices, or other private agreements
+- We'd often like to compare as-a-service APIs to other options like pay-per-GPU-hour infrastructure hosting services
+
+To provide the flexibility to model and compare these different pricing structures, LLMeter offers the [`CostModel`](../../reference/callbacks/cost/model/#llmeter.callbacks.cost.model.CostModel) callback and supporting classes in the [`llmeter.callbacks.cost` module](../../reference/callbacks/cost/).
+
+Check out the ["Model Costs" example notebook](https://github.com/awslabs/llmeter/blob/main/examples/Model%20Costs.ipynb) on GitHub for a full walkthrough of how LLMeter can help you attach cost metrics to and compare cost across your test results.

--- a/docs/user_guide/callbacks/cost.md
+++ b/docs/user_guide/callbacks/cost.md
@@ -3,6 +3,7 @@
 Comparing AI endpoints and models by inference speed alone is, of course, not particularly useful: A holistic evaluation should consider other factors including cost and the various different ways "quality" can be measured too.
 
 Unfortunately, pricing for AI inference is not as simple as common "dollars per input and output token" listings might first appear:
+
 - Many services offer multiple "service tiers", volume discounts, region-specific prices, or other private agreements
 - We'd often like to compare as-a-service APIs to other options like pay-per-GPU-hour infrastructure hosting services
 

--- a/docs/user_guide/callbacks/index.md
+++ b/docs/user_guide/callbacks/index.md
@@ -1,0 +1,38 @@
+# Extend LLMeter with Callbacks
+
+There's a lot more to performance testing beyond calling your LLM lots of times and capturing the speed of the responses... But to avoid bloating the performance-sensitive core of the library, LLMeter handles many of these more advanced or optional concerns via a **callback mechanism**.
+
+See the dedicated sections in this guide on how [built-in callbacks](../../reference/callbacks/) and standard patterns can help you to, for example:
+
+- [Avoid prompt caching](cache_buster.md) on your target Endpoint
+- [Model and compare the costs](cost.md) of different Endpoints
+- [Track your experiments](mlflow.md) with MLflow
+
+
+## Build your own custom callbacks
+
+You can implement custom callbacks to add your own functionality to LLMeter, by extending from the [`Callback`](../../reference/callbacks/base/#llmeter.callbacks.base.Callback) base class and implementing one or multiple of its standard methods:
+
+- [`before_run`](../../reference/callbacks/base/#llmeter.callbacks.base.Callback.before_run) is called before each test Run starts, and has the opportunity to inspect or modify the run configuration.
+- [`before_invoke`](../../reference/callbacks/base/#llmeter.callbacks.base.Callback.before_invoke) is called before each individual model invocation, and can inspect or modify the request payload.
+- [`after_invoke`](../../reference/callbacks/base/#llmeter.callbacks.base.Callback.after_invoke) is called after each model invocation, and can inspect or modify the `InvocationResponse`.
+- [`after_run`](../../reference/callbacks/base/#llmeter.callbacks.base.Callback.after_run) is called after each test Run completes, and can inspect or modify the run `Result`.
+
+Callbacks are processed outside of the timing of invocations, and `before_run` and `after_run` callbacks are processed outside of the timing of the overall run. However, it's important to remember that slow callbacks could still affect the overall volume of traffic that LLMeter is able to drive - and that the backlog of `after_invoke` callbacks must be cleared before a run is considered ended.
+
+You can specify one or multiple callbacks when setting up your Runner, as below:
+
+```python
+runner = Runner(
+    endpoint,
+    output_path=f"outputs/{endpoint.model_id}",
+    callbacks=[MlflowCallback(), MyCoolCallback()],
+)
+results = await runner.run(
+    payload=sample_payloads,
+    n_requests=10,
+    clients=10,
+)
+```
+
+Each callback will be processed in the **same order** as you provide them to the runner. This is important to remember and configure properly, if you're stacking multiple callbacks that access the same data (for example - transforming an invocation response *then* logging/exporting it somewhere, both using `after_invoke`).

--- a/docs/user_guide/callbacks/index.md
+++ b/docs/user_guide/callbacks/index.md
@@ -13,12 +13,12 @@ See the dedicated sections in this guide on how [built-in callbacks](../../refer
 
 You can implement custom callbacks to add your own functionality to LLMeter, by extending from the [`Callback`](../../reference/callbacks/base/#llmeter.callbacks.base.Callback) base class and implementing one or multiple of its standard methods:
 
-- [`before_run`](../../reference/callbacks/base/#llmeter.callbacks.base.Callback.before_run) is called before each test Run starts, and has the opportunity to inspect or modify the run configuration.
+- [`before_run`](../../reference/callbacks/base/#llmeter.callbacks.base.Callback.before_run) is called before each test Run starts, and has the opportunity to inspect or modify the Run configuration.
 - [`before_invoke`](../../reference/callbacks/base/#llmeter.callbacks.base.Callback.before_invoke) is called before each individual model invocation, and can inspect or modify the request payload.
 - [`after_invoke`](../../reference/callbacks/base/#llmeter.callbacks.base.Callback.after_invoke) is called after each model invocation, and can inspect or modify the `InvocationResponse`.
-- [`after_run`](../../reference/callbacks/base/#llmeter.callbacks.base.Callback.after_run) is called after each test Run completes, and can inspect or modify the run `Result`.
+- [`after_run`](../../reference/callbacks/base/#llmeter.callbacks.base.Callback.after_run) is called after each test Run completes, and can inspect or modify the Run `Result`.
 
-Callbacks are processed outside of the timing of invocations, and `before_run` and `after_run` callbacks are processed outside of the timing of the overall run. However, it's important to remember that slow callbacks could still affect the overall volume of traffic that LLMeter is able to drive - and that the backlog of `after_invoke` callbacks must be cleared before a run is considered ended.
+Callbacks are processed outside of the timing of invocations, and `before_run` and `after_run` callbacks are processed outside of the timing of the overall Run. However, it's important to remember that slow callbacks could still affect the maximum volume of traffic that LLMeter is able to drive - and that the backlog of `after_invoke` callbacks must be cleared before a Run is considered ended.
 
 You can specify one or multiple callbacks when setting up your Runner, as below:
 

--- a/docs/user_guide/callbacks/mlflow.md
+++ b/docs/user_guide/callbacks/mlflow.md
@@ -1,0 +1,9 @@
+# Track Experiments with MLflow
+
+When running many different tests or experiments, you'll likely be interested to set up a tool in which to compare, sort, search, plot, and log the results.
+
+[MLflow](https://mlflow.org/) is one tool already used by many data science teams for experiment tracking in general, and AWS offers [fully-managed, serverless MLflow on Amazon SageMaker](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow.html).
+
+Wherever your MLflow tracking server is hosted, you can use LLMeter's built-in [`MlflowCallback`](../../reference/callbacks/mlflow/#llmeter.callbacks.mlflow.MlflowCallback) to log your Run input parameters and output metrics to MLflow experiment runs.
+
+Just set up MLflow as usual in your script, before running your LLMeter `Runner`. You can find client setup guidance for MLflow on Amazon SageMaker [in its developer guide](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow-track-experiments.html).

--- a/docs/user_guide/callbacks/mlflow.md
+++ b/docs/user_guide/callbacks/mlflow.md
@@ -7,3 +7,6 @@ When running many different tests or experiments, you'll likely be interested to
 Wherever your MLflow tracking server is hosted, you can use LLMeter's built-in [`MlflowCallback`](../../reference/callbacks/mlflow/#llmeter.callbacks.mlflow.MlflowCallback) to log your Run input parameters and output metrics to MLflow experiment runs.
 
 Just set up MLflow as usual in your script, before running your LLMeter `Runner`. You can find client setup guidance for MLflow on Amazon SageMaker [in its developer guide](https://docs.aws.amazon.com/sagemaker/latest/dg/mlflow-track-experiments.html).
+
+!!! tip "Logging callback-contributed stats"
+    If you're using some other callback that contributes statistics to the Run Result via an `after_run` hook, and you want those statistics to be reflected in your MLflow experiments, remember to include the `MlflowCallback` **after** your other stat-contributing callbacks - not before!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,11 @@ nav:
     - Metrics and Statistics: user_guide/metrics.md
     - Connect to Endpoints: user_guide/connect_endpoints.md
     - Run Experiments: user_guide/run_experiments.md
+    - Callback-Powered Features:
+      - user_guide/callbacks/index.md
+      - user_guide/callbacks/cache_buster.md
+      - user_guide/callbacks/cost.md
+      - user_guide/callbacks/mlflow.md
   - API Reference:
     - reference/index.md
     - callbacks:


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**

Add an initial user guide for callbacks - mostly because I wanted the CacheBuster pattern to be documented somewhere, but don't think our draft implementation's quite ready for library inclusion yet... Difficult to see how we should implement it without bringing in a load of endpoint-specific logic.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
