### PR TITLE
fix: gracefully save/load interrupted runs

### DIFF
--- a/llmeter/results.py
+++ b/llmeter/results.py
@@ -377,10 +377,25 @@ class Result:
                 responses_path,
             )
 
+        # Derive timing info from response request_time timestamps
+        first_request_time = None
+        last_request_time = None
+        if responses:
+            request_times = [
+                r.request_time for r in responses if r.request_time is not None
+            ]
+            if request_times:
+                first_request_time = min(request_times)
+                last_request_time = max(request_times)
+
         result = cls(
             responses=responses,
             total_requests=len(responses) if responses else None,
             output_path=str(result_path),
+            start_time=first_request_time,
+            first_request_time=first_request_time,
+            last_request_time=last_request_time,
+            end_time=last_request_time,
             **config_info,
         )
 

--- a/llmeter/results.py
+++ b/llmeter/results.py
@@ -215,6 +215,9 @@ class Result:
         result_path = ensure_path(result_path)
         summary_path = result_path / "summary.json"
 
+        if not summary_path.exists():
+            return cls._load_without_summary(result_path, load_responses)
+
         with summary_path.open("r") as g:
             summary = json.load(g)
 
@@ -292,6 +295,128 @@ class Result:
                     if key not in result._preloaded_stats:
                         result._preloaded_stats[key] = value
 
+        return result
+
+    @classmethod
+    def _load_without_summary(
+        cls, result_path, load_responses: bool = True
+    ) -> "Result":
+        """Reconstruct a Result from an incomplete run directory (no summary.json).
+
+        This handles the case where a run was interrupted (e.g. Ctrl+C) before
+        ``summary.json`` could be written. It reconstructs what it can from
+        whatever files are available:
+
+        - ``responses.jsonl``: Individual invocation responses (main data source)
+        - ``run_config.json``: Run configuration (endpoint, payload, clients, etc.)
+        - ``stats.json``: Pre-computed statistics (if available)
+
+        Args:
+            result_path: Path to the run output directory.
+            load_responses: Whether to load individual responses into memory.
+
+        Returns:
+            A ``Result`` instance reconstructed from available files.
+
+        Raises:
+            FileNotFoundError: If neither ``responses.jsonl`` nor ``stats.json``
+                exist at the given path (no useful data to recover).
+        """
+        result_path = ensure_path(result_path)
+        responses_path = result_path / "responses.jsonl"
+        config_path = result_path / "run_config.json"
+        stats_path = result_path / "stats.json"
+
+        # We need at least responses or stats to reconstruct anything useful
+        if not responses_path.exists() and not stats_path.exists():
+            raise FileNotFoundError(
+                f"Cannot recover run from '{result_path}': neither 'summary.json' "
+                "nor 'responses.jsonl' or 'stats.json' were found. "
+                "There is no data to recover."
+            )
+
+        # Extract what we can from run_config.json
+        config_info: dict[str, Any] = {}
+        if config_path.exists():
+            try:
+                with config_path.open("r") as f:
+                    config = json.load(f)
+                # Pull relevant fields from the run config
+                if "clients" in config:
+                    config_info["clients"] = config["clients"]
+                if "n_requests" in config:
+                    config_info["n_requests"] = config["n_requests"]
+                if "run_name" in config:
+                    config_info["run_name"] = config["run_name"]
+                if "run_description" in config:
+                    config_info["run_description"] = config["run_description"]
+                # Extract endpoint info
+                endpoint = config.get("endpoint", {})
+                if isinstance(endpoint, dict):
+                    config_info["model_id"] = endpoint.get("model_id")
+                    config_info["endpoint_name"] = endpoint.get("endpoint_name")
+                    config_info["provider"] = endpoint.get("provider")
+            except (json.JSONDecodeError, KeyError) as e:
+                logger.warning(f"Could not parse run_config.json: {e}")
+
+        # Load responses if available and requested
+        responses: list[InvocationResponse] = []
+        if load_responses and responses_path.exists():
+            with responses_path.open("r") as f:
+                responses = [InvocationResponse.from_json(line) for line in f if line]
+            logger.info(
+                "Recovered %d responses from interrupted run at %s",
+                len(responses),
+                result_path,
+            )
+        elif not load_responses and responses_path.exists():
+            logger.info(
+                "Recovered run metadata from interrupted run at %s. "
+                "Call result.load_responses() to load %s.",
+                result_path,
+                responses_path,
+            )
+
+        result = cls(
+            responses=responses,
+            total_requests=len(responses) if responses else None,
+            output_path=str(result_path),
+            **config_info,
+        )
+
+        # Load or compute stats
+        if stats_path.exists():
+            try:
+                with stats_path.open("r") as s:
+                    result._preloaded_stats = json.loads(s.read())
+                # Convert datetime strings in stats
+                for key in [
+                    "start_time",
+                    "end_time",
+                    "first_request_time",
+                    "last_request_time",
+                ]:
+                    val = result._preloaded_stats.get(key)
+                    if val and isinstance(val, str):
+                        try:
+                            result._preloaded_stats[key] = datetime.fromisoformat(
+                                val.replace("Z", "+00:00")
+                            )
+                        except ValueError:
+                            pass
+            except (json.JSONDecodeError, OSError) as e:
+                logger.warning(f"Could not load stats.json: {e}")
+                result._preloaded_stats = None
+        elif responses:
+            # Compute stats from loaded responses
+            result._preloaded_stats = cls._compute_stats(result)
+        else:
+            result._preloaded_stats = None
+
+        logger.warning(
+            "Loaded result from interrupted run (no summary.json). "
+            "Some metadata may be incomplete."
+        )
         return result
 
     @classmethod

--- a/llmeter/results.py
+++ b/llmeter/results.py
@@ -216,10 +216,10 @@ class Result:
         """
         Load run results from disk or cloud storage.
 
-        Reads previously saved run results from the specified
-        path. It expects 'summary.json' to be present in the given directory.
-        By default, also loads 'responses.jsonl' containing individual invocation
-        responses.
+        Reads previously saved run results from the specified path. Handles
+        both complete runs (with ``summary.json``) and interrupted runs where
+        only ``responses.jsonl``, ``run_config.json``, or ``stats.json`` are
+        available.
 
         Args:
             result_path (UPath | str): The path to the directory containing the
@@ -235,77 +235,63 @@ class Result:
             responses and summary data.
 
         Raises:
-            FileNotFoundError: If required files are not found in the specified
-                directory.
-            JSONDecodeError: If there's an issue parsing the JSON data in
-                either file.
-
+            FileNotFoundError: If the directory does not exist or contains no
+                recognizable result files (``summary.json``, ``responses.jsonl``,
+                or ``stats.json``).
+            JSONDecodeError: If ``summary.json`` cannot be parsed.
         """
         result_path = ensure_path(result_path)
         summary_path = result_path / "summary.json"
 
-        if not summary_path.exists():
-            return cls._load_without_summary(result_path, load_responses)
-
-        with summary_path.open("r") as g:
-            summary = json.load(g)
-
-        cls._parse_datetime_fields(summary)
-
-        # Ensure output_path is set so load_responses() can find the files later
-        if "output_path" not in summary or summary["output_path"] is None:
-            summary["output_path"] = str(result_path)
-
-        if load_responses:
-            responses_path = result_path / "responses.jsonl"
-            with responses_path.open("r") as f:
-                responses = [InvocationResponse.from_json(line) for line in f if line]
+        # 1. Resolve metadata
+        if summary_path.exists():
+            metadata = cls._load_summary(result_path)
         else:
-            responses = []
-            responses_path = result_path / "responses.jsonl"
+            metadata = cls._recover_metadata(result_path)
+
+        # 2. Load responses (if requested and available)
+        responses = cls._read_responses(result_path) if load_responses else []
+        if not load_responses:
             logger.info(
                 "Loaded summary only (responses not loaded). "
-                "Individual responses are stored at: %s. "
                 "Call result.load_responses() to load them on demand.",
-                responses_path,
             )
 
