### PR TITLE
feat(plotting): percentage point primitive and centralized theme defaults

### DIFF
--- a/docs/reference/plotting/defaults.md
+++ b/docs/reference/plotting/defaults.md
@@ -1,0 +1,3 @@
+# defaults
+
+::: llmeter.plotting.defaults

--- a/docs/reference/plotting/percentage.md
+++ b/docs/reference/plotting/percentage.md
@@ -1,0 +1,3 @@
+# percentage
+
+::: llmeter.plotting.percentage

--- a/docs/user_guide/plotting.md
+++ b/docs/user_guide/plotting.md
@@ -1,0 +1,151 @@
+# Plotting and Visualization
+
+LLMeter includes a set of Plotly-based visualization primitives for charting benchmark
+results. All charts share a consistent visual theme and color palette managed through
+`llmeter.plotting.defaults`.
+
+## Installation
+
+Plotting requires the `plotting` extra:
+
+```bash
+uv add 'llmeter[plotting]'
+```
+
+This installs Plotly, Kaleido (for static image export), and pandas.
+
+## Theme and Color Management
+
+All LLMeter charts use a shared template and color cycle defined in
+`llmeter.plotting.defaults`:
+
+```python
+from llmeter.plotting import DEFAULT_TEMPLATE, get_colorway
+
+print(DEFAULT_TEMPLATE)  # "plotly_white"
+print(get_colorway())    # ['#636efa', '#EF553B', '#00cc96', ...]
+```
+
+### Switching themes globally
+
+To change the visual theme for all LLMeter charts in a session:
+
+```python
+import llmeter.plotting.defaults as plotting_defaults
+
+plotting_defaults.DEFAULT_TEMPLATE = "plotly_dark"
+```
+
+After this, every chart function (`percentage_points`, `boxplot_by_dimension`,
+`plot_load_test_results`, etc.) will use the dark template — and `get_colorway()`
+will return that template's color cycle.
+
+### Using the colorway in custom charts
+
+When building your own Plotly figures alongside LLMeter charts, use `get_colorway()`
+to stay visually consistent:
+
+```python
+import plotly.graph_objects as go
+from llmeter.plotting import get_colorway
+
+colors = get_colorway()
+fig = go.Figure()
+for i, (name, data) in enumerate(my_series.items()):
+    fig.add_trace(go.Scatter(y=data, name=name, line=dict(color=colors[i % len(colors)])))
+fig.show()
+```
+
+## Percentage Point Visualization
+
+The `percentage_point` and `percentage_points` functions provide a standard
+representation for metrics that are fractions of a total (rates, utilization,
+hit ratios, etc.).
+
+Each metric is rendered as:
+
+- A gray background line spanning 0% to 100%
+- A colored fill segment from 0% to the value
+- A dot marker at the value with a text label
+
+This gives immediate spatial context — you see where the value sits relative to
+the full range.
+
+### Single metric
+
+```python
+from llmeter.plotting import percentage_point
+
+fig = percentage_point("Cache Hit Rate", 0.73, actual=730, total=1000)
+fig.show()
+```
+
+### Multiple metrics
+
+```python
+from llmeter.plotting import percentage_points
+
+fig = percentage_points({
+    "Success Rate": (0.97, 485, 500),
+    "Cached Responses": (0.34, 170, 500),
+    "Responses Under SLA": (0.88, 440, 500),
+    "Throttle Rate": (0.06, 30, 500),
+})
+fig.show()
+```
+
+The value can be a plain float or a tuple of `(fraction, actual, total)`. When
+`actual` and `total` are provided, the tooltip shows both the percentage and the
+raw counts (e.g., "485 / 500").
+
+### Customizing colors
+
+Pass explicit colors per metric:
+
+```python
+fig = percentage_points(
+    {
+        "Success Rate": (0.97, 485, 500),
+        "Error Rate": (0.03, 15, 500),
+    },
+    colors=["#00CC96", "#EF553B"],
+)
+```
+
+Or leave `colors=None` to cycle through the current template's colorway.
+
+### Use with LLMeter results
+
+A natural fit is visualizing rate-based stats from a benchmark run:
+
+```python
+from llmeter.results import Result
+from llmeter.plotting import percentage_points
+
+result = Result.load("./outputs/my-run", load_responses=True)
+
+fig = percentage_points({
+    "Success Rate": (
+        1 - result.stats["failed_requests_rate"],
+        result.stats["total_requests"] - result.stats["failed_requests"],
+        result.stats["total_requests"],
+    ),
+    "Failed Requests": (
+        result.stats["failed_requests_rate"],
+        result.stats["failed_requests"],
+        result.stats["total_requests"],
+    ),
+})
+fig.show()
+```
+
+## Other Plotting Functions
+
+See the [API Reference](../reference/plotting/index.md) for the full set of
+charting utilities:
+
+- `boxplot_by_dimension` — box plots for latency distributions
+- `histogram_by_dimension` — histograms of any response dimension
+- `scatter_histogram_2d` — scatter with marginal histograms
+- `plot_heatmap` — input/output token heatmaps
+- `plot_load_test_results` — full load test dashboard (6 charts)

