### PR TITLE
fix: call after_run() on callbacks when run is interrupted

### DIFF
--- a/llmeter/runner.py
+++ b/llmeter/runner.py
@@ -831,47 +831,21 @@ class _Run(_RunConfig):
                 # External cancellation with no collected data (e.g. timeout)
                 return result
 
-            actual_total = self._running_stats._count
-            result = replace(
-                result,
-                responses=self._responses,
-                total_test_time=total_test_time,
-                total_requests=actual_total,
-                n_requests=actual_total // max(self.clients, 1),
-                start_time=run_start_time,
-                first_request_time=self._running_stats._first_send_time,
-                last_request_time=self._running_stats._last_send_time,
-                end_time=run_end_time,
-            )
-            result._preloaded_stats = self._running_stats.to_stats(
-                end_time=run_end_time,
-                result_dict=result.to_dict(),
-            )
-            result._preloaded_stats["start_time"] = run_start_time
-            result._preloaded_stats["end_time"] = run_end_time
-            result._preloaded_stats["interrupted"] = True
-
-            if result.output_path:
-                result.save()
-                logger.info(
-                    f"Partial results saved to {result.output_path}. "
-                    "Use Result.load() to recover them."
-                )
-
-            return result
-
-        logger.info(f"Test completed in {total_test_time * 1000:.2f} seconds.")
-
         actual_total = self._running_stats._count
+
+        if interrupted:
+            n_requests = actual_total // max(self.clients, 1)
+        elif self._time_bound:
+            n_requests = actual_total // max(self.clients, 1)
+        else:
+            n_requests = self.n_requests
 
         result = replace(
             result,
             responses=self._responses,
             total_test_time=total_test_time,
             total_requests=actual_total,
-            n_requests=actual_total // max(self.clients, 1)
-            if self._time_bound
-            else self.n_requests,
+            n_requests=n_requests,
             start_time=run_start_time,
             first_request_time=self._running_stats._first_send_time,
             last_request_time=self._running_stats._last_send_time,
@@ -885,19 +859,35 @@ class _Run(_RunConfig):
         )
         result._preloaded_stats["start_time"] = run_start_time
         result._preloaded_stats["end_time"] = run_end_time
-        result._preloaded_stats["total_test_time"] = total_test_time
 
-        if self.low_memory:
+        if interrupted:
+            result._preloaded_stats["interrupted"] = True
+        else:
+            result._preloaded_stats["total_test_time"] = total_test_time
+            logger.info(f"Test completed in {total_test_time * 1000:.2f} seconds.")
+
+        if self.low_memory and not interrupted:
             logger.info(
                 "Low-memory mode: responses not stored in memory. "
                 "Use result.load_responses() to load from disk."
             )
 
         if self.callbacks is not None:
-            [await cb.after_run(result) for cb in self.callbacks]
+            for cb in self.callbacks:
+                try:
+                    await cb.after_run(result)
+                except Exception as e:
+                    logger.debug(
+                        f"Callback {cb.__class__.__name__}.after_run failed: {e}"
+                    )
 
         if result.output_path:
             result.save()
+            if interrupted:
+                logger.info(
+                    f"Partial results saved to {result.output_path}. "
+                    "Use Result.load() to recover them."
+                )
 
         return result
 

--- a/llmeter/runner.py
+++ b/llmeter/runner.py
@@ -833,9 +833,7 @@ class _Run(_RunConfig):
 
         actual_total = self._running_stats._count
 
-        if interrupted:
-            n_requests = actual_total // max(self.clients, 1)
-        elif self._time_bound:
+        if interrupted or self._time_bound:
             n_requests = actual_total // max(self.clients, 1)
         else:
             n_requests = self.n_requests
@@ -859,15 +857,15 @@ class _Run(_RunConfig):
         )
         result._preloaded_stats["start_time"] = run_start_time
         result._preloaded_stats["end_time"] = run_end_time
+        result._preloaded_stats["total_test_time"] = total_test_time
 
         if interrupted:
             result._preloaded_stats["interrupted"] = True
         else:
-            result._preloaded_stats["total_test_time"] = total_test_time
             logger.info(f"Test completed in {total_test_time * 1000:.2f} seconds.")
 