-        result = cls(responses=responses, **summary)
-        stats_path = result_path / "stats.json"
-        cls._resolve_stats(result, stats_path)
+        # 3. Construct and resolve stats
+        result = cls(responses=responses, **metadata)
+        cls._resolve_stats(result, result_path / "stats.json")
         return result
 
     @classmethod
-    def _load_without_summary(
-        cls, result_path, load_responses: bool = True
-    ) -> "Result":
-        """Reconstruct a Result from an incomplete run directory (no summary.json).
+    def _load_summary(cls, result_path) -> dict[str, Any]:
+        """Load metadata from a complete run directory (has ``summary.json``)."""
+        summary_path = result_path / "summary.json"
+        with summary_path.open("r") as f:
+            summary = json.load(f)
 
-        This handles the case where a run was interrupted (e.g. Ctrl+C) before
-        ``summary.json`` could be written. It reconstructs what it can from
-        whatever files are available:
+        cls._parse_datetime_fields(summary)
 
-        - ``responses.jsonl``: Individual invocation responses (main data source)
-        - ``run_config.json``: Run configuration (endpoint, payload, clients, etc.)
-        - ``stats.json``: Pre-computed statistics (if available)
+        if "output_path" not in summary or summary["output_path"] is None:
+            summary["output_path"] = str(result_path)
 
-        Args:
-            result_path: Path to the run output directory.
-            load_responses: Whether to load individual responses into memory.
+        return summary
 
-        Returns:
-            A ``Result`` instance reconstructed from available files.
+    @classmethod
+    def _recover_metadata(cls, result_path) -> dict[str, Any]:
+        """Recover metadata from an incomplete run directory (no ``summary.json``).
+
+        Reconstructs what it can from ``run_config.json`` and, if responses are
+        readable, their timestamps. Falls back gracefully when files are missing
+        or corrupt.
 
         Raises:
             FileNotFoundError: If neither ``responses.jsonl`` nor ``stats.json``
-                exist at the given path (no useful data to recover).
+                exist (no useful data to recover).
         """
-        result_path = ensure_path(result_path)
         responses_path = result_path / "responses.jsonl"
         config_path = result_path / "run_config.json"
         stats_path = result_path / "stats.json"
 
-        # We need at least responses or stats to reconstruct anything useful
         if not responses_path.exists() and not stats_path.exists():
             raise FileNotFoundError(
                 f"Cannot recover run from '{result_path}': neither 'summary.json' "
@@ -313,77 +299,78 @@ class Result:
                 "There is no data to recover."
             )
 
+        metadata: dict[str, Any] = {"output_path": str(result_path)}
+
         # Extract what we can from run_config.json
-        config_info: dict[str, Any] = {}
         if config_path.exists():
             try:
                 with config_path.open("r") as f:
                     config = json.load(f)
-                # Pull relevant fields from the run config
-                if "clients" in config:
-                    config_info["clients"] = config["clients"]
-                if "n_requests" in config:
-                    config_info["n_requests"] = config["n_requests"]
-                if "run_name" in config:
-                    config_info["run_name"] = config["run_name"]
-                if "run_description" in config:
-                    config_info["run_description"] = config["run_description"]
-                # Extract endpoint info
+                for passthru_field in (
+                    "clients",
+                    "n_requests",
+                    "run_name",
+                    "run_description",
+                ):
+                    if passthru_field in config:
+                        metadata[passthru_field] = config[passthru_field]
                 endpoint = config.get("endpoint", {})
                 if isinstance(endpoint, dict):
-                    config_info["model_id"] = endpoint.get("model_id")
-                    config_info["endpoint_name"] = endpoint.get("endpoint_name")
-                    config_info["provider"] = endpoint.get("provider")
+                    metadata["model_id"] = endpoint.get("model_id")
+                    metadata["endpoint_name"] = endpoint.get("endpoint_name")
+                    metadata["provider"] = endpoint.get("provider")
             except (json.JSONDecodeError, KeyError) as e:
                 logger.warning(f"Could not parse run_config.json: {e}")
 
-        # Load responses if available and requested
-        responses: list[InvocationResponse] = []
-        if load_responses and responses_path.exists():
-            with responses_path.open("r") as f:
-                responses = [InvocationResponse.from_json(line) for line in f if line]
-            logger.info(
-                "Recovered %d responses from interrupted run at %s",
-                len(responses),
-                result_path,
-            )
-        elif not load_responses and responses_path.exists():
-            logger.info(
-                "Recovered run metadata from interrupted run at %s. "
-                "Call result.load_responses() to load %s.",
-                result_path,
-                responses_path,
-            )
-
-        # Derive timing info from response request_time timestamps
-        first_request_time = None
-        last_request_time = None
-        if responses:
-            request_times = [
-                r.request_time for r in responses if r.request_time is not None
-            ]
-            if request_times:
-                first_request_time = min(request_times)
-                last_request_time = max(request_times)
-
-        result = cls(
-            responses=responses,
-            total_requests=len(responses) if responses else None,
-            output_path=str(result_path),
-            start_time=first_request_time,
-            first_request_time=first_request_time,
-            last_request_time=last_request_time,
-            end_time=last_request_time,
-            **config_info,
-        )
-
-        cls._resolve_stats(result, stats_path)
+        # Derive timing info and count by streaming through responses
+        if responses_path.exists():
+            try:
+                first = None
+                last = None
+                count = 0
+                with responses_path.open("r") as f:
+                    for line in f:
+                        if not line:
+                            continue
+                        count += 1
+                        resp = InvocationResponse.from_json(line)
+                        if resp.request_time is not None:
+                            if first is None or resp.request_time < first:
+                                first = resp.request_time
+                            if last is None or resp.request_time > last:
+                                last = resp.request_time
+                if first is not None:
+                    metadata.update(
+                        start_time=first,
+                        first_request_time=first,
+                        last_request_time=last,
+                        end_time=last,
+                    )
+                metadata["total_requests"] = count
+            except OSError as e:
+                logger.warning(f"Could not read responses.jsonl for timestamps: {e}")
 
         logger.warning(
             "Loaded result from interrupted run (no summary.json). "
             "Some metadata may be incomplete."
         )
-        return result
+        return metadata
+
+    @classmethod
+    def _read_responses(cls, result_path) -> list[InvocationResponse]:
+        """Read responses.jsonl, returning an empty list if the file is missing."""
+        responses_path = result_path / "responses.jsonl"
+        if not responses_path.exists():
+            logger.warning(
+                "responses.jsonl not found at %s. "
+                "Responses will be empty; stats may come from stats.json.",
+                result_path,
+            )
+            return []
+        with responses_path.open("r") as f:
+            responses = [InvocationResponse.from_json(line) for line in f if line]
+        logger.info("Loaded %d responses from %s", len(responses), responses_path)
+        return responses
 
     @classmethod
     def _resolve_stats(cls, result: "Result", stats_path) -> None:

--- a/llmeter/results.py
+++ b/llmeter/results.py
@@ -3,7 +3,8 @@
 
 import json
 import logging
-from dataclasses import asdict, dataclass
+import types as _types
+from dataclasses import asdict, dataclass, fields
 from datetime import datetime
 from numbers import Number
 from typing import Any, Sequence
@@ -16,6 +17,16 @@ from .json_utils import llmeter_default_serializer
 from .utils import ensure_path, summary_stats_from_list
 
 logger = logging.getLogger(__name__)
+
+
+def _get_type_args(tp) -> tuple:
+    """Return the members of a union type (e.g. ``datetime | None`` -> (datetime, NoneType))."""
+    if isinstance(tp, _types.UnionType):
+        return tp.__args__
+    origin = getattr(tp, "__origin__", None)
+    if origin is _types.UnionType:
+        return tp.__args__
+    return (tp,) if isinstance(tp, type) else ()
 
 
 @dataclass
@@ -47,6 +58,24 @@ class Result:
         if not hasattr(self, "_preloaded_stats"):
             self._preloaded_stats = None
 
+    @classmethod
+    def _parse_datetime_fields(cls, d: dict) -> None:
+        """Convert any datetime fields on cls present in d from ISO-8601 strings to datetimes
+
+        Introspects this (data)class to find all `datetime`-typed fields, and converts any matching
+        entries in `d` with ISO-8601 string values to datetimes instead. This is used for loading
+        JSON data (in which dates are stringified) into the Result class or stats.
+        """
+        for f in fields(cls):
+            if datetime not in _get_type_args(f.type):
+                continue
+            val = d.get(f.name)
+            if val and isinstance(val, str):
+                try:
+                    d[f.name] = datetime.fromisoformat(val.replace("Z", "+00:00"))
+                except ValueError:
+                    pass
+
     def _update_contributed_stats(self, stats: dict[str, Number]):
         """
         Upsert externally-provided statistics for the `stats` property