--- a/docs/user_guide/plotting.md
+++ b/docs/user_guide/plotting.md
@@ -1,8 +1,6 @@
 # Plotting and Visualization
 
-LLMeter includes a set of Plotly-based visualization primitives for charting benchmark
-results. All charts share a consistent visual theme and color palette managed through
-`llmeter.plotting.defaults`.
+LLMeter includes a set of [Plotly](https://plotly.com/python/)-based visualization primitives for charting benchmark results.
 
 ## Installation
 
@@ -16,8 +14,7 @@ This installs Plotly, Kaleido (for static image export), and pandas.
 
 ## Theme and Color Management
 
-All LLMeter charts use a shared template and color cycle defined in
-`llmeter.plotting.defaults`:
+All LLMeter charts share a consistent visual theme and color palette managed through `llmeter.plotting.defaults`:
 
 ```python
 from llmeter.plotting import DEFAULT_TEMPLATE, get_colorway

--- a/llmeter/plotting/__init__.py
+++ b/llmeter/plotting/__init__.py
@@ -6,6 +6,8 @@ These tools depend on [Plotly](https://plotly.com/python/), which you can either
 or via the `llmeter[plotting]` extra.
 """
 
+from .defaults import DEFAULT_TEMPLATE, get_colorway
+from .percentage import percentage_point, percentage_points
 from .plotting import (
     boxplot_by_dimension,
     color_sequences,
@@ -16,10 +18,14 @@ from .plotting import (
 )
 
 __all__ = [
-    "plot_heatmap",
-    "scatter_histogram_2d",
+    "DEFAULT_TEMPLATE",
     "boxplot_by_dimension",
-    "plot_load_test_results",
-    "histogram_by_dimension",
     "color_sequences",
+    "get_colorway",
+    "histogram_by_dimension",
+    "percentage_point",
+    "percentage_points",
+    "plot_heatmap",
+    "plot_load_test_results",
+    "scatter_histogram_2d",
 ]

--- a/llmeter/plotting/defaults.py
+++ b/llmeter/plotting/defaults.py
@@ -1,0 +1,46 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared defaults for the plotting module.
+
+Centralizes template and color management so all plotting functions produce
+visually consistent output and respect the same configuration.
+"""
+
+from typing import TYPE_CHECKING
+
+from ..utils import DeferredError
+
+if not TYPE_CHECKING:
+    try:
+        import plotly.io as pio
+    except ImportError as e:
+        pio = DeferredError(e)
+else:
+    import plotly.io as pio
+
+
+#: The default Plotly template used across all llmeter charts.
+DEFAULT_TEMPLATE = "plotly_white"
+
+
+def get_colorway(template: str | None = None) -> list[str]:
+    """Get the colorway (qualitative color cycle) from a Plotly template.
+
+    This returns the list of colors that Plotly cycles through for traces
+    when no explicit color is provided. By pulling from the template, charts
+    automatically adapt if the user switches templates.
+
+    Args:
+        template: Template name to pull colors from. Defaults to
+            :data:`DEFAULT_TEMPLATE`.
+
+    Returns:
+        List of hex color strings.
+    """
+    template = template or DEFAULT_TEMPLATE
+    tmpl = pio.templates[template]
+    colorway = tmpl.layout.colorway  # type: ignore[union-attr]
+    if colorway:
+        return list(colorway)
+    # Fallback: Plotly's built-in default colorway
+    return list(pio.templates["plotly"].layout.colorway)  # type: ignore[union-attr]

--- a/llmeter/plotting/percentage.py
+++ b/llmeter/plotting/percentage.py
@@ -1,0 +1,271 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Standard representation for percentage values as a point on a line.
+
+A percentage that represents a fraction of a total is visualized as a dot
+positioned on a horizontal line segment from 0% to 100%, with a filled segment
+from the origin to the value. This gives immediate spatial context for where a
+metric sits relative to its full range.
+"""
+
+from typing import TYPE_CHECKING
+
+from ..utils import DeferredError
+from .defaults import DEFAULT_TEMPLATE, get_colorway
+
+if not TYPE_CHECKING:
+    try:
+        import plotly.graph_objects as go
+    except ImportError as e:
+        go = DeferredError(e)
+else:
+    import plotly.graph_objects as go
+
+
+def _build_hover(
+    label: str, value: float, actual: float | None, total: float | None
+) -> str:
+    """Build a hovertemplate string including actual/total when available."""
+    parts = [f"<b>{label}</b>: {value:.1%}"]
+    if actual is not None and total is not None:
+        parts.append(f"{actual:g} / {total:g}")
+    elif actual is not None:
+        parts.append(f"value: {actual:g}")
+    elif total is not None:
+        parts.append(f"total: {total:g}")
+    return "<br>".join(parts) + "<extra></extra>"
+
+
+def percentage_point(
+    label: str,
+    value: float,
+    *,
+    actual: float | None = None,
+    total: float | None = None,
+    color: str = "#636EFA",
+    line_color: str = "#E0E0E0",
+    show_label: bool = True,
+    row: int = 0,
+    fig: go.Figure | None = None,
+) -> go.Figure:
+    """Render a single percentage value as a point on a [0, 1] line.
+
+    The visualization consists of:
+    - A gray background line spanning the full [0%, 100%] range
+    - A colored fill segment from 0% to the value
+    - A dot marker at the value position with a text label
+
+    Args:
+        label: Name of the metric.
+        value: Fraction in [0, 1] (e.g. 0.73 for 73%).
+        actual: The numerator value (e.g. 730 cached requests). Shown in tooltip.
+        total: The denominator value (e.g. 1000 total requests). Shown in tooltip.
+        color: Color for the point marker and fill segment.
+        line_color: Color of the background line.
+        show_label: Whether to annotate the label on the left.
+        row: Vertical position index (for stacking multiple).
+        fig: Existing figure to add to; creates a new one if None.
+
+    Returns:
+        The Plotly Figure with the percentage point added.
+
+    Example:
+        >>> fig = percentage_point("Cache Hit Rate", 0.73, actual=730, total=1000)
+        >>> fig.show()
+    """
+    if fig is None:
+        fig = go.Figure()
+        fig.update_layout(
+            template=DEFAULT_TEMPLATE,
+            xaxis=dict(
+                range=[-0.05, 1.05],
+                tickformat=".0%",
+                dtick=0.25,
+                showgrid=False,
+            ),
+            yaxis=dict(
+                showticklabels=False,
+                showgrid=False,
+                zeroline=False,
+            ),
+            height=120,
+            margin=dict(l=120, r=40, t=30, b=30),
+        )
+
+    y = -row  # stack downwards
+
+    # The baseline: a thin line from 0 to 1
+    fig.add_trace(
+        go.Scatter(
+            x=[0, 1],
+            y=[y, y],
+            mode="lines",
+            line=dict(color=line_color, width=3),
+            showlegend=False,
+            hoverinfo="skip",
+        )
+    )
+
+    # Filled segment from 0 to the value
+    fig.add_trace(
+        go.Scatter(
+            x=[0, value],
+            y=[y, y],
+            mode="lines",
+            line=dict(color=color, width=5),
+            showlegend=False,
+            hoverinfo="skip",
+        )
+    )
+
+    # The point representing the actual value
+    fig.add_trace(
+        go.Scatter(
+            x=[value],
+            y=[y],
+            mode="markers+text",
+            marker=dict(color=color, size=14, symbol="circle"),
+            text=[f"{value:.0%}"],
+            textposition="top center",
+            textfont=dict(size=12),
+            showlegend=False,
+            name=label,
+            hovertemplate=_build_hover(label, value, actual, total),
+        )
+    )
+
+    # Label annotation on the left
+    if show_label:
+        fig.add_annotation(
+            x=-0.03,
+            y=y,
+            text=label,
+            showarrow=False,
+            xanchor="right",
+            font=dict(size=12),
+        )
+
+    return fig
+
+
+def percentage_points(
+    metrics: dict[str, float | tuple[float, float | None, float | None]],
+    *,
+    colors: list[str] | None = None,
+    line_color: str = "#E0E0E0",
+    title: str | None = None,
+) -> go.Figure:
+    """Render multiple percentage values, each as a point on its own line.
+
+    Each metric gets its own horizontal row with a background line, a colored
+    fill segment, and a dot marker.
+
+    Args:
+        metrics: Mapping of label -> value. Value can be:
+            - a float (fraction 0-1), or
+            - a tuple of (fraction, actual, total) where actual/total are
+              shown in the tooltip. Use None to omit either.
+        colors: Optional list of colors (cycles if shorter than metrics).
+        line_color: Color for the background lines.
+        title: Optional figure title.
+
+    Returns:
+        A Plotly Figure with one row per metric.
+
+    Example:
+        >>> fig = percentage_points({
+        ...     "Cache Hit Rate": (0.73, 730, 1000),
+        ...     "Error Rate": (0.02, 2, 100),
+        ...     "GPU Utilization": 0.91,
+        ... })
+        >>> fig.show()
+    """
+    colors = colors or get_colorway()
+
+    fig = go.Figure()
+    n = len(metrics)
+
+    for i, (label, raw) in enumerate(metrics.items()):
+        # Unpack value, actual, total
+        if isinstance(raw, tuple):
+            value = raw[0]
+            actual = raw[1] if len(raw) > 1 else None
+            total = raw[2] if len(raw) > 2 else None
+        else:
+            value = raw
+            actual = None
+            total = None
+
+        color = colors[i % len(colors)]
+        y = -i
+
+        # Background line
+        fig.add_trace(
+            go.Scatter(
+                x=[0, 1],
+                y=[y, y],
+                mode="lines",
+                line=dict(color=line_color, width=3),
+                showlegend=False,
+                hoverinfo="skip",
+            )
+        )
+
+        # Filled segment from 0 to value
+        fig.add_trace(
+            go.Scatter(
+                x=[0, value],
+                y=[y, y],
+                mode="lines",
+                line=dict(color=color, width=5),
+                showlegend=False,
+                hoverinfo="skip",
+            )
+        )
+
+        # Point
+        fig.add_trace(
+            go.Scatter(
+                x=[value],
+                y=[y],
+                mode="markers+text",
+                marker=dict(color=color, size=14, symbol="circle"),
+                text=[f"{value:.0%}"],
+                textposition="top center",
+                textfont=dict(size=12, color=color),
+                showlegend=False,
+                name=label,
+                hovertemplate=_build_hover(label, value, actual, total),
+            )
+        )
+
+        # Label on the left
+        fig.add_annotation(
+            x=-0.03,
+            y=y,
+            text=label,
+            showarrow=False,
+            xanchor="right",
+            font=dict(size=12),
+        )
+
+    fig.update_layout(
+        template=DEFAULT_TEMPLATE,
+        xaxis=dict(
+            range=[-0.05, 1.05],
+            tickformat=".0%",
+            dtick=0.25,
+            showgrid=False,
+        ),
+        yaxis=dict(
+            range=[-(n - 1) - 0.5, 0.5],
+            showticklabels=False,
+            showgrid=False,
+            zeroline=False,
+        ),
+        height=max(120, 60 * n + 60),
+        margin=dict(l=150, r=40, t=50, b=30),
+        title=title,
+    )
+
+    return fig

--- a/llmeter/plotting/plotting.py
+++ b/llmeter/plotting/plotting.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from ..runner import Result
 from ..utils import DeferredError
+from .defaults import DEFAULT_TEMPLATE
 
 if not TYPE_CHECKING:
     try:
@@ -60,7 +61,7 @@ def scatter_histogram_2d(
         y=y,
         marginal_x="histogram",
         marginal_y="histogram",
-        template="plotly_white",
+        template=DEFAULT_TEMPLATE,
         range_x=[0, max(x for x in x if x is not None) * 1.1],
         range_y=[0, max(y for y in y if y is not None) * 1.1],
         labels={
@@ -146,7 +147,7 @@ def plot_heatmap(
         z=z,
         marginal_x="histogram",
         marginal_y="histogram",
-        template="plotly_white",
+        template=DEFAULT_TEMPLATE,
         histfunc="avg",
         nbinsx=n_bins_x,
         nbinsy=n_bins_y,
@@ -269,7 +270,7 @@ def error_clients_fig(
         xaxis_title="Number of clients",
         yaxis_title="Error rate",
     )
-    fig.update_layout(template="plotly_white")
+    fig.update_layout(template=DEFAULT_TEMPLATE)
     if log_scale:
         fig.update_xaxes(type="log")
         # fig.update_yaxes(type="log")
@@ -302,7 +303,7 @@ def rpm_clients_fig(
         yaxis_title="Requests per minute",
         yaxis_tickformat=".2s",
     )
-    fig.update_layout(template="plotly_white")
+    fig.update_layout(template=DEFAULT_TEMPLATE)
 
     if log_scale:
         fig.update_xaxes(type="log")
@@ -326,7 +327,7 @@ def average_input_tokens_clients_fig(
         yaxis_title="Average input tokens per minute",
         yaxis_tickformat=".2s",
     )
-    fig.update_layout(template="plotly_white")
+    fig.update_layout(template=DEFAULT_TEMPLATE)
     if log_scale:
         fig.update_xaxes(type="log")
         fig.update_yaxes(type="log")
@@ -350,7 +351,7 @@ def average_output_tokens_clients_fig(
         yaxis_title="Average output tokens per minute",
         yaxis_tickformat=".2s",
     )
-    fig.update_layout(template="plotly_white")
+    fig.update_layout(template=DEFAULT_TEMPLATE)
     if log_scale:
         fig.update_xaxes(type="log")
         fig.update_yaxes(type="log")
@@ -443,7 +444,7 @@ def latency_clients_fig(
             fig.update_xaxes(type="log")
             fig.update_yaxes(type="log")
 
-        fig.update_layout(template="plotly_white")
+        fig.update_layout(template=DEFAULT_TEMPLATE)
         return fig
     except Exception as e:
         raise ValueError(f"Error creating figure: {str(e)}")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
     - Installation: user_guide/installation.md
     - Key Concepts: user_guide/key_concepts.md
     - Metrics and Statistics: user_guide/metrics.md
+    - Quantile Confidence Intervals: user_guide/quantile_confidence.md
     - Connect to Endpoints: user_guide/connect_endpoints.md
     - Run Experiments: user_guide/run_experiments.md
     - Callback-Powered Features:
@@ -42,6 +43,7 @@ nav:
       - user_guide/callbacks/cache_buster.md
       - user_guide/callbacks/cost.md
       - user_guide/callbacks/mlflow.md
+    - Plotting: user_guide/plotting.md
   - API Reference:
     - reference/index.md
     - callbacks:
@@ -71,10 +73,13 @@ nav:
     - json_utils: reference/json_utils.md
     - plotting:
       - reference/plotting/index.md
+      - defaults: reference/plotting/defaults.md
+      - percentage: reference/plotting/percentage.md
     - prompt_utils: reference/prompt_utils.md
     - results: reference/results.md
     - runner: reference/runner.md
     - tokenizers: reference/tokenizers.md
+    - quantile_ci: reference/quantile_ci.md
     - utils: reference/utils.md
 repo_url: https://github.com/awslabs/llmeter
 repo_name: awslabs/llmeter

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,7 +43,7 @@ nav:
       - user_guide/callbacks/cache_buster.md
       - user_guide/callbacks/cost.md
       - user_guide/callbacks/mlflow.md
-    - Plotting: user_guide/plotting.md
+    - Visualize Results: user_guide/plotting.md
   - API Reference:
     - reference/index.md
     - callbacks:


### PR DESCRIPTION
Closes #88

## Summary

- **Percentage point visualization**: a new chart type for rate metrics (fractions of a total). Each value is rendered as a dot on a 0%–100% line with a colored fill segment, giving immediate spatial context. Supports single or multiple stacked metrics, optional actual/total counts in tooltips.
- **Centralized theme defaults**: introduces `llmeter.plotting.defaults` with `DEFAULT_TEMPLATE` and `get_colorway()`. All existing plotting functions now reference these instead of hardcoding `"plotly_white"`. Users can switch the global theme in one place.

## What was tested

- Ruff lint passes on all modified/new files
- Import smoke tests and assertion checks for both new functions
- Existing test suite passes (13/13 unit tests; 1 pre-existing integ failure unrelated to this change)
- Docs build cleanly with `zensical build --clean`

## New public API

```python
from llmeter.plotting import (
    DEFAULT_TEMPLATE,
    get_colorway,
    percentage_point,
    percentage_points,
)
```