-        if self.low_memory and not interrupted:
-            logger.info(
+        if self.low_memory:
+            logger.warning(
                 "Low-memory mode: responses not stored in memory. "
                 "Use result.load_responses() to load from disk."
             )

--- a/tests/unit/test_interrupted_run.py
+++ b/tests/unit/test_interrupted_run.py
@@ -748,3 +748,133 @@ class TestRunnerInterruptFlow:
         assert result.total_test_time is None  # Unknown for interrupted runs
         assert result.clients == 1
         assert result.model_id == "test-model"
+
+    @pytest.mark.asyncio
+    async def test_callbacks_after_run_called_on_interrupt(
+        self, tmp_path, mock_endpoint
+    ):
+        """after_run() should be called on all callbacks even when the run is interrupted."""
+        from llmeter.callbacks.base import Callback
+        from llmeter.runner import Runner
+        from llmeter.tokenizers import DummyTokenizer
+
+        class SpyCallback(Callback):
+            def __init__(self):
+                self.before_run_called = False
+                self.after_run_called = False
+                self.after_run_result = None
+
+            async def before_run(self, run_config):
+                self.before_run_called = True
+
+            async def after_run(self, result):
+                self.after_run_called = True
+                self.after_run_result = result
+
+        cb1 = SpyCallback()
+        cb2 = SpyCallback()
+
+        runner = Runner(
+            endpoint=mock_endpoint,
+            tokenizer=DummyTokenizer(),
+            output_path=UPath(tmp_path / "cb_interrupt"),
+            clients=1,
+            n_requests=200,
+            payload=[{"prompt": "hello"}],
+            callbacks=[cb1, cb2],
+        )
+
+        call_count = 0
+
+        def fast_invoke(payload):
+            nonlocal call_count
+            import time
+
+            call_count += 1
+            time.sleep(0.01)
+            return InvocationResponse(
+                id=f"r{call_count}",
+                input_prompt="test",
+                response_text="resp",
+                num_tokens_input=5,
+                num_tokens_output=10,
+            )
+
+        mock_endpoint.invoke = fast_invoke
+
+        loop = asyncio.get_running_loop()
+        loop.call_later(0.5, os.kill, os.getpid(), signal.SIGINT)
+
+        result = await runner.run()
+
+        # Verify the run was indeed interrupted
+        assert result.stats.get("interrupted") is True
+
+        # Both callbacks should have before_run and after_run called
+        assert cb1.before_run_called is True
+        assert cb1.after_run_called is True
+        assert cb1.after_run_result is result
+
+        assert cb2.before_run_called is True
+        assert cb2.after_run_called is True
+        assert cb2.after_run_result is result
+
+    @pytest.mark.asyncio
+    async def test_callback_after_run_exception_does_not_block_others(
+        self, tmp_path, mock_endpoint
+    ):
+        """If one callback's after_run() raises on interrupt, others still run."""
+        from llmeter.callbacks.base import Callback
+        from llmeter.runner import Runner
+        from llmeter.tokenizers import DummyTokenizer
+
+        class ExplodingCallback(Callback):
+            async def after_run(self, result):
+                raise RuntimeError("boom")
+
+        class SpyCallback(Callback):
+            def __init__(self):
+                self.after_run_called = False
+
+            async def after_run(self, result):
+                self.after_run_called = True
+
+        exploding = ExplodingCallback()
+        spy = SpyCallback()
+
+        runner = Runner(
+            endpoint=mock_endpoint,
+            tokenizer=DummyTokenizer(),
+            output_path=UPath(tmp_path / "cb_exc"),
+            clients=1,
+            n_requests=200,
+            payload=[{"prompt": "hello"}],
+            callbacks=[exploding, spy],
+        )
+
+        call_count = 0
+
+        def fast_invoke(payload):
+            nonlocal call_count
+            import time
+
+            call_count += 1
+            time.sleep(0.01)
+            return InvocationResponse(
+                id=f"r{call_count}",
+                input_prompt="test",
+                response_text="resp",
+                num_tokens_input=5,
+                num_tokens_output=10,
+            )
+
+        mock_endpoint.invoke = fast_invoke
+
+        loop = asyncio.get_running_loop()
+        loop.call_later(0.5, os.kill, os.getpid(), signal.SIGINT)
+
+        result = await runner.run()
+
+        assert result.stats.get("interrupted") is True
+        # The spy callback should still have been called despite the exploding one
+        assert spy.after_run_called is True


### PR DESCRIPTION
## Summary

When a run is interrupted (SIGINT/SIGTERM), `after_run()` was not called on registered callbacks. This meant callbacks that acquired resources in `before_run()` (threads, connections, experiment tracking) had no opportunity to release them, and callbacks like `CostModel` or `SystemMetricsMonitor` couldn't contribute data to the partial result.

## Changes

- Unified the interrupted and successful code paths in `_Run._run()`, eliminating ~20 lines of duplicated result-assembly logic.
- `after_run()` is now always called on all callbacks regardless of whether the run completed or was interrupted.
- Each callback invocation is wrapped in try/except so a failing callback cannot prevent others from running or block result saving.
- Added two regression tests:
  - `test_callbacks_after_run_called_on_interrupt` — verifies all callbacks receive `after_run()` on interrupt.
  - `test_callback_after_run_exception_does_not_block_others` — verifies exception isolation between callbacks.

Fixes #92