@@ -62,7 +91,7 @@ class Result:
                 )
         self._contributed_stats.update(stats)
 
-    def save(self, output_path: WritablePathLike | None = None):
+    def save(self, output_path: WritablePathLike | None = None) -> None:
         """
         Save the results to disk or cloud storage.
 
@@ -113,7 +142,7 @@ class Result:
                         + "\n"
                     )
 
-    def to_json(self, default=llmeter_default_serializer, **kwargs):
+    def to_json(self, default=llmeter_default_serializer, **kwargs) -> str:
         """Return the results as a JSON string.
 
         Args:
@@ -126,7 +155,7 @@ class Result:
         }
         return json.dumps(summary, default=default, **kwargs)
 
-    def to_dict(self, include_responses: bool = False):
+    def to_dict(self, include_responses: bool = False) -> dict:
         """Return a dictionary representation of this result.
 
         Returns a plain ``dict`` produced by :func:`dataclasses.asdict`,
@@ -221,20 +250,7 @@ class Result:
         with summary_path.open("r") as g:
             summary = json.load(g)
 
-        # Convert datetime strings back to datetime objects
-        for key in [
-            "start_time",
-            "end_time",
-            "first_request_time",
-            "last_request_time",
-        ]:
-            if key in summary and summary[key] and isinstance(summary[key], str):
-                try:
-                    summary[key] = datetime.fromisoformat(
-                        summary[key].replace("Z", "+00:00")
-                    )
-                except ValueError:
-                    pass
+        cls._parse_datetime_fields(summary)
 
         # Ensure output_path is set so load_responses() can find the files later
         if "output_path" not in summary or summary["output_path"] is None:
@@ -255,46 +271,8 @@ class Result:
             )
 
         result = cls(responses=responses, **summary)
-
-        # Load or compute stats
-        if not load_responses:
-            # Use pre-computed stats from disk when responses aren't loaded
-            stats_path = result_path / "stats.json"
-            if stats_path.exists():
-                with stats_path.open("r") as s:
-                    result._preloaded_stats = json.loads(s.read())
-                    # Convert datetime strings in stats
-                    for key in [
-                        "start_time",
-                        "end_time",
-                        "first_request_time",
-                        "last_request_time",
-                    ]:
-                        val = result._preloaded_stats.get(key)
-                        if val and isinstance(val, str):
-                            try:
-                                result._preloaded_stats[key] = datetime.fromisoformat(
-                                    val.replace("Z", "+00:00")
-                                )
-                            except ValueError:
-                                pass
-            else:
-                result._preloaded_stats = None
-        else:
-            # Compute stats from the loaded responses, but also merge any
-            # contributed stats that were persisted in stats.json so they
-            # survive a save/load round-trip.
-            result._preloaded_stats = cls._compute_stats(result)
-            stats_path = result_path / "stats.json"
-            if stats_path.exists():
-                with stats_path.open("r") as s:
-                    saved_stats = json.loads(s.read())
-                # Contributed stats are any keys in the saved file that are
-                # not produced by _compute_stats (i.e. they came from callbacks).
-                for key, value in saved_stats.items():
-                    if key not in result._preloaded_stats:
-                        result._preloaded_stats[key] = value
-
+        stats_path = result_path / "stats.json"
+        cls._resolve_stats(result, stats_path)
         return result
 
     @classmethod
@@ -399,40 +377,53 @@ class Result:
             **config_info,
         )
 
-        # Load or compute stats
-        if stats_path.exists():
-            try:
-                with stats_path.open("r") as s:
-                    result._preloaded_stats = json.loads(s.read())
-                # Convert datetime strings in stats
-                for key in [
-                    "start_time",
-                    "end_time",
-                    "first_request_time",
-                    "last_request_time",
-                ]:
-                    val = result._preloaded_stats.get(key)
-                    if val and isinstance(val, str):
-                        try:
-                            result._preloaded_stats[key] = datetime.fromisoformat(
-                                val.replace("Z", "+00:00")
-                            )
-                        except ValueError:
-                            pass
-            except (json.JSONDecodeError, OSError) as e:
-                logger.warning(f"Could not load stats.json: {e}")
-                result._preloaded_stats = None
-        elif responses:
-            # Compute stats from loaded responses
-            result._preloaded_stats = cls._compute_stats(result)
-        else:
-            result._preloaded_stats = None
+        cls._resolve_stats(result, stats_path)
 
         logger.warning(
             "Loaded result from interrupted run (no summary.json). "
             "Some metadata may be incomplete."
         )
         return result
+
+    @classmethod
+    def _resolve_stats(cls, result: "Result", stats_path) -> None:
+        """Resolve ``_preloaded_stats`` for a freshly loaded Result.
+
+        Unifies the stats-loading logic used by :meth:`load` and
+        :meth:`_load_without_summary`. The resolution strategy is:
+
+        - **responses populated**: Compute stats from the in-memory responses
+          (authoritative), then merge any *contributed* stats (callback-injected
+          keys not produced by ``_compute_stats``) from ``stats.json`` on disk.
+        - **responses empty**: Use the pre-computed stats from ``stats.json``
+          directly. If that file is missing or corrupt, set ``None`` (deferred
+          computation will happen on first access via the ``stats`` property).
+
+        Args:
+            result: The ``Result`` instance to update (mutated in place).
+            stats_path: Path to the ``stats.json`` file (may not exist).
+        """
+        saved_stats = None
+        if stats_path.exists():
+            try:
+                with stats_path.open("r") as s:
+                    saved_stats = json.loads(s.read())
+                cls._parse_datetime_fields(saved_stats)
+            except (json.JSONDecodeError, OSError) as e:
+                logger.warning(f"Could not load stats.json: {e}")
+                saved_stats = None
+
+        if result.responses:
+            result._preloaded_stats = cls._compute_stats(result)
+            # Merge contributed stats (callback-injected keys) from disk
+            if saved_stats:
+                for key, value in saved_stats.items():
+                    if key not in result._preloaded_stats:
+                        result._preloaded_stats[key] = value
+        elif saved_stats is not None:
+            result._preloaded_stats = saved_stats
+        else:
+            result._preloaded_stats = None
 
     @classmethod
     def _compute_stats(cls, result: "Result") -> dict:

--- a/llmeter/runner.py
+++ b/llmeter/runner.py
@@ -82,7 +82,11 @@ class _GracefulShutdown:
 
     def _handle(self, sig: signal.Signals) -> None:
         self.received_signal = sig
-        logger.warning("Received %s — shutting down gracefully.", sig.name)
+        logger.warning(
+            "Received %s — shutting down gracefully. Note that in-flight requests cannot be "
+            "cancelled so may take time to clear.",
+            sig.name,
+        )
         if self._task is not None and not self._task.cancelled():
             self._task.cancel()
 

--- a/llmeter/runner.py
+++ b/llmeter/runner.py
@@ -629,6 +629,7 @@ class _Run(_RunConfig):
         prefix = "reqs=0" if self._time_bound else ""
         self._stats_display.update({}, extra_prefix=prefix)
 
+        interrupted = False
         try:
             run_start_time = now_utc()
             if self._time_bound:
@@ -668,9 +669,50 @@ class _Run(_RunConfig):
             )
             return result
 
-        self._progress_bar.close()
+        except KeyboardInterrupt:
+            interrupted = True
+            run_end_time = now_utc()
+            total_test_time = None
+            logger.warning(
+                "Run interrupted by user. Saving partial results "
+                f"({self._running_stats._count} responses collected)."
+            )
+
+        if self._progress_bar is not None:
+            self._progress_bar.close()
         if self._stats_display is not None:
             self._stats_display.close()
+
+        if interrupted:
+            actual_total = self._running_stats._count
+            result = replace(
+                result,
+                responses=self._responses,
+                total_test_time=total_test_time,
+                total_requests=actual_total,
+                n_requests=actual_total // max(self.clients, 1),
+                start_time=run_start_time,
+                first_request_time=self._running_stats._first_send_time,
+                last_request_time=self._running_stats._last_send_time,
+                end_time=run_end_time,
+            )
+            result._preloaded_stats = self._running_stats.to_stats(
+                end_time=run_end_time,
+                result_dict=result.to_dict(),
+            )
+            result._preloaded_stats["start_time"] = run_start_time
+            result._preloaded_stats["end_time"] = run_end_time
+            result._preloaded_stats["interrupted"] = True
+
+            if result.output_path:
+                result.save()
+                logger.info(
+                    f"Partial results saved to {result.output_path}. "
+                    "Use Result.load() to recover them."
+                )
+
+            return result
+
         logger.info(f"Test completed in {total_test_time * 1000:.2f} seconds.")
 
         actual_total = self._running_stats._count

--- a/llmeter/runner.py
+++ b/llmeter/runner.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import random
+import signal
 import time
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
@@ -41,6 +42,49 @@ _disable_tqdm = False
 if os.getenv("LLMETER_DISABLE_ALL_PROGRESS_BARS") == "1":
     logger.info("Disabling tqdm progress bars")
     _disable_tqdm = True
+
+
+class _GracefulShutdown:
+    """Context manager that installs signal handlers for graceful async shutdown.
+
+    Registers handlers for SIGINT and SIGTERM on the running event loop that
+    cancel the current task instead of raising exceptions out of thin air.
+    Restores previous handlers on exit.
+
+    See https://docs.python.org/3/library/signal.html#note-on-signal-handlers-and-exceptions
+
+    Attributes:
+        received_signal: The signal that triggered shutdown, or ``None`` if no
+            signal was received during the context.
+    """
+
+    def __init__(self, loop: asyncio.AbstractEventLoop):
+        self._loop = loop
+        self._task: asyncio.Task | None = None
+        self._registered: list[signal.Signals] = []
+        self.received_signal: signal.Signals | None = None
+
+    def __enter__(self):
+        self._task = asyncio.current_task()
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            try:
+                self._loop.add_signal_handler(sig, self._handle, sig)
+                self._registered.append(sig)
+            except (NotImplementedError, OSError):
+                # add_signal_handler unavailable on Windows / some event loops
+                pass
+        return self
+
+    def __exit__(self, *exc_info):
+        for sig in self._registered:
+            self._loop.remove_signal_handler(sig)
+        self._registered.clear()
+
+    def _handle(self, sig: signal.Signals) -> None:
+        self.received_signal = sig
+        logger.warning("Received %s — shutting down gracefully.", sig.name)
+        if self._task is not None and not self._task.cancelled():
+            self._task.cancel()
 
 
 @dataclass
@@ -630,53 +674,51 @@ class _Run(_RunConfig):
         self._stats_display.update({}, extra_prefix=prefix)
 
         interrupted = False
-        try:
-            run_start_time = now_utc()
-            if self._time_bound:
-                invoke_coro = self._invoke_clients(
-                    payload=self.payload,  # type: ignore
-                    duration=self.run_duration,
-                    clients=self.clients,
-                )
-                _, (total_test_time, start_time, end_time), _ = await asyncio.gather(
-                    self._process_results_from_q(
-                        output_path=ensure_path(self.output_path) / "responses.jsonl"
-                        if self.output_path
-                        else None,
-                    ),
-                    invoke_coro,
-                    self._tick_time_bar(),
-                )
-            else:
-                invoke_coro = self._invoke_clients(
-                    payload=self.payload,  # type: ignore
-                    n_requests=self.n_requests,
-                    clients=self.clients,
-                )
-                _, (total_test_time, start_time, end_time) = await asyncio.gather(
-                    self._process_results_from_q(
-                        output_path=Path(self.output_path) / "responses.jsonl"
-                        if self.output_path
-                        else None,
-                    ),
-                    invoke_coro,
-                )
-            run_end_time = now_utc()
+        run_start_time = now_utc()
 
-        except asyncio.CancelledError:
-            logger.error(
-                f"Waited {self.timeout} seconds, but received no response. Test failed."
-            )
-            return result
+        # Install signal handlers so SIGINT (Ctrl+C) and SIGTERM both trigger
+        # graceful shutdown via task cancellation rather than raising exceptions
+        # out of thin air.  See:
+        # https://docs.python.org/3/library/signal.html#note-on-signal-handlers-and-exceptions
+        shutdown = _GracefulShutdown(loop)
+        with shutdown:
+            try:
+                responses_path = (
+                    ensure_path(self.output_path) / "responses.jsonl"
+                    if self.output_path
+                    else None
+                )
+                coros: list = [
+                    self._process_results_from_q(output_path=responses_path),
+                    self._invoke_clients(
+                        payload=self.payload,  # type: ignore
+                        clients=self.clients,
+                        **(
+                            {"duration": self.run_duration}
+                            if self._time_bound
+                            else {"n_requests": self.n_requests}
+                        ),
+                    ),
+                ]
+                if self._time_bound:
+                    coros.append(self._tick_time_bar())
 
-        except KeyboardInterrupt:
-            interrupted = True
-            run_end_time = now_utc()
-            total_test_time = None
-            logger.warning(
-                "Run interrupted by user. Saving partial results "
-                f"({self._running_stats._count} responses collected)."
-            )
+                results = await asyncio.gather(*coros)
+                total_test_time, start_time, end_time = results[1]
+                run_end_time = now_utc()
+
+            except asyncio.CancelledError:
+                if shutdown.received_signal is None:
+                    raise  # Not ours — propagate
+                interrupted = True
+                run_end_time = now_utc()
+                total_test_time = None
+                logger.warning(
+                    "Run interrupted (%s). Saving partial results "
+                    "(%d responses collected).",
+                    shutdown.received_signal.name,
+                    self._running_stats._count,
+                )
 
         if self._progress_bar is not None:
             self._progress_bar.close()
@@ -684,6 +726,10 @@ class _Run(_RunConfig):
             self._stats_display.close()
 
         if interrupted:
+            if shutdown.received_signal is None and self._running_stats._count == 0:
+                # External cancellation with no collected data (e.g. timeout)
+                return result
+
             actual_total = self._running_stats._count
             result = replace(
                 result,

--- a/tests/unit/test_interrupted_run.py
+++ b/tests/unit/test_interrupted_run.py
@@ -2,18 +2,24 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for graceful save/load of interrupted runs (issue #73)."""
 
+import asyncio
 import json
+import os
+import signal
 
 import pytest
 from upath import UPath
 
 from llmeter.endpoints.base import InvocationResponse
 from llmeter.results import Result
+from llmeter.runner import _GracefulShutdown
 
 
 @pytest.fixture
 def sample_responses():
     """Create a set of sample responses as would be found in responses.jsonl."""
+    from datetime import datetime, timezone
+
     return [
         InvocationResponse(
             id=f"resp_{i}",
@@ -23,6 +29,9 @@ def sample_responses():
             time_to_last_token=0.3 * (i + 1),
             num_tokens_input=10 * (i + 1),
             num_tokens_output=20 * (i + 1),
+            request_time=datetime(
+                2025, 6, 1, 10, 0, i * 2, tzinfo=timezone.utc
+            ),
         )
         for i in range(5)
     ]
@@ -99,6 +108,24 @@ class TestLoadWithoutSummary:
         assert result.model_id == "test-model-id"
         assert result.endpoint_name == "test-endpoint"
         assert result.provider == "test-provider"
+
+    def test_load_derives_timestamps_from_responses(self, interrupted_run_dir):
+        """start_time and end_time should be derived from response request_time."""
+        from datetime import datetime, timezone
+
+        result = Result.load(interrupted_run_dir)
+
+        # First response has request_time 10:00:00, last has 10:00:08
+        assert result.start_time == datetime(2025, 6, 1, 10, 0, 0, tzinfo=timezone.utc)
+        assert result.first_request_time == datetime(
+            2025, 6, 1, 10, 0, 0, tzinfo=timezone.utc
+        )
+        assert result.last_request_time == datetime(
+            2025, 6, 1, 10, 0, 8, tzinfo=timezone.utc
+        )
+        assert result.end_time == datetime(
+            2025, 6, 1, 10, 0, 8, tzinfo=timezone.utc
+        )
 
     def test_load_sets_total_requests_from_responses(self, interrupted_run_dir):
         """total_requests should be set to the number of recovered responses."""
@@ -285,3 +312,439 @@ class TestInterruptedRunSave:
         assert loaded.run_name == "partial-run"
         assert len(loaded.responses) == 5
         assert loaded.stats.get("interrupted") is True
+
+
+class TestLoadWithoutSummaryEdgeCases:
+    """Edge cases for _load_without_summary."""
+
+    def test_responses_without_request_time(self, tmp_path):
+        """Timestamps should be None when responses lack request_time."""
+        run_dir = UPath(tmp_path / "no_timestamps")
+        run_dir.mkdir(parents=True)
+
+        responses = [
+            InvocationResponse(
+                id=f"r{i}",
+                response_text=f"text {i}",
+                num_tokens_input=5,
+                num_tokens_output=10,
+                # No request_time set
+            )
+            for i in range(3)
+        ]
+        responses_path = run_dir / "responses.jsonl"
+        with responses_path.open("w") as f:
+            for resp in responses:
+                f.write(resp.to_json() + "\n")
+
+        result = Result.load(run_dir)
+
+        assert result.start_time is None
+        assert result.first_request_time is None
+        assert result.last_request_time is None
+        assert result.end_time is None
+        assert result.total_requests == 3
+
+    def test_corrupted_run_config_json(self, tmp_path, sample_responses):
+        """Should recover even if run_config.json is corrupted."""
+        run_dir = UPath(tmp_path / "bad_config")
+        run_dir.mkdir(parents=True)
+
+        responses_path = run_dir / "responses.jsonl"
+        with responses_path.open("w") as f:
+            for resp in sample_responses:
+                f.write(resp.to_json() + "\n")
+
+        # Write invalid JSON
+        config_path = run_dir / "run_config.json"
+        with config_path.open("w") as f:
+            f.write("{invalid json content!!")
+
+        result = Result.load(run_dir)
+
+        # Should still load responses and use defaults
+        assert len(result.responses) == 5
+        assert result.clients == 1  # default
+        assert result.model_id is None
+
+    def test_corrupted_stats_json(self, tmp_path, sample_responses):
+        """Should fall back to computing stats when stats.json is corrupted."""
+        run_dir = UPath(tmp_path / "bad_stats")
+        run_dir.mkdir(parents=True)
+
+        responses_path = run_dir / "responses.jsonl"
+        with responses_path.open("w") as f:
+            for resp in sample_responses:
+                f.write(resp.to_json() + "\n")
+
+        stats_path = run_dir / "stats.json"
+        with stats_path.open("w") as f:
+            f.write("not valid json")
+
+        result = Result.load(run_dir)
+
+        # Should compute stats from responses as fallback
+        assert len(result.responses) == 5
+        assert result.stats["failed_requests"] == 0
+        assert "time_to_first_token-p50" in result.stats
+
+    def test_partial_responses_with_errors(self, tmp_path):
+        """Recovery should handle responses with errors correctly."""
+        from datetime import datetime, timezone
+
+        run_dir = UPath(tmp_path / "with_errors")
+        run_dir.mkdir(parents=True)
+
+        responses = [
+            InvocationResponse(
+                id="ok_1",
+                response_text="good response",
+                num_tokens_input=10,
+                num_tokens_output=20,
+                time_to_first_token=0.1,
+                time_to_last_token=0.3,
+                request_time=datetime(2025, 6, 1, 10, 0, 0, tzinfo=timezone.utc),
+            ),
+            InvocationResponse(
+                id="err_1",
+                error="timeout",
+                response_text="",
+                request_time=datetime(2025, 6, 1, 10, 0, 1, tzinfo=timezone.utc),
+            ),
+            InvocationResponse(
+                id="ok_2",
+                response_text="another good one",
+                num_tokens_input=8,
+                num_tokens_output=15,
+                time_to_first_token=0.2,
+                time_to_last_token=0.5,
+                request_time=datetime(2025, 6, 1, 10, 0, 2, tzinfo=timezone.utc),
+            ),
+        ]
+        responses_path = run_dir / "responses.jsonl"
+        with responses_path.open("w") as f:
+            for resp in responses:
+                f.write(resp.to_json() + "\n")
+
+        result = Result.load(run_dir)
+
+        assert result.total_requests == 3
+        assert result.stats["failed_requests"] == 1
+        assert result.start_time == datetime(2025, 6, 1, 10, 0, 0, tzinfo=timezone.utc)
+        assert result.end_time == datetime(2025, 6, 1, 10, 0, 2, tzinfo=timezone.utc)
+
+    def test_single_response(self, tmp_path):
+        """Recovery should work with a single response."""
+        from datetime import datetime, timezone
+
+        run_dir = UPath(tmp_path / "single")
+        run_dir.mkdir(parents=True)
+
+        responses = [
+            InvocationResponse(
+                id="only",
+                response_text="single",
+                num_tokens_input=5,
+                num_tokens_output=10,
+                time_to_first_token=0.2,
+                time_to_last_token=0.4,
+                request_time=datetime(2025, 6, 1, 10, 0, 0, tzinfo=timezone.utc),
+            )
+        ]
+        responses_path = run_dir / "responses.jsonl"
+        with responses_path.open("w") as f:
+            for resp in responses:
+                f.write(resp.to_json() + "\n")
+
+        result = Result.load(run_dir)
+
+        assert result.total_requests == 1
+        assert result.start_time == result.end_time
+        assert result.first_request_time == result.last_request_time
+
+
+class TestGracefulShutdown:
+    """Tests for the _GracefulShutdown context manager."""
+
+    @pytest.mark.asyncio
+    async def test_registers_and_removes_signal_handlers(self):
+        """Handlers should be installed on enter and removed on exit."""
+        loop = asyncio.get_running_loop()
+        shutdown = _GracefulShutdown(loop)
+
+        with shutdown:
+            # Handlers are registered
+            assert len(shutdown._registered) == 2
+            assert signal.SIGINT in shutdown._registered
+            assert signal.SIGTERM in shutdown._registered
+
+        # Handlers are removed after exit
+        assert shutdown._registered == []
+
+    @pytest.mark.asyncio
+    async def test_received_signal_initially_none(self):
+        """received_signal should be None before any signal arrives."""
+        loop = asyncio.get_running_loop()
+        shutdown = _GracefulShutdown(loop)
+
+        with shutdown:
+            assert shutdown.received_signal is None
+
+    @pytest.mark.asyncio
+    async def test_handle_sets_received_signal(self):
+        """Calling _handle should set received_signal."""
+        loop = asyncio.get_running_loop()
+        shutdown = _GracefulShutdown(loop)
+
+        # Use a separate task so cancelling it doesn't kill the test
+        async def target():
+            await asyncio.sleep(10)
+
+        task = asyncio.ensure_future(target())
+        shutdown._task = task
+
+        shutdown._handle(signal.SIGTERM)
+        assert shutdown.received_signal == signal.SIGTERM
+
+        # Cleanup
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_handle_cancels_task(self):
+        """_handle should request cancellation of the captured task."""
+        loop = asyncio.get_running_loop()
+        shutdown = _GracefulShutdown(loop)
+
+        async def target():
+            await asyncio.sleep(10)
+
+        task = asyncio.ensure_future(target())
+        shutdown._task = task
+
+        shutdown._handle(signal.SIGINT)
+        assert task.cancelling() > 0
+
+        # Cleanup
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_cleanup_on_exception(self):
+        """Signal handlers should be removed even if an exception occurs."""
+        loop = asyncio.get_running_loop()
+        shutdown = _GracefulShutdown(loop)
+
+        with pytest.raises(RuntimeError):
+            with shutdown:
+                assert len(shutdown._registered) == 2
+                raise RuntimeError("boom")
+
+        assert shutdown._registered == []
+
+
+class TestRunnerInterruptFlow:
+    """Tests for the full Runner interrupt flow via signal simulation."""
+
+    @pytest.fixture
+    def mock_endpoint(self):
+        from unittest.mock import MagicMock
+
+        from llmeter.endpoints.base import Endpoint
+
+        endpoint = MagicMock(spec=Endpoint)
+        endpoint.endpoint_name = "test-endpoint"
+        endpoint.model_id = "test-model"
+        endpoint.provider = "test-provider"
+        endpoint.invoke.return_value = InvocationResponse(
+            id="1", input_prompt="test", response_text="response"
+        )
+        endpoint.to_dict.return_value = {
+            "endpoint_name": "test-endpoint",
+            "model_id": "test-model",
+            "provider": "test-provider",
+            "endpoint_type": "mock",
+        }
+        return endpoint
+
+    @pytest.mark.asyncio
+    async def test_sigint_saves_partial_result(self, tmp_path, mock_endpoint):
+        """SIGINT during a run should save partial results and return."""
+        from llmeter.runner import Runner
+        from llmeter.tokenizers import DummyTokenizer
+
+        output_path = UPath(tmp_path / "sigint_run")
+
+        runner = Runner(
+            endpoint=mock_endpoint,
+            tokenizer=DummyTokenizer(),
+            output_path=output_path,
+            clients=1,
+            n_requests=200,
+            payload=[{"prompt": "hello"}],
+        )
+
+        # Fast enough to collect several before the signal, but enough total
+        # that the run won't finish before the signal arrives
+        call_count = 0
+
+        def fast_invoke(payload):
+            nonlocal call_count
+            import time
+
+            call_count += 1
+            time.sleep(0.01)
+            return InvocationResponse(
+                id=f"r{call_count}",
+                input_prompt="test",
+                response_text="resp",
+                num_tokens_input=5,
+                num_tokens_output=10,
+            )
+
+        mock_endpoint.invoke = fast_invoke
+
+        # Give time for some requests to complete before interrupting
+        loop = asyncio.get_running_loop()
+        loop.call_later(0.5, os.kill, os.getpid(), signal.SIGINT)
+
+        result = await runner.run()
+
+        # Result should be marked as interrupted
+        assert result.stats.get("interrupted") is True
+        # Should NOT have completed all requests
+        assert result.total_requests < 200
+
+        # Output files should exist
+        run_output = output_path / result.run_name
+        assert (run_output / "summary.json").exists()
+        assert (run_output / "stats.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_sigterm_saves_partial_result(self, tmp_path, mock_endpoint):
+        """SIGTERM during a run should save partial results and return."""
+        from llmeter.runner import Runner
+        from llmeter.tokenizers import DummyTokenizer
+
+        output_path = UPath(tmp_path / "sigterm_run")
+
+        runner = Runner(
+            endpoint=mock_endpoint,
+            tokenizer=DummyTokenizer(),
+            output_path=output_path,
+            clients=1,
+            n_requests=200,
+            payload=[{"prompt": "hello"}],
+        )
+
+        call_count = 0
+
+        def fast_invoke(payload):
+            nonlocal call_count
+            import time
+
+            call_count += 1
+            time.sleep(0.01)
+            return InvocationResponse(
+                id=f"r{call_count}",
+                input_prompt="test",
+                response_text="resp",
+                num_tokens_input=5,
+                num_tokens_output=10,
+            )
+
+        mock_endpoint.invoke = fast_invoke
+
+        loop = asyncio.get_running_loop()
+        loop.call_later(0.5, os.kill, os.getpid(), signal.SIGTERM)
+
+        result = await runner.run()
+
+        assert result.stats.get("interrupted") is True
+        assert result.total_requests < 200
+
+    @pytest.mark.asyncio
+    async def test_unrelated_cancellation_propagates(self, mock_endpoint):
+        """CancelledError not from our signal handler should propagate."""
+        from llmeter.runner import Runner
+        from llmeter.tokenizers import DummyTokenizer
+
+        runner = Runner(
+            endpoint=mock_endpoint,
+            tokenizer=DummyTokenizer(),
+            clients=1,
+            n_requests=200,
+            payload=[{"prompt": "hello"}],
+        )
+
+        def slow_invoke(payload):
+            import time
+
+            time.sleep(0.05)
+            return InvocationResponse(
+                id="x", input_prompt="test", response_text="resp"
+            )
+
+        mock_endpoint.invoke = slow_invoke
+
+        # Run in a task and cancel from outside (not via our signal handler)
+        task = asyncio.ensure_future(runner.run())
+        await asyncio.sleep(0.1)  # Let it start
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    @pytest.mark.asyncio
+    async def test_interrupted_result_has_correct_metadata(
+        self, tmp_path, mock_endpoint
+    ):
+        """Interrupted result should have timing info from collected responses."""
+        from llmeter.runner import Runner
+        from llmeter.tokenizers import DummyTokenizer
+
+        output_path = UPath(tmp_path / "meta_run")
+
+        runner = Runner(
+            endpoint=mock_endpoint,
+            tokenizer=DummyTokenizer(),
+            output_path=output_path,
+            clients=1,
+            n_requests=200,
+            payload=[{"prompt": "hello"}],
+        )
+
+        call_count = 0
+
+        def counting_invoke(payload):
+            nonlocal call_count
+            import time
+
+            call_count += 1
+            time.sleep(0.01)
+            return InvocationResponse(
+                id=f"r{call_count}",
+                input_prompt="test",
+                response_text="resp",
+                num_tokens_input=5,
+                num_tokens_output=10,
+            )
+
+        mock_endpoint.invoke = counting_invoke
+
+        loop = asyncio.get_running_loop()
+        loop.call_later(0.5, os.kill, os.getpid(), signal.SIGINT)
+
+        result = await runner.run()
+
+        assert result.start_time is not None
+        assert result.end_time is not None
+        assert result.end_time >= result.start_time
+        assert result.total_test_time is None  # Unknown for interrupted runs
+        assert result.clients == 1
+        assert result.model_id == "test-model"

--- a/tests/unit/test_interrupted_run.py
+++ b/tests/unit/test_interrupted_run.py
@@ -1,0 +1,287 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for graceful save/load of interrupted runs (issue #73)."""
+
+import json
+
+import pytest
+from upath import UPath
+
+from llmeter.endpoints.base import InvocationResponse
+from llmeter.results import Result
+
+
+@pytest.fixture
+def sample_responses():
+    """Create a set of sample responses as would be found in responses.jsonl."""
+    return [
+        InvocationResponse(
+            id=f"resp_{i}",
+            response_text=f"Response text {i}",
+            input_prompt=f"Test prompt {i}",
+            time_to_first_token=0.1 * (i + 1),
+            time_to_last_token=0.3 * (i + 1),
+            num_tokens_input=10 * (i + 1),
+            num_tokens_output=20 * (i + 1),
+        )
+        for i in range(5)
+    ]
+
+
+@pytest.fixture
+def interrupted_run_dir(tmp_path, sample_responses):
+    """Create a directory simulating an interrupted run (no summary.json).
+
+    Contains only responses.jsonl and run_config.json, as would be left behind
+    when a run is interrupted before Result.save() completes.
+    """
+    from llmeter.json_utils import llmeter_default_serializer
+
+    run_dir = UPath(tmp_path / "interrupted_run")
+    run_dir.mkdir(parents=True)
+
+    # Write responses.jsonl (written incrementally during the run)
+    responses_path = run_dir / "responses.jsonl"
+    with responses_path.open("w") as f:
+        for resp in sample_responses:
+            f.write(resp.to_json() + "\n")
+
+    # Write run_config.json (written at the start of the run)
+    config = {
+        "endpoint": {
+            "model_id": "test-model-id",
+            "endpoint_name": "test-endpoint",
+            "provider": "test-provider",
+        },
+        "tokenizer": {"type": "DummyTokenizer"},
+        "clients": 3,
+        "n_requests": 10,
+        "run_name": "interrupted-test-run",
+        "run_description": "A test run that was interrupted",
+        "payload": "payload.jsonl",
+        "timeout": 60,
+        "low_memory": False,
+        "run_duration": None,
+        "callbacks": None,
+        "progress_bar_stats": None,
+        "disable_per_client_progress_bar": False,
+        "disable_clients_progress_bar": False,
+    }
+    config_path = run_dir / "run_config.json"
+    with config_path.open("w") as f:
+        json.dump(config, f, default=llmeter_default_serializer)
+
+    return run_dir
+
+
+class TestLoadWithoutSummary:
+    """Tests for Result.load() when summary.json is missing."""
+
+    def test_load_recovers_responses(self, interrupted_run_dir, sample_responses):
+        """Should load responses from responses.jsonl when summary.json is absent."""
+        result = Result.load(interrupted_run_dir)
+
+        assert len(result.responses) == len(sample_responses)
+        for orig, loaded in zip(sample_responses, result.responses):
+            assert orig.id == loaded.id
+            assert orig.response_text == loaded.response_text
+            assert orig.num_tokens_input == loaded.num_tokens_input
+            assert orig.num_tokens_output == loaded.num_tokens_output
+
+    def test_load_extracts_config_metadata(self, interrupted_run_dir):
+        """Should extract endpoint and run metadata from run_config.json."""
+        result = Result.load(interrupted_run_dir)
+
+        assert result.clients == 3
+        assert result.n_requests == 10
+        assert result.run_name == "interrupted-test-run"
+        assert result.run_description == "A test run that was interrupted"
+        assert result.model_id == "test-model-id"
+        assert result.endpoint_name == "test-endpoint"
+        assert result.provider == "test-provider"
+
+    def test_load_sets_total_requests_from_responses(self, interrupted_run_dir):
+        """total_requests should be set to the number of recovered responses."""
+        result = Result.load(interrupted_run_dir)
+        assert result.total_requests == 5
+
+    def test_load_computes_stats_from_responses(self, interrupted_run_dir):
+        """Stats should be computed from the recovered responses."""
+        result = Result.load(interrupted_run_dir)
+        stats = result.stats
+
+        assert "time_to_first_token-p50" in stats
+        assert "time_to_last_token-average" in stats
+        assert "num_tokens_output-p90" in stats
+        assert stats["failed_requests"] == 0
+
+    def test_load_sets_output_path(self, interrupted_run_dir):
+        """output_path should be set so load_responses() works later."""
+        result = Result.load(interrupted_run_dir)
+        assert result.output_path is not None
+        assert str(interrupted_run_dir) in str(result.output_path)
+
+    def test_load_without_responses_flag(self, interrupted_run_dir):
+        """Should work with load_responses=False (metadata only)."""
+        result = Result.load(interrupted_run_dir, load_responses=False)
+
+        assert result.responses == []
+        assert result.clients == 3
+        assert result.run_name == "interrupted-test-run"
+        # Stats should be None since we have no stats.json and didn't load responses
+        assert result._preloaded_stats is None
+
+    def test_load_only_responses_no_config(self, tmp_path, sample_responses):
+        """Should work even if run_config.json is missing."""
+        run_dir = UPath(tmp_path / "responses_only")
+        run_dir.mkdir(parents=True)
+
+        responses_path = run_dir / "responses.jsonl"
+        with responses_path.open("w") as f:
+            for resp in sample_responses:
+                f.write(resp.to_json() + "\n")
+
+        result = Result.load(run_dir)
+
+        assert len(result.responses) == 5
+        assert result.total_requests == 5
+        # Config fields should be defaults when run_config.json is missing
+        assert result.clients == 1  # default
+        assert result.model_id is None
+
+    def test_load_with_stats_json_no_responses(self, tmp_path):
+        """Should load pre-computed stats even without responses.jsonl."""
+        run_dir = UPath(tmp_path / "stats_only")
+        run_dir.mkdir(parents=True)
+
+        stats = {
+            "total_requests": 100,
+            "failed_requests": 2,
+            "time_to_first_token-p50": 0.25,
+            "time_to_last_token-average": 0.8,
+        }
+        stats_path = run_dir / "stats.json"
+        with stats_path.open("w") as f:
+            json.dump(stats, f)
+
+        result = Result.load(run_dir)
+
+        assert result._preloaded_stats is not None
+        assert result._preloaded_stats["total_requests"] == 100
+        assert result._preloaded_stats["failed_requests"] == 2
+        assert result._preloaded_stats["time_to_first_token-p50"] == 0.25
+
+    def test_load_empty_directory_raises(self, tmp_path):
+        """Should raise FileNotFoundError when no useful files are present."""
+        empty_dir = UPath(tmp_path / "empty")
+        empty_dir.mkdir(parents=True)
+
+        with pytest.raises(FileNotFoundError, match="no data to recover"):
+            Result.load(empty_dir)
+
+    def test_load_nonexistent_directory_raises(self, tmp_path):
+        """Should raise FileNotFoundError for non-existent paths."""
+        with pytest.raises(FileNotFoundError):
+            Result.load(tmp_path / "does_not_exist")
+
+    def test_load_recovers_interrupted_run_with_stats(self, tmp_path, sample_responses):
+        """Simulates the case where both stats.json and responses.jsonl exist
+        (e.g. the interrupt handler managed to write stats before exiting)."""
+        from llmeter.json_utils import llmeter_default_serializer
+
+        run_dir = UPath(tmp_path / "partial_with_stats")
+        run_dir.mkdir(parents=True)
+
+        responses_path = run_dir / "responses.jsonl"
+        with responses_path.open("w") as f:
+            for resp in sample_responses:
+                f.write(resp.to_json() + "\n")
+
+        stats = {
+            "total_requests": 5,
+            "failed_requests": 0,
+            "interrupted": True,
+            "time_to_first_token-p50": 0.3,
+        }
+        stats_path = run_dir / "stats.json"
+        with stats_path.open("w") as f:
+            json.dump(stats, f, default=llmeter_default_serializer)
+
+        result = Result.load(run_dir)
+
+        # When both are present and we load responses, stats are recomputed
+        # from responses (which is more accurate)
+        assert len(result.responses) == 5
+        assert result.stats["failed_requests"] == 0
+
+    def test_load_responses_after_recovery(self, interrupted_run_dir):
+        """load_responses() should work on a recovered result."""
+        result = Result.load(interrupted_run_dir, load_responses=False)
+        assert result.responses == []
+
+        responses = result.load_responses()
+        assert len(responses) == 5
+        assert responses[0].id == "resp_0"
+
+
+class TestInterruptedRunSave:
+    """Tests for saving partial results during interrupt."""
+
+    def test_save_interrupted_result_creates_all_files(
+        self, tmp_path, sample_responses
+    ):
+        """A partial result from an interrupted run should save correctly."""
+        from datetime import datetime, timezone
+
+        result = Result(
+            responses=sample_responses,
+            total_requests=5,
+            clients=2,
+            n_requests=5,
+            total_test_time=None,  # Unknown for interrupted runs
+            start_time=datetime(2025, 6, 1, 10, 0, 0, tzinfo=timezone.utc),
+            end_time=datetime(2025, 6, 1, 10, 0, 3, tzinfo=timezone.utc),
+            model_id="test-model",
+            run_name="partial-run",
+        )
+        result._preloaded_stats = Result._compute_stats(result)
+        result._preloaded_stats["interrupted"] = True
+
+        output_path = UPath(tmp_path / "partial_output")
+        result.save(output_path)
+
+        assert (output_path / "summary.json").exists()
+        assert (output_path / "stats.json").exists()
+        assert (output_path / "responses.jsonl").exists()
+
+        # Verify stats.json contains the interrupted marker
+        with (output_path / "stats.json").open() as f:
+            stats = json.load(f)
+        assert stats.get("interrupted") is True
+
+    def test_round_trip_interrupted_result(self, tmp_path, sample_responses):
+        """A saved interrupted result should load back correctly."""
+        from datetime import datetime, timezone
+
+        result = Result(
+            responses=sample_responses,
+            total_requests=5,
+            clients=2,
+            n_requests=5,
+            total_test_time=None,
+            start_time=datetime(2025, 6, 1, 10, 0, 0, tzinfo=timezone.utc),
+            end_time=datetime(2025, 6, 1, 10, 0, 3, tzinfo=timezone.utc),
+            model_id="test-model",
+            run_name="partial-run",
+        )
+        result._preloaded_stats = Result._compute_stats(result)
+        result._preloaded_stats["interrupted"] = True
+
+        output_path = UPath(tmp_path / "rt_output")
+        result.save(output_path)
+
+        loaded = Result.load(output_path)
+        assert loaded.total_requests == 5
+        assert loaded.run_name == "partial-run"
+        assert len(loaded.responses) == 5
+        assert loaded.stats.get("interrupted") is True

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -404,6 +405,80 @@ def test_save_method_existing_responses(sample_result: Result, temp_dir: UPath):
         responses = [json.loads(line) for line in f]
         assert len(responses) == 6  # 5 original + 1 extra
         assert responses[-1]["id"] == "extra_response"
+
+
+# ── _parse_datetime_fields introspection ───────────────────────────────────────
+
+
+def test_parse_datetime_fields_converts_iso_strings():
+    """_parse_datetime_fields should convert all datetime-typed field keys."""
+    d = {
+        "start_time": "2025-06-01T10:00:00Z",
+        "end_time": "2025-06-01T10:05:00+00:00",
+        "first_request_time": "2025-06-01T10:00:01Z",
+        "last_request_time": None,
+        "total_requests": 5,  # non-datetime field, should be left alone
+    }
+    Result._parse_datetime_fields(d)
+
+    assert isinstance(d["start_time"], datetime)
+    assert isinstance(d["end_time"], datetime)
+    assert isinstance(d["first_request_time"], datetime)
+    assert d["last_request_time"] is None
+    assert d["total_requests"] == 5
+
+
+def test_parse_datetime_fields_skips_already_parsed():
+    """Already-datetime values should pass through unchanged."""
+    from datetime import timezone
+
+    dt = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    d = {"start_time": dt}
+    Result._parse_datetime_fields(d)
+    assert d["start_time"] is dt
+
+
+def test_parse_datetime_fields_handles_invalid_string():
+    """Invalid date strings should be left as-is (not raise)."""
+    d = {"start_time": "not-a-date"}
+    Result._parse_datetime_fields(d)
+    assert d["start_time"] == "not-a-date"
+
+
+# ── Corrupt stats.json alongside valid summary.json ────────────────────────────
+
+
+def test_load_with_corrupt_stats_json_and_responses(sample_result: Result, temp_dir):
+    """Corrupt stats.json should not crash load() when responses are available."""
+    output_path = temp_dir / "corrupt_stats"
+    sample_result.save(output_path)
+
+    # Corrupt stats.json
+    with (output_path / "stats.json").open("w") as f:
+        f.write("{invalid json!!")
+
+    loaded = Result.load(output_path, load_responses=True)
+
+    # Stats should still be computed from responses
+    assert loaded.stats["failed_requests"] == 0
+    assert "time_to_first_token-p50" in loaded.stats
+    assert loaded.total_requests == 5
+
+
+def test_load_with_corrupt_stats_json_no_responses(sample_result: Result, temp_dir):
+    """Corrupt stats.json with load_responses=False should not crash."""
+    output_path = temp_dir / "corrupt_stats_lazy"
+    sample_result.save(output_path)
+
+    with (output_path / "stats.json").open("w") as f:
+        f.write("not json")
+
+    loaded = Result.load(output_path, load_responses=False)
+
+    # _preloaded_stats falls back to None; stats property will compute on demand
+    assert loaded._preloaded_stats is None
+    stats = loaded.stats
+    assert stats["total_requests"] == 5
 
 
 # Tests for llmeter_default_serializer

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -481,6 +481,22 @@ def test_load_with_corrupt_stats_json_no_responses(sample_result: Result, temp_d
     assert stats["total_requests"] == 5
 
 
+def test_load_missing_responses_jsonl_with_summary(sample_result: Result, temp_dir):
+    """Missing responses.jsonl should not crash; stats come from stats.json."""
+    output_path = temp_dir / "no_responses"
+    sample_result.save(output_path)
+
+    # Remove responses.jsonl
+    (output_path / "responses.jsonl").unlink()
+
+    loaded = Result.load(output_path, load_responses=True)
+
+    assert loaded.responses == []
+    assert loaded.total_requests == 5
+    # Stats should come from stats.json on disk
+    assert "time_to_first_token-p50" in loaded.stats
+
+
 # Tests for llmeter_default_serializer
 # Validates Requirements: 7.1, 7.2
 


### PR DESCRIPTION
## Summary

Catch `KeyboardInterrupt` during `Runner._run()` and write whatever partial data has been collected so that interrupted runs are recoverable. `Result.load()` now gracefully handles missing `summary.json` by reconstructing from available files.

## Changes

### 1. Interrupt handling (`llmeter/runner.py`)

- Catch `KeyboardInterrupt` in `_Run._run()`
- Finalize stats from `RunningStats` accumulator
- Mark stats with `"interrupted": True`
- Call `result.save()` to write `summary.json`, `stats.json`, and `responses.jsonl`
- Return the partial `Result` to the caller

### 2. Recovery from incomplete directories (`llmeter/results.py`)

- `Result.load()` falls back to `_load_without_summary()` when `summary.json` is missing
- Reconstructs metadata from `run_config.json` (clients, model_id, run_name, etc.)
- Loads and recomputes stats from `responses.jsonl`
- Falls back to `stats.json` if only that is available
- Raises a clear error only when there's no data to recover

### Tests

14 new unit tests covering recovery from various file combinations, metadata extraction, stats computation, error cases, and round-trip save/load.

## Testing

```
uv run pytest tests/unit/ -q
# 878 passed, 1 warning
```

Fixes